### PR TITLE
gitignore 'download' since it is also build product

### DIFF
--- a/libpiper/.gitignore
+++ b/libpiper/.gitignore
@@ -6,3 +6,4 @@ tmp/
 /build/
 /install/
 /lib/
+/download/


### PR DESCRIPTION
In libpiper, 'download' is a file created by the readme.md install instructions. This patch adds it to `.gitignore` so no one accidentally commits the onnixruntime archive to a commit.