### PR TITLE
fix MSVC build of piper.dll

### DIFF
--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -11,10 +11,10 @@ include(ExternalProject)
 set(ESPEAKNG_BUILD_DIR ${CMAKE_BINARY_DIR}/espeak_ng)
 set(ESPEAKNG_INSTALL_DIR ${CMAKE_BINARY_DIR}/espeak_ng-install)
 
-if(WIN32)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Special handling for Windows
     set(ESPEAKNG_STATIC_LIB ${ESPEAKNG_INSTALL_DIR}/lib/espeak-ng.lib)
-    set(UCD_STATIC_LIB ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/ucd.lib)
+    set(UCD_STATIC_LIB ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/${CMAKE_BUILD_TYPE}/ucd.lib)
 else()
     set(ESPEAKNG_STATIC_LIB ${ESPEAKNG_INSTALL_DIR}/lib/libespeak-ng.a)
     set(UCD_STATIC_LIB ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/libucd.a)
@@ -26,6 +26,7 @@ ExternalProject_Add(espeak_ng_external
     PREFIX ${ESPEAKNG_BUILD_DIR}
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${ESPEAKNG_INSTALL_DIR}
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DBUILD_SHARED_LIBS:BOOL=OFF
         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
         -DUSE_ASYNC:BOOL=OFF

--- a/libpiper/README.md
+++ b/libpiper/README.md
@@ -7,8 +7,8 @@ See `piper.h` for details.
 ## Building
 
 ``` sh
-cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install
-cmake --build build
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install
+cmake --build build --config Release
 cmake --install build
 ```
 

--- a/libpiper/README.md
+++ b/libpiper/README.md
@@ -8,6 +8,12 @@ See `piper.h` for details.
 
 ``` sh
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install
+```
+or use %CD% instead of $PWD when building on Windows in a DOS window:
+```
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%CD%/install
+```
+```
 cmake --build build --config Release
 cmake --install build
 ```

--- a/libpiper/include/piper.h
+++ b/libpiper/include/piper.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <uchar.h>
 
-#if defined(__GNUC__) || defined (_MSC_VER)
+#if defined (WIN32) && (defined(__GNUC__) || defined (_MSC_VER))
 #if defined(BUILDING_LIBPIPER)
 #define EXPORT_SYMBOL __declspec( dllexport )
 #else

--- a/libpiper/include/piper.h
+++ b/libpiper/include/piper.h
@@ -7,7 +7,11 @@
 #include <uchar.h>
 
 #if defined(_MSC_VER)
+#if defined(BUILDING_LIBPIPER)
 #define EXPORT_SYMBOL __declspec( dllexport )
+#else
+#define EXPORT_SYMBOL __declspec( dllimport )
+#endif
 #else
 #define EXPORT_SYMBOL
 #endif

--- a/libpiper/include/piper.h
+++ b/libpiper/include/piper.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <uchar.h>
 
-#if defined(_MSC_VER)
+#if defined(__GNUC__) || defined (_MSC_VER)
 #if defined(BUILDING_LIBPIPER)
 #define EXPORT_SYMBOL __declspec( dllexport )
 #else

--- a/libpiper/include/piper.h
+++ b/libpiper/include/piper.h
@@ -6,6 +6,12 @@
 #include <stdint.h>
 #include <uchar.h>
 
+#if defined(_MSC_VER)
+#define EXPORT_SYMBOL __declspec( dllexport )
+#else
+#define EXPORT_SYMBOL
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -155,6 +161,7 @@ typedef struct piper_synthesize_options {
  *
  * \return a Piper text-to-speech synthesizer for the voice model.
  */
+EXPORT_SYMBOL
 piper_synthesizer *piper_create(const char *model_path, const char *config_path,
                                 const char *espeak_data_path);
 
@@ -163,6 +170,7 @@ piper_synthesizer *piper_create(const char *model_path, const char *config_path,
  *
  * \param synth Piper synthesizer.
  */
+EXPORT_SYMBOL
 void piper_free(piper_synthesizer *synth);
 
 /**
@@ -172,6 +180,7 @@ void piper_free(piper_synthesizer *synth);
  *
  * \return synthesis options from voice config.
  */
+EXPORT_SYMBOL
 piper_synthesize_options
 piper_default_synthesize_options(piper_synthesizer *synth);
 
@@ -188,6 +197,7 @@ piper_default_synthesize_options(piper_synthesizer *synth);
  *
  * \return PIPER_OK or error code.
  */
+EXPORT_SYMBOL
 int piper_synthesize_start(piper_synthesizer *synth, const char *text,
                            const piper_synthesize_options *options);
 
@@ -208,6 +218,7 @@ int piper_synthesize_start(piper_synthesizer *synth, const char *text,
  *
  * \return PIPER_DONE when complete, otherwise PIPER_OK or error code.
  */
+EXPORT_SYMBOL
 int piper_synthesize_next(piper_synthesizer *synth, piper_audio_chunk *chunk);
 
 #ifdef __cplusplus

--- a/libpiper/include/piper_impl.hpp
+++ b/libpiper/include/piper_impl.hpp
@@ -34,8 +34,6 @@ const float DEFAULT_NOISE_W_SCALE = 0.8f;
 
 const int DEFAULT_HOP_LENGTH = 256;
 
-// onnx
-Ort::Env ort_env{ORT_LOGGING_LEVEL_WARNING, "piper"};
 
 // espeak
 #define CLAUSE_INTONATION_FULL_STOP 0x00000000

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -121,11 +121,16 @@ struct piper_synthesizer *piper_create(const char *model_path,
     synth->session_options.DisableMemPattern();
     synth->session_options.DisableProfiling();
 
+    #if !defined (_MSC_VER) // MSVC onnx has wchar_t model_path
+    auto model_path_ort = model_path;
+    #else
     auto sz = ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, 0,0);
     std::vector<wchar_t> model_path_wc(sz+1);
     ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, &model_path_wc[0], sz);
+    auto model_path_ort = &model_path_wc[0];
+    #endif
     synth->session = std::make_unique<Ort::Session>(
-        Ort::Session(ort_env, &model_path_wc[0], synth->session_options));
+        Ort::Session(ort_env, model_path_ort, synth->session_options));
 
     return synth;
 }

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -1,3 +1,4 @@
+#define BUILDING_LIBPIPER
 #include "piper.h"
 #include "piper_impl.hpp"
 

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -121,7 +121,7 @@ struct piper_synthesizer *piper_create(const char *model_path,
     synth->session_options.DisableMemPattern();
     synth->session_options.DisableProfiling();
 
-    #if !defined (_MSC_VER) // MSVC onnx has wchar_t model_path
+    #if !defined (WIN32) // ort on WIN32 uses wchar_t
     auto model_path_ort = model_path;
     #else
     auto sz = ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, 0,0);

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -122,7 +122,7 @@ struct piper_synthesizer *piper_create(const char *model_path,
 
     auto sz = ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, 0,0);
     std::vector<wchar_t> model_path_wc(sz+1);
-    ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, &model_path_wc[0], sz - 1);
+    ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, &model_path_wc[0], sz);
     synth->session = std::make_unique<Ort::Session>(
         Ort::Session(ort_env, &model_path_wc[0], synth->session_options));
 

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -16,7 +16,7 @@
 #endif
 #endif
 
