### PR TITLE
Fix espeak_SetVoiceByName error checking

### DIFF
--- a/src/piper/espeakbridge.c
+++ b/src/piper/espeakbridge.c
@@ -3,6 +3,7 @@
 #define Py_LIMITED_API 0x03090000
 #include <Python.h>
 #include <espeak-ng/speak_lib.h>
+#include <espeak-ng/espeak_ng.h>
 
 #define CLAUSE_INTONATION_FULL_STOP 0x00000000
 #define CLAUSE_INTONATION_COMMA 0x00001000
@@ -40,7 +41,7 @@ static PyObject *py_set_voice(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (espeak_SetVoiceByName(voice) < 0) {
+    if (espeak_SetVoiceByName(voice) != ENS_OK) {
         PyErr_Format(PyExc_RuntimeError, "Failed to set voice: %s", voice);
         return NULL;
     }


### PR DESCRIPTION
espeak_SetVoiceByName() returns an `espeak_ng_STATUS` value.

As all `espeak_ng_STATUS` values are [non-negative](https://github.com/espeak-ng/espeak-ng/blob/a4ca101c99de35345f89df58195b2159748b7092/src/include/espeak-ng/espeak_ng.h#L41-L66), `espeak_SetVoiceByName(voice) < 0` will never be true; therefore, the error will never be correctly identified.
