### PR TITLE
Add realtime streaming to HTTP server

### DIFF
--- a/docs/API_HTTP.md
+++ b/docs/API_HTTP.md
@@ -36,6 +36,7 @@ The JSON data fields area:
 * `length_scale` (optional) - speaking speed; defaults to 1
 * `noise_scale` (optional) - speaking variability
 * `noise_w_scale` (optional) - phoneme width variability
+* `realtime` (optional) - stream with a provisional WAV header and zero‑padding for low‑latency playback
 
 Get the available voices with:
 


### PR DESCRIPTION
# Add realtime streaming to HTTP server

## Summary
Adds an optional `realtime` flag to the `POST /` synthesis endpoint in `piper.http_server`. When set, the server immediately sends a provisional WAV header (with an estimated data length), streams PCM frames as they are produced, and zero‑pads any remaining bytes to match the header length. Default behavior (buffered WAV response) is unchanged.

## Motivation
- Lower end‑to‑end latency for clients that begin playback as soon as headers arrive.
- Preserve compatibility with simple WAV clients while enabling streaming.

## Implementation
- New request field: `realtime: true` (boolean). No CLI changes; per‑request control.
- Provisional header: estimate total bytes using a simple chars/sec model, sentence count, configured `--sentence-silence`, a 0.5s margin, and a 1.5× safety factor.
- Stream frames as generated; insert inter‑sentence silence like the buffered path.
- Pad with zeros to reach the estimated data size. If actual audio exceeds the estimate (rare), log a warning and finish the stream.
- Files touched:
  - `src/piper/http_server.py`
  - `docs/API_HTTP.md` (document `realtime` field)

## Usage
```sh
python -m piper.http_server -m de_DE-thorsten-medium --data-dir ~/projekte/hardlife
curl -X POST -H 'Content-Type: application/json' \
  -d '{"text":"Hallo Welt","realtime":true}' \
  -o out.wav localhost:5000
```

## Testing
- Manual: verify immediate header arrival and valid WAV playback while data streams.
- Validate the final file opens in common players and that padding is silent tail data.
- Confirm default requests (no `realtime`) behave exactly as before.

## Backwards Compatibility
- Opt‑in only; no behavior change for existing clients.

## Follow‑ups (optional)
- Server flag for default realtime (e.g., `--realtime-default`).
- Configurable estimate constants (chars/sec, margin, safety factor).

## Checklist
- [x] Format/lint: `script/format` and `script/lint`
- [x] Docs: `docs/API_HTTP.md` updated
- [x] Local test requests (buffered and realtime)