-#if defined (_MSC_VER) // MSVC compile of espeak gives a STATIC library.
+#if defined (WIN32) // MSVC compile of espeak gives a STATIC library.
 // tell espeak-ng/speak_lib.h to use unadorned entry points
 #if defined (_WIN32)
 #undef _WIN32

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -5,6 +5,27 @@
 #include <fstream>
 #include <limits>
 
+#if defined(WIN32)
+#include <windows.h>
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+#endif
+
+#if defined (_MSC_VER) // MSVC compile of espeak gives a STATIC library.
+// tell espeak-ng/speak_lib.h to use unadorned entry points
+#if defined (_WIN32)
+#undef _WIN32
+#endif
+#if defined (_WIN64)
+#undef _WIN64
+#endif
+#endif
+
+
 #include <espeak-ng/speak_lib.h>
 
 using json = nlohmann::json;
@@ -12,6 +33,9 @@ using json = nlohmann::json;
 struct piper_synthesizer *piper_create(const char *model_path,
                                        const char *config_path,
                                        const char *espeak_data_path) {
+    // onnx
+    static Ort::Env ort_env{ ORT_LOGGING_LEVEL_WARNING, "piper" };
+
     if (!model_path) {
         return nullptr;
     }
@@ -96,8 +120,11 @@ struct piper_synthesizer *piper_create(const char *model_path,
     synth->session_options.DisableMemPattern();
     synth->session_options.DisableProfiling();
 
+    auto sz = ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, 0,0);
+    std::vector<wchar_t> model_path_wc(sz+1);
+    ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, &model_path_wc[0], sz - 1);
     synth->session = std::make_unique<Ort::Session>(
-        Ort::Session(ort_env, model_path, synth->session_options));
+        Ort::Session(ort_env, &model_path_wc[0], synth->session_options));
 
     return synth;
 }

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -7,25 +7,13 @@
 #include <limits>
 
 #if defined(WIN32)
-#include <windows.h>
-#ifdef min
-#undef min
+#define WIN32_LEAN_AND_MEAN
+#if !defined(NOMINMAX)
+#define NOMINMAX
 #endif
-#ifdef max
-#undef max
+#include <windows.h> // for MultiByteToWideChar below
+#define LIBESPEAK_NG_EXPORT // espeak is exported from piper dll
 #endif
-#endif
-
-#if defined (WIN32) // MSVC compile of espeak gives a STATIC library.
-// tell espeak-ng/speak_lib.h to use unadorned entry points
-#if defined (_WIN32)
-#undef _WIN32
-#endif
-#if defined (_WIN64)
-#undef _WIN64
-#endif
-#endif
-
 
 #include <espeak-ng/speak_lib.h>
 


### PR DESCRIPTION
libpiper does not currently build using the Visual Studio 2026 cmake tools. 
There is more than one way to fix that, but here is a proposal
a) has the appropriate include file goop in piper.cpp to prevent the espeak static library build to adorn its entry points as if they were in a dll.
b)has the appropriate include file goop in piper.h to make it adorn its DLL entry points for MSVC style dll build
c)the original code has a static declaration of an onnx data type that runs too soon in DllMain. This commit moves that declare to a static variable in the only place it was used.