### PR TITLE
Windows build & DLL loading crash fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ src/piper/train/vits/monotonic_align/core.c
 *.so
 
 lightning_logs/
+.vs
+*.zip
+/libpiper/$PWD

--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -14,7 +14,10 @@ set(ESPEAKNG_INSTALL_DIR ${CMAKE_BINARY_DIR}/espeak_ng-install)
 if(WIN32)
     # Special handling for Windows
     set(ESPEAKNG_STATIC_LIB ${ESPEAKNG_INSTALL_DIR}/lib/espeak-ng.lib)
-    set(UCD_STATIC_LIB ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/ucd.lib)
+    # For multi-config generators (Visual Studio), the library is in a config subdirectory
+    # For single-config generators (Ninja, Makefiles), the library is directly in ucd-tools
+    set(UCD_STATIC_LIB_MULTICONFIG ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/$<CONFIG>/ucd.lib)
+    set(UCD_STATIC_LIB_SINGLECONFIG ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/ucd.lib)
 else()
     set(ESPEAKNG_STATIC_LIB ${ESPEAKNG_INSTALL_DIR}/lib/libespeak-ng.a)
     set(UCD_STATIC_LIB ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/libucd.a)
@@ -125,11 +128,26 @@ target_include_directories(piper PUBLIC
 target_link_directories(piper PUBLIC
     ${ONNXRUNTIME_DIR}/lib
 )
-target_link_libraries(piper
-    ${ESPEAKNG_STATIC_LIB}
-    ${UCD_STATIC_LIB}
-    onnxruntime
-)
+
+if(WIN32)
+    # Define LIBESPEAK_NG_EXPORT to avoid __declspec(dllimport) for static linking
+    # The headers check for this macro and use dllexport instead, which works for static linking
+    target_compile_definitions(piper PRIVATE
+        LIBESPEAK_NG_EXPORT
+    )
+    # Try multi-config path first, fall back to single-config
+    target_link_libraries(piper
+        ${ESPEAKNG_STATIC_LIB}
+        $<IF:$<BOOL:${CMAKE_CONFIGURATION_TYPES}>,${UCD_STATIC_LIB_MULTICONFIG},${UCD_STATIC_LIB_SINGLECONFIG}>
+        onnxruntime
+    )
+else()
+    target_link_libraries(piper
+        ${ESPEAKNG_STATIC_LIB}
+        ${UCD_STATIC_LIB}
+        onnxruntime
+    )
+endif()
 
 # ---- install ---
 

--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -132,8 +132,10 @@ target_link_directories(piper PUBLIC
 if(WIN32)
     # Define LIBESPEAK_NG_EXPORT to avoid __declspec(dllimport) for static linking
     # The headers check for this macro and use dllexport instead, which works for static linking
+    # Define PIPER_EXPORTS so our public API functions are exported from the DLL
     target_compile_definitions(piper PRIVATE
         LIBESPEAK_NG_EXPORT
+        PIPER_EXPORTS
     )
     # Try multi-config path first, fall back to single-config
     target_link_libraries(piper

--- a/libpiper/README.md
+++ b/libpiper/README.md
@@ -6,6 +6,16 @@ See `piper.h` for details.
 
 ## Building
 
+### Windows
+
+``` sh
+cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$PWD/install -G "Visual Studio 17 2022" -A x64
+cmake --build build --config Release
+cmake --install build --config Release
+```
+
+### Linux/macOS
+
 ``` sh
 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install
 cmake --build build

--- a/libpiper/include/piper.h
+++ b/libpiper/include/piper.h
@@ -10,6 +10,17 @@
 extern "C" {
 #endif
 
+/* DLL export/import macro for Windows */
+#ifdef _WIN32
+  #ifdef PIPER_EXPORTS
+    #define PIPER_API __declspec(dllexport)
+  #else
+    #define PIPER_API __declspec(dllimport)
+  #endif
+#else
+  #define PIPER_API
+#endif
+
 #define PIPER_OK 0
 #define PIPER_DONE 1
 #define PIPER_ERR_GENERIC -1
@@ -155,7 +166,7 @@ typedef struct piper_synthesize_options {
  *
  * \return a Piper text-to-speech synthesizer for the voice model.
  */
-piper_synthesizer *piper_create(const char *model_path, const char *config_path,
+PIPER_API piper_synthesizer *piper_create(const char *model_path, const char *config_path,
                                 const char *espeak_data_path);
 
 /**
@@ -163,7 +174,7 @@ piper_synthesizer *piper_create(const char *model_path, const char *config_path,
  *
  * \param synth Piper synthesizer.
  */
-void piper_free(piper_synthesizer *synth);
+PIPER_API void piper_free(piper_synthesizer *synth);
 
 /**
  * \brief Get the default synthesis options for a Piper synthesizer.
@@ -172,7 +183,7 @@ void piper_free(piper_synthesizer *synth);
  *
  * \return synthesis options from voice config.
  */
-piper_synthesize_options
+PIPER_API piper_synthesize_options
 piper_default_synthesize_options(piper_synthesizer *synth);
 
 /**
@@ -188,7 +199,7 @@ piper_default_synthesize_options(piper_synthesizer *synth);
  *
  * \return PIPER_OK or error code.
  */
-int piper_synthesize_start(piper_synthesizer *synth, const char *text,
+PIPER_API int piper_synthesize_start(piper_synthesizer *synth, const char *text,
                            const piper_synthesize_options *options);
 
 /**
@@ -208,7 +219,7 @@ int piper_synthesize_start(piper_synthesizer *synth, const char *text,
  *
  * \return PIPER_DONE when complete, otherwise PIPER_OK or error code.
  */
-int piper_synthesize_next(piper_synthesizer *synth, piper_audio_chunk *chunk);
+PIPER_API int piper_synthesize_next(piper_synthesizer *synth, piper_audio_chunk *chunk);
 
 #ifdef __cplusplus
 }

--- a/libpiper/include/piper_impl.hpp
+++ b/libpiper/include/piper_impl.hpp
@@ -35,7 +35,10 @@ const float DEFAULT_NOISE_W_SCALE = 0.8f;
 const int DEFAULT_HOP_LENGTH = 256;
 
 // onnx
-Ort::Env ort_env{ORT_LOGGING_LEVEL_WARNING, "piper"};
+inline Ort::Env& get_ort_env() {
+    static Ort::Env env{ORT_LOGGING_LEVEL_WARNING, "piper"};
+    return env;
+}
 
 // espeak
 #define CLAUSE_INTONATION_FULL_STOP 0x00000000

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -106,10 +106,10 @@ struct piper_synthesizer *piper_create(const char *model_path,
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
     std::wstring wide_model_path = converter.from_bytes(model_path);
     synth->session = std::make_unique<Ort::Session>(
-        Ort::Session(ort_env, wide_model_path.c_str(), synth->session_options));
+        Ort::Session(get_ort_env(), wide_model_path.c_str(), synth->session_options));
 #else
     synth->session = std::make_unique<Ort::Session>(
-        Ort::Session(ort_env, model_path, synth->session_options));
+        Ort::Session(get_ort_env(), model_path, synth->session_options));
 #endif
 
     return synth;
@@ -353,11 +353,13 @@ int piper_synthesize_next(struct piper_synthesizer *synth,
                                                "scales", "sid"};
 
     // Get all output names
-    std::vector<std::string> output_names_strs =
-        synth->session->GetOutputNames();
+    std::vector<Ort::AllocatedStringPtr> output_name_ptrs;
     std::vector<const char *> output_names;
-    for (const auto &name : output_names_strs) {
-        output_names.push_back(name.c_str());
+    size_t num_outputs = synth->session->GetOutputCount();
+    for (size_t i = 0; i < num_outputs; i++) {
+        output_name_ptrs.push_back(
+            synth->session->GetOutputNameAllocated(i, synth->session_allocator));
+        output_names.push_back(output_name_ptrs.back().get());
     }
 
     // Infer

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -7,6 +7,11 @@
 
 #include <espeak-ng/speak_lib.h>
 
+#ifdef _WIN32
+#include <codecvt>
+#include <locale>
+#endif
+
 using json = nlohmann::json;
 
 struct piper_synthesizer *piper_create(const char *model_path,
@@ -96,8 +101,16 @@ struct piper_synthesizer *piper_create(const char *model_path,
     synth->session_options.DisableMemPattern();
     synth->session_options.DisableProfiling();
 
+#ifdef _WIN32
+    // Windows requires wide character path
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::wstring wide_model_path = converter.from_bytes(model_path);
+    synth->session = std::make_unique<Ort::Session>(
+        Ort::Session(ort_env, wide_model_path.c_str(), synth->session_options));
+#else
     synth->session = std::make_unique<Ort::Session>(
         Ort::Session(ort_env, model_path, synth->session_options));
+#endif
 
     return synth;
 }


### PR DESCRIPTION
- Enable Windows-specific build and runtime behavior: update CMake to handle multi-config vs single-config UCD library paths, define LIBESPEAK_NG_EXPORT for static linking on Windows, and conditionally link libraries. Add Windows build instructions to README. Make piper.cpp use wide UTF-16 paths on Windows (include codecvt/locale and convert model_path) so ONNX Runtime can open models on Windows. Also update .gitignore to exclude .vs, zip files, and a local /libpiper/$PWD entry.
- Add Windows DLL export support so the library exports its public symbols when built as a DLL. Defined PIPER_EXPORTS in libpiper/CMakeLists.txt for Windows builds and introduced a PIPER_API macro in libpiper/include/piper.h that expands to __declspec(dllexport) or __declspec(dllimport) as appropriate. Annotated public API functions (piper_create, piper_free, piper_default_synthesize_options, piper_synthesize_start, piper_synthesize_next) with PIPER_API to ensure correct symbol visibility for consumers on Windows.
- Replace the global Ort::Env with a function-local static get_ort_env() to ensure proper initialization and return a reference; update session creation sites to call get_ort_env(). Replace GetOutputNames() usage with GetOutputCount() and GetOutputNameAllocated(...), storing Ort::AllocatedStringPtr values and pushing their .get() pointer into the output name array to ensure correct lifetime management of output name strings and avoid dangling pointers.