### PR TITLE
Add Apple Piper App to README ecosystem list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ People/projects using Piper:
 * [POTaTOS](https://www.youtube.com/watch?v=Dz95q6XYjwY)
 * [Narration Studio](https://github.com/phyce/Narration-Studio)
 * [Basic TTS](https://basictts.com/) - Simple online text-to-speech converter.
+* [Apple Piper App](https://github.com/IhorShevchuk/piper-app) - Native iOS/macOS app for offline Piper text-to-speech.
 
 [![A library from the Open Home Foundation](https://www.openhomefoundation.org/badges/ohf-library.png)](https://www.openhomefoundation.org/)
 


### PR DESCRIPTION
## Summary

Add Apple Piper App to the README list of projects using Piper.

## Added

* [Apple Piper App](https://github.com/IhorShevchuk/piper-app) - Native iOS/macOS app for offline Piper text-to-speech.