### PR TITLE
Promote pathvalidate to non-optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     python_requires=">=3.9",
     install_requires=[
         "onnxruntime>=1,<2",
+        "pathvalidate>=3,<4",
     ],
     extras_require={
         "train": [
@@ -52,7 +53,6 @@ setup(
             "tensorboard>=2,<3",
             "tensorboardX>=2,<3",
             "jsonargparse[signatures]>=4.27.7",
-            "pathvalidate>=3,<4",
             "onnx>=1,<2",
             "pysilero-vad>=2.1,<3",
             "cython>=3,<4",


### PR DESCRIPTION
Was used in `piper.__main__` since 1.4.0[1] and caused an import error when dependencies were only installed selectively.

[1] https://github.com/OHF-Voice/piper1-gpl/commit/3d3121eeac30611a09d1ab9603193fbd6c14ce67

Reported-By: Vincent Bernat <vincent@bernat.ch>