### PR TITLE
Fix trim silence from the beggining of audio

### DIFF
--- a/src/piper/train/vits/dataset.py
+++ b/src/piper/train/vits/dataset.py
@@ -539,7 +539,7 @@ class VitsDataModule(L.LightningDataModule):
             first_sec = first_chunk * seconds_per_chunk
             first_sec = max(0, first_sec - self.keep_seconds_before_silence)
             first_sample = int(
-                math.floor(num_original_samples * (offset_sec / audio_seconds))
+                math.floor(num_original_samples * (first_sec / audio_seconds))
             )
 
             last_sec = (last_chunk + 1) * seconds_per_chunk


### PR DESCRIPTION
When I checked the cached audio files in the cache folder used for training, it turned out that the silence at the beginning of the audio had not been removed. This affects model inference, as the model produces audio with silence at the beginning.
The issue originates from this line in dataset.py.

`math.floor(num_original_samples * (offset_sec / audio_seconds))
`