### PR TITLE
Add in-memory patching for alignments

### DIFF
--- a/docs/ALIGNMENTS.md
+++ b/docs/ALIGNMENTS.md
@@ -13,6 +13,16 @@ python3 -m piper.patch_voice_with_alignment /path/to/model.onnx
 
 This requires the `onnx` Python package to be installed (not to be confused with `onnxruntime`). After patching, the `onnx` package is no longer required. Patched ONNX models should still work fine with existing Piper installations.
 
+### Patching at Load Time
+
+Alternatively, you can patch a voice in memory when loading it, without writing a modified model to disk:
+
+``` python
+voice = PiperVoice.load("/path/to/model.onnx", include_alignments=True)
+```
+
+This also requires the `onnx` package (install with `pip install piper-tts[alignment]`), but it leaves the original `.onnx` file untouched. If the model is already patched, or the `onnx` package is unavailable, the voice loads normally and alignments are simply unavailable.
+
 ## Python API
 
 The `AudioChunk` class has been extended with several new fields:

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
             "scikit-build<1",
             "cmake>=3.18,<4",
             "ninja>=1,<2",
+            "onnx>=1,<2",  # for alignments
         ],
         "http": [
             "flask>=3,<4",

--- a/src/piper/patch_voice_with_alignment.py
+++ b/src/piper/patch_voice_with_alignment.py
@@ -5,11 +5,56 @@ Requires the onnx package to be installed (not onnxruntime).
 
 import argparse
 import logging
-from typing import Set
+from typing import Optional, Set
 
 import onnx
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def add_alignment_output(
+    model: onnx.ModelProto, tensor_name: Optional[str] = None
+) -> str:
+    """Mark the model's w_ceil (Ceil) tensor as a graph output.
+
+    The model is modified in place. This exposes the per-phoneme-id audio
+    sample counts needed for alignments.
+
+    :param model: ONNX model to modify in place.
+    :param tensor_name: Name of tensor to mark as output (autodetected if None).
+    :return: Name of the tensor that was marked as an output.
+    :raises ValueError: If the tensor cannot be autodetected or is already an output.
+    """
+    if tensor_name:
+        ceil_tensor_name = tensor_name
+    else:
+        ceil_tensor_names: Set[str] = set()
+        for node in model.graph.node:
+            if node.op_type != "Ceil":
+                continue
+
+            ceil_tensor_names.update(node.output)
+
+        if not ceil_tensor_names:
+            raise ValueError("No ceil tensors detected. Provide tensor_name manually.")
+
+        if len(ceil_tensor_names) > 1:
+            raise ValueError(
+                f"Multiple ceil tensors detected, provide tensor_name manually: "
+                f"{ceil_tensor_names}"
+            )
+
+        ceil_tensor_name = next(iter(ceil_tensor_names))
+        _LOGGER.debug("Detected tensor name: %s", ceil_tensor_name)
+
+    if any(output.name == ceil_tensor_name for output in model.graph.output):
+        raise ValueError(f"Tensor is already marked as output: {ceil_tensor_name}")
+
+    ceil_value_info = onnx.helper.ValueInfoProto()
+    ceil_value_info.name = ceil_tensor_name
+    model.graph.output.append(ceil_value_info)
+
+    return ceil_tensor_name
 
 
 def main() -> int:
@@ -31,39 +76,13 @@ def main() -> int:
 
     model = onnx.load(args.model)
 
-    if args.tensor_name:
-        ceil_tensor_name = args.tensor_name
-    else:
-        ceil_tensor_names: Set[str] = set()
-        for node in model.graph.node:
-            if node.op_type != "Ceil":
-                continue
-
-            ceil_tensor_names.update(node.output)
-
-        if not ceil_tensor_names:
-            _LOGGER.fatal("No ceil tensors detected. Use --tensor-name manually.")
-            return 1
-
-        if len(ceil_tensor_names) > 1:
-            _LOGGER.fatal(
-                "Multiple ceil tensors detected. Use --tensor-name manually: %s",
-                ceil_tensor_names,
-            )
-            return 1
-
-        ceil_tensor_name = next(iter(ceil_tensor_names))
-        _LOGGER.info("Detected tensor name: %s", ceil_tensor_name)
-
-    if any(output.name == ceil_tensor_name for output in model.graph.output):
-        _LOGGER.fatal(
-            "Tensor is already marked as output. Aborting: %s", ceil_tensor_name
-        )
+    try:
+        ceil_tensor_name = add_alignment_output(model, args.tensor_name)
+    except ValueError as error:
+        _LOGGER.fatal("%s", error)
         return 1
 
-    ceil_value_info = onnx.helper.ValueInfoProto()
-    ceil_value_info.name = ceil_tensor_name
-    model.graph.output.append(ceil_value_info)
+    _LOGGER.info("Marked tensor as output: %s", ceil_tensor_name)
 
     onnx.save(model, args.output)
     _LOGGER.info("Successfully wrote %s", args.output)

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -126,6 +126,7 @@ class PiperVoice:
         use_cuda: bool = False,
         espeak_data_dir: Union[str, Path] = ESPEAK_DATA_DIR,
         download_dir: Optional[Union[str, Path]] = None,
+        include_alignments: bool = False,
     ) -> "PiperVoice":
         """
         Load an ONNX model and config.
@@ -135,6 +136,9 @@ class PiperVoice:
         :param use_cuda: True if CUDA (GPU) should be used instead of CPU.
         :param espeak_data_dir: Path to espeak-ng data dir (defaults to internal data).
         :param download_dir: Path to download resources (defaults to current directory).
+        :param include_alignments: If True, patch the model in memory (requires the
+            onnx package) so phoneme/audio alignments are available even if the model
+            file has not been patched with piper.patch_voice_with_alignment.
         :return: Voice object.
         """
         if config_path is None:
