### PR TITLE
fix for arm64 C++ binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ ExternalProject_Add(espeak_ng_external
         -DEXTRA_ru:BOOL=ON
         # Need to explicitly add ucd include directory for CI
         "-DCMAKE_C_FLAGS=-D_FILE_OFFSET_BITS=64 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
+        "-DCMAKE_CXX_FLAGS=-D_FILE_OFFSET_BITS=64 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
     BUILD_BYPRODUCTS
         ${ESPEAKNG_STATIC_LIB}
         ${UCD_STATIC_LIB}

--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -38,6 +38,7 @@ ExternalProject_Add(espeak_ng_external
         -DEXTRA_ru:BOOL=ON
         # Need to explicitly add ucd include directory for CI
         "-DCMAKE_C_FLAGS=-D_FILE_OFFSET_BITS=64 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
+        "-DCMAKE_CXX_FLAGS=-D_FILE_OFFSET_BITS=64 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
     BUILD_BYPRODUCTS
         ${ESPEAKNG_STATIC_LIB}
         ${UCD_STATIC_LIB}


### PR DESCRIPTION
I use the C++ library part in a C++ program. In arm64 I get without this fix:

> /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/stl_vector.h:1130: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = unsigned int; _Alloc = std::allocator<unsigned int>; reference = unsigned int&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.

The reason seems to be the C++ binding during the compilation.