### PR TITLE
Fix: The Dataset "Missing Phoneme" Bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
             "onnx>=1,<2",
             "pysilero-vad>=2.1,<3",
             "cython>=3,<4",
+            "scikit-build>=0.19,<1",
             "librosa<1",
         ],
         "dev": [

--- a/src/piper/train/vits/dataset.py
+++ b/src/piper/train/vits/dataset.py
@@ -310,7 +310,7 @@ class VitsDataModule(L.LightningDataModule):
                         phoneme_ids = list(
                             itertools.chain(
                                 *(
-                                    phonemes_to_ids(sentence_phonemes)
+                                    phonemes_to_ids(sentence_phonemes, id_map=self.piper_config.phoneme_id_map)
                                     for sentence_phonemes in phonemes
                                 )
                             )


### PR DESCRIPTION
1. On line 142 of `dataset.py`, Piper successfully loads phonemes into the variable `phoneme_id_map`.
2. However, on line 311 of `dataset.py`, it calls the conversion function:
   ```python
   phonemes_to_ids(sentence_phonemes)
   ```
3. Looking at `phoneme_ids.py`, the function is defined as:
   ```python
   def phonemes_to_ids(phonemes: list[str], id_map: Optional[Mapping[str, Sequence[int]]] = None) -> list[int]:
       if not id_map:
           id_map = DEFAULT_PHONEME_ID_MAP # <--- The English defaults!
   ```
   Because Piper's `dataset.py` forgets to pass your custom map into the function, it falls back to English, fails to find non-English letters, and throws warnings.