@@ -159,10 +163,35 @@ class PiperVoice:
         if download_dir is None:
             download_dir = Path.cwd()
 
+        # By default, load the model directly from its path. To expose alignments
+        # without writing a patched model to disk, load and patch the model in
+        # memory and hand the serialized bytes to onnxruntime.
+        model_or_path: Union[str, bytes] = str(model_path)
+        if include_alignments:
+            try:
+                import onnx
+
+                from .patch_voice_with_alignment import add_alignment_output
+
+                model = onnx.load(str(model_path))
+                tensor_name = add_alignment_output(model)
+                model_or_path = model.SerializeToString()
+                _LOGGER.debug(
+                    "Patched model in memory for alignments (tensor=%s)", tensor_name
+                )
+            except ImportError:
+                _LOGGER.warning(
+                    "The onnx package is required for include_alignments. "
+                    "Install it with: pip install piper-tts[alignment]"
+                )
+            except ValueError as error:
+                # Tensor not found or model already patched: use it as-is.
+                _LOGGER.debug("Not patching model for alignments: %s", error)
+
         return PiperVoice(
             config=PiperConfig.from_dict(config_dict),
             session=onnxruntime.InferenceSession(
-                str(model_path),
+                model_or_path,
                 sess_options=onnxruntime.SessionOptions(),
                 providers=providers,
             ),

--- a/tests/test_piper.py
+++ b/tests/test_piper.py
@@ -1,9 +1,14 @@
 """Tests for Piper."""
 
 import io
+import shutil
 import wave
 from pathlib import Path
 from unittest.mock import patch
+
+import onnx
+import pytest
+from onnx import TensorProto, helper
 
 from piper import PiperVoice
 from piper.const import BOS, EOS
@@ -12,6 +17,7 @@ from piper.phonemize_espeak import EspeakPhonemizer
 _DIR = Path(__file__).parent
 _TESTS_DIR = _DIR
 _TEST_VOICE = _TESTS_DIR / "test_voice.onnx"
+_TEST_CONFIG = _TESTS_DIR / "test_voice.onnx.json"
 
 
 def test_load_voice() -> None:
@@ -377,3 +383,87 @@ def test_synthesize_alignment() -> None:
 
             assert actual_alignment.num_samples == expected_samples
             assert actual_alignment.phoneme_ids == expected_ids
+
+
+def test_add_alignment_output_autodetect() -> None:
+    """Test autodetecting and marking the Ceil tensor as an output."""
+    from piper.patch_voice_with_alignment import add_alignment_output
+
+    model = onnx.parser.parse_model(
+        """
+        <ir_version: 8, opset_import: ["": 15]>
+        agraph (float[N] input) => (float[N] output) {
+            w_ceil = Ceil(input)
+            output = Identity(w_ceil)
+        }
+        """
+    )
+    assert [o.name for o in model.graph.output] == ["output"]
+
+    tensor_name = add_alignment_output(model)
+    assert tensor_name == "w_ceil"
+    assert [o.name for o in model.graph.output] == ["output", "w_ceil"]
+
+
+def test_add_alignment_output_errors() -> None:
+    """Test errors when no Ceil tensor exists or it is already an output."""
+    from piper.patch_voice_with_alignment import add_alignment_output
+
+    # No Ceil node
+    no_ceil = onnx.parser.parse_model(
+        """
+        <ir_version: 8, opset_import: ["": 15]>
+        agraph (float[N] input) => (float[N] output) {
+            output = Identity(input)
+        }
+        """
+    )
+    with pytest.raises(ValueError):
+        add_alignment_output(no_ceil)
+
+    # Tensor already marked as an output
+    with pytest.raises(ValueError):
+        add_alignment_output(no_ceil, tensor_name="output")
+
+
+def test_load_include_alignments_in_memory(tmp_path: Path) -> None:
+    """Test patching an unpatched model in memory at load time."""
+    model_path = tmp_path / "ceil_voice.onnx"
+    _make_ceil_model(model_path)
+    shutil.copy(_TEST_CONFIG, f"{model_path}.json")
+
+    # Without alignments: single (unpatched) output
+    voice = PiperVoice.load(model_path)
+    assert [o.name for o in voice.session.get_outputs()] == ["output"]
+
+    # With alignments: Ceil tensor is exposed as an extra output
+    voice = PiperVoice.load(model_path, include_alignments=True)
+    assert [o.name for o in voice.session.get_outputs()] == ["output", "w_ceil"]
+
+    # The on-disk model is left unpatched
+    on_disk = onnx.load(str(model_path))
+    assert [o.name for o in on_disk.graph.output] == ["output"]
+
+
+def test_load_include_alignments_no_ceil() -> None:
+    """Test that loading falls back gracefully when there is no Ceil tensor."""
+    # The test voice has no Ceil tensor, so alignments cannot be added.
+    voice = PiperVoice.load(_TEST_VOICE, include_alignments=True)
+    assert [o.name for o in voice.session.get_outputs()] == ["output"]
+
+
+# -----------------------------------------------------------------------------
+
+
+def _make_ceil_model(path: Path) -> None:
+    """Write a minimal ONNX model with a Ceil node (unpatched, single output)."""
+
+    inp = helper.make_tensor_value_info("input", TensorProto.FLOAT, [None])
+    out = helper.make_tensor_value_info("output", TensorProto.FLOAT, [None])
+    ceil_node = helper.make_node("Ceil", ["input"], ["w_ceil"])
+    identity_node = helper.make_node("Identity", ["w_ceil"], ["output"])
+    graph = helper.make_graph([ceil_node, identity_node], "ceil_graph", [inp], [out])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 15)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx.save(model, str(path))


### PR DESCRIPTION
Adds an `include_alignments` option to voice that patches the in-memory onnx model to support alignments (requires the `onnx` package via `[alignment]` extra).