### PR TITLE
Fix multi-GPU (DDP) training support

### DIFF
--- a/src/piper/train/__main__.py
+++ b/src/piper/train/__main__.py
@@ -26,8 +26,17 @@ def main():
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
     torch.backends.cudnn.deterministic = False
+
+    trainer_defaults = {"max_epochs": -1}
+
+    # VITS has conditional code paths (e.g., SDP, speaker embeddings) that
+    # leave some parameters unused in certain steps. DDP needs to be told
+    # to detect these instead of raising an error.
+    if torch.cuda.device_count() > 1:
+        trainer_defaults["strategy"] = "ddp_find_unused_parameters_true"
+
     _cli = VitsLightningCLI(  # noqa: ignore=F841
-        VitsModel, VitsDataModule, trainer_defaults={"max_epochs": -1}
+        VitsModel, VitsDataModule, trainer_defaults=trainer_defaults
     )
 
 

--- a/src/piper/train/vits/dataset.py
+++ b/src/piper/train/vits/dataset.py
@@ -378,7 +378,16 @@ class VitsDataModule(L.LightningDataModule):
         _LOGGER.info("Processed %s utterance(s)", num_utterances)
 
     def setup(self, stage: str) -> None:
-        assert self.piper_config is not None
+        # In DDP mode, prepare_data() only runs on rank 0, so piper_config
+        # will be None on other ranks. Load it from the JSON file that
+        # prepare_data() wrote to disk.
+        if self.piper_config is None:
+            assert self.config_path.exists(), (
+                f"Config file not found: {self.config_path}. "
+                "Ensure prepare_data() has completed on rank 0."
+            )
+            with open(self.config_path, "r", encoding="utf-8") as config_file:
+                self.piper_config = PiperConfig.from_dict(json.load(config_file))
 
         all_utts: list[CachedUtterance] = []
         speaker_id_map = self.piper_config.speaker_id_map

--- a/src/piper/train/vits/lightning.py
+++ b/src/piper/train/vits/lightning.py
@@ -239,21 +239,38 @@ class VitsModel(L.LightningModule):
         opt_g, opt_d = self.optimizers()
         loss_g, loss_d = self._compute_loss(batch)
 
+        # Generator step
+        # toggle_optimizer ensures DDP only syncs generator gradients
+        self.toggle_optimizer(opt_g)
         self.log("loss_g", loss_g, batch_size=self.batch_size)
         opt_g.zero_grad()
-        self.manual_backward(loss_g, retain_graph=True)
+        self.manual_backward(loss_g)
         opt_g.step()
+        self.untoggle_optimizer(opt_g)
 
+        # Discriminator step
+        self.toggle_optimizer(opt_d)
         self.log("loss_d", loss_d, batch_size=self.batch_size)
         opt_d.zero_grad()
         self.manual_backward(loss_d)
         opt_d.step()
+        self.untoggle_optimizer(opt_d)
 
     def validation_step(self, batch: Batch, batch_idx: int):
         loss_g, _loss_d = self._compute_loss(batch)
         val_loss = loss_g  # only generator loss matters
         self.log("val_loss", val_loss, batch_size=self.batch_size)
         return val_loss
+
+    def on_train_epoch_end(self) -> None:
+        # With manual optimization, LR schedulers must be stepped manually
+        schedulers = self.lr_schedulers()
+        if schedulers is not None:
+            if isinstance(schedulers, (list, tuple)):
+                for sched in schedulers:
+                    sched.step()
+            else:
+                schedulers.step()
 
     def on_validation_end(self) -> None:
         # Generate audio examples after validation, but not during sanity check


### PR DESCRIPTION
Multi-GPU training with DDP strategy fails with AssertionError in dataset.py because prepare_data() only runs on rank 0 in DDP mode, leaving piper_config as None on other ranks.
This PR fixes four issues that prevent or affect multi-GPU training:
1. dataset.py — setup() crashes on non-rank-0 processes
prepare_data() only runs on rank 0 in DDP mode (by Lightning design), but it's where self.piper_config gets set. setup() runs on all ranks and asserts self.piper_config is not None, which fails on ranks 1+. Fix: load the config from the JSON file that prepare_data() already writes to disk.
2. lightning.py — Missing toggle_optimizer/untoggle_optimizer
With manual optimization + multiple optimizers in DDP, toggle_optimizer is needed so DDP correctly synchronizes only the relevant gradients during each backward pass. This also makes retain_graph=True unnecessary since the generator and discriminator loss graphs are already independent (via y_hat.detach()).
3. lightning.py — LR schedulers never stepped
With automatic_optimization = False, Lightning does not automatically step LR schedulers. Added on_train_epoch_end to step them manually. Note: this was also a bug on single-GPU training — the learning rate decay was never being applied.
4. __main__.py — Auto-detect multi-GPU and set DDP strategy
VITS has conditional code paths (e.g., stochastic duration predictor, speaker embeddings) that leave some parameters unused in certain steps. DDP requires find_unused_parameters=True to handle this. Instead of requiring users to pass an extra flag, multi-GPU is now auto-detected and the correct strategy is set automatically.
Usage:
No extra flags needed — multi-GPU training works out of the box


Tested with: 4x GPU setup, PyTorch Lightning, Python 3.13
