### PR TITLE
Fixes to make training work with new dependencies

### DIFF
--- a/src/piper/train/__main__.py
+++ b/src/piper/train/__main__.py
@@ -1,4 +1,7 @@
+import inspect
 import logging
+import pathlib
+import sys
 
 import torch
 from lightning.pytorch.cli import LightningCLI
@@ -7,6 +10,8 @@ from .vits.dataset import VitsDataModule
 from .vits.lightning import VitsModel
 
 _LOGGER = logging.getLogger(__package__)
+
+_KNOWN_MODEL_PARAMS = set(inspect.signature(VitsModel.__init__).parameters) - {"self"}
 
 
 class VitsLightningCLI(LightningCLI):
@@ -20,9 +25,31 @@ class VitsLightningCLI(LightningCLI):
         parser.link_arguments("model.win_length", "data.win_length")
         parser.link_arguments("model.segment_size", "data.segment_size")
 
+    def _parse_ckpt_path(self) -> None:
+        if not self.config.get("subcommand"):
+            return
+        ckpt_path = self.config[self.config.subcommand].get("ckpt_path")
+        if not (ckpt_path and pathlib.Path(ckpt_path).is_file()):
+            return
+        ckpt = torch.load(ckpt_path, weights_only=True, map_location="cpu")
+        hparams = ckpt.get("hyper_parameters", {})
+        hparams.pop("_instantiator", None)
+        hparams = {k: v for k, v in hparams.items() if k in _KNOWN_MODEL_PARAMS}
+        if not hparams:
+            return
+        if "_class_path" in hparams:
+            hparams = {"class_path": hparams.pop("_class_path"), "dict_kwargs": hparams}
+        hparams = {self.config.subcommand: {"model": hparams}}
+        try:
+            self.config = self.parser.parse_object(hparams, self.config)
+        except SystemExit:
+            sys.stderr.write("Parsing of ckpt_path hyperparameters failed!\n")
+            raise
+
 
 def main():
     logging.basicConfig(level=logging.INFO)
+    torch.serialization.add_safe_globals([pathlib.PosixPath])
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
     torch.backends.cudnn.deterministic = False

--- a/src/piper/train/export_onnx.py
+++ b/src/piper/train/export_onnx.py
@@ -45,7 +45,13 @@ def main() -> None:
     checkpoint_path = Path(args.checkpoint)
 
     # pylint: disable=no-value-for-parameter
-    model = VitsModel.load_from_checkpoint(checkpoint_path, map_location="cpu")
+    # `_instantiator=None` bypasses the LightningCLI jsonargparse instantiator
+    # stored in the checkpoint, which strictly rejects stale hyperparameters
+    # (e.g. `sample_bytes`). VitsModel.__init__ accepts **kwargs, so unknown
+    # hparams are harmless when instantiated directly.
+    model = VitsModel.load_from_checkpoint(
+        checkpoint_path, map_location="cpu", _instantiator=None
+    )
     model_g = model.model_g
 
     # Inference only
@@ -102,6 +108,11 @@ def main() -> None:
             "input_lengths": {0: "batch_size"},
             "output": {0: "batch_size", 2: "time"},
         },
+        # The model relies on data-dependent control flow (e.g. boolean-mask
+        # indexing in the spline transforms) that the dynamo-based exporter
+        # cannot capture. torch>=2.9 defaults dynamo=True, so force the legacy
+        # TorchScript exporter.
+        dynamo=False,
     )
     _LOGGER.info("Exported model to %s", output_path)
 

--- a/src/piper/train/vits/dataset.py
+++ b/src/piper/train/vits/dataset.py
@@ -487,6 +487,7 @@ class VitsDataModule(L.LightningDataModule):
             ),
             batch_size=self.batch_size,
             num_workers=self.num_workers,
+            shuffle=True,
         )
 
     def test_dataloader(self):


### PR DESCRIPTION
I have installed freshly from repo, and hit issues (exceptions), when I wanted to train model with new data (Czech language - from https://huggingface.co/datasets/Thomcles/Czech-Speech-Monospeaker-Honza,  actually data are not good, had to do some cleanup,  but anyhow it was learning exercise) .  Problems I encountered:

- Was not able to use existing checkpoints (jirka or cori)  - first problem was with globals in model, second with extra model parameters, which pytorch is now checking.
- Second problem was with export -  again parsing some extra arguments and also with dynamo as default now.

Below are fixes, which I've done with help of Claude Code, as I'm not an expert in pytorch.   These helped me to train model to first checkpoint and export checkpoint to onnx and test onnx (quality was poor, but that I expect having only one epoch of training).   I was testing on my notebook without NVidia card - just to test the process. So I cannot guarantee that my fixes works flawlessly -  when exporting module got some warnings like:

```
/home/ivan/workspace/piper/piper1-gpl/src/piper/train/vits/transforms.py:174: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  assert (discriminant >= 0).all(), discriminant
/home/ivan/workspace/piper/.venv/lib/python3.12/site-packages/torch/onnx/_internal/torchscript_exporter/jit_utils.py:308: UserWarning: Constant folding - Only steps=1 can be constant folded for opset >= 10 onnx::Slice op. Constant folding not applied. (Triggered internally at /pytorch/torch/csrc/jit/passes/onnx/constant_fold.cpp:178.)
```

