### PR TITLE
Allow GPU acceleration with AMD GPUs with ROCm 

### DIFF
--- a/docs/API_PYTHON.md
+++ b/docs/API_PYTHON.md
@@ -45,6 +45,14 @@ voice = PiperVoice.load(..., use_cuda=True)
 
 This requires the `onnxruntime-gpu` package to be installed.
 
+To use ROCm for GPU acceleration in AMD GPUs instead:
+
+``` python
+voice = PiperVoice.load(..., use_rocm=True)
+```
+
+This requires the `onnxruntime-rocm` package to be [installed](https://rocm.docs.amd.com/projects/radeon-ryzen/en/docs-6.1.3/docs/install/native_linux/install-onnx.html) and the appropiate version of torch to be used. You can find more information in [here](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/native_linux/install-pytorch.html#verify-pytorch-installation)
+
 For streaming, use `PiperVoice.synthesize`:
 
 ``` python

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence, Tuple, Union
 
 import numpy as np
+import torch
 import onnxruntime
 
 from .config import PhonemeType, PiperConfig, SynthesisConfig
@@ -121,6 +122,7 @@ class PiperVoice:
         model_path: Union[str, Path],
         config_path: Optional[Union[str, Path]] = None,
         use_cuda: bool = False,
+        use_rocm: bool = False,
         espeak_data_dir: Union[str, Path] = ESPEAK_DATA_DIR,
     ) -> "PiperVoice":
         """
@@ -148,6 +150,13 @@ class PiperVoice:
                 )
             ]
             _LOGGER.debug("Using CUDA")
+        elif use_rocm:
+            providers = [
+                (
+                    "ROCMExecutionProvider"
+                )
+            ]
+            _LOGGER.debug("Using ROCm")
         else:
             providers = ["CPUExecutionProvider"]
 


### PR DESCRIPTION
I was able to run piper with an AMD GPU by installing the "onnxruntime-rocm" and the appropriate "torch" package based on my GPU.

Without taking into account the installation of the packages, it didn't require to much setup to get it to work so I thought more people could benefit of it. 

Importing the "torch" package before the "onnxruntime" package it's actually necessary since  "onnxruntime-rocm" will crash without it.