### PR TITLE
Add scikit-build dependency to train package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     extras_require={
         "train": [
-            "torch>=2,<3",
+            "torch==2.8.0",
             "lightning>=2,<3",
             "tensorboard>=2,<3",
             "tensorboardX>=2,<3",


### PR DESCRIPTION
When running `python3 setup.py build_ext --inplace`, this error is produced: `ModuleNotFoundError: No module named 'skbuild'`
This is fixed by including `scikit-build` in the requirements.