### PR TITLE
libpiper: robust multi-config ucd path + Windows/macOS CI

### DIFF
--- a/.github/workflows/build-libpiper.yml
+++ b/.github/workflows/build-libpiper.yml
@@ -1,0 +1,45 @@
+---
+name: Build libpiper
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'libpiper/**'
+      - '.github/workflows/build-libpiper.yml'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        working-directory: libpiper
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PWD/install"
+
+      - name: Build
+        working-directory: libpiper
+        run: cmake --build build --config Release
+
+      - name: Install
+        working-directory: libpiper
+        run: cmake --install build --config Release
+
+      - name: Upload install artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libpiper-${{ matrix.os }}
+          path: libpiper/install/

--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -11,13 +11,28 @@ include(ExternalProject)
 set(ESPEAKNG_BUILD_DIR ${CMAKE_BINARY_DIR}/espeak_ng)
 set(ESPEAKNG_INSTALL_DIR ${CMAKE_BINARY_DIR}/espeak_ng-install)
 
+# ucd-tools is built (not installed) by espeak-ng, so we reference its static
+# library directly from the build tree. Multi-config generators (e.g. Visual
+# Studio) place the output in a per-config subdirectory whose name is only
+# known at build time, so resolve it with a $<CONFIG> generator expression.
+# Single-config generators (Unix Makefiles, Ninja) write directly into the
+# build directory with no subdirectory.
+get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(IS_MULTI_CONFIG)
+    set(UCD_CONFIG_SUBDIR "$<CONFIG>/")
+else()
+    set(UCD_CONFIG_SUBDIR "")
+endif()
+
+set(UCD_TOOLS_DIR ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # Special handling for Windows
+    # MSVC emits .lib files (espeak-ng is re-exported from piper.dll)
     set(ESPEAKNG_STATIC_LIB ${ESPEAKNG_INSTALL_DIR}/lib/espeak-ng.lib)
-    set(UCD_STATIC_LIB ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/${CMAKE_BUILD_TYPE}/ucd.lib)
+    set(UCD_STATIC_LIB ${UCD_TOOLS_DIR}/${UCD_CONFIG_SUBDIR}ucd.lib)
 else()
     set(ESPEAKNG_STATIC_LIB ${ESPEAKNG_INSTALL_DIR}/lib/libespeak-ng.a)
-    set(UCD_STATIC_LIB ${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external-build/src/ucd-tools/libucd.a)
+    set(UCD_STATIC_LIB ${UCD_TOOLS_DIR}/${UCD_CONFIG_SUBDIR}libucd.a)
 endif()
 
 ExternalProject_Add(espeak_ng_external

--- a/libpiper/README.md
+++ b/libpiper/README.md
@@ -8,15 +8,21 @@ See `piper.h` for details.
 
 ``` sh
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install
-```
-or use %CD% instead of $PWD when building on Windows in a DOS window:
-```
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%CD%/install
-```
-```
 cmake --build build --config Release
-cmake --install build
+cmake --install build --config Release
 ```
+
+On Windows in a `cmd` shell, use `%CD%` instead of `$PWD`:
+
+``` bat
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%CD%/install
+cmake --build build --config Release
+cmake --install build --config Release
+```
+
+The `--config Release` flag is required for multi-config generators such as
+Visual Studio and is ignored by single-config generators, so it is safe to
+pass on every platform.
 
 This will automatically download/build [espeak-ng][] as well as download shared libraries for the [onnxruntime][].
 


### PR DESCRIPTION
Follow-up to #143. Two improvements to the libpiper Windows build:

## 1. Make the ucd-tools library path robust for multi-config generators

#143 located `ucd.lib` via `.../ucd-tools/${CMAKE_BUILD_TYPE}/ucd.lib`. That works only when `CMAKE_BUILD_TYPE` is set, but **multi-config generators (Visual Studio, Ninja Multi-Config) leave `CMAKE_BUILD_TYPE` empty** — the config is chosen at build time (`--build --config Release`). In that case the path collapsed to `.../ucd-tools//ucd.lib` and the link broke.

This resolves the per-config subdirectory with a `$<CONFIG>` generator expression, gated on the `GENERATOR_IS_MULTI_CONFIG` global property:

- Multi-config generators → `.../ucd-tools/$<CONFIG>/ucd.lib`
- Single-config generators (Unix Makefiles, Ninja) → no subdirectory, as before

Verified to still build cleanly on Linux (single-config Makefiles).

## 2. Add a `build-libpiper` GitHub workflow

`libpiper/` had **no CI coverage** — the existing `wheels.yml` Windows job builds the Python extension, not this C DLL. This adds a workflow that configures, builds, and installs `libpiper` on `ubuntu-latest`, `macos-latest`, and `windows-latest` (MSVC) on PRs touching `libpiper/**`, uploading the install tree as an artifact. This will actually exercise the MSVC `dllexport`/`wchar_t`/espeak re-export fixes from #143 on every change.

The README is updated to document the cross-platform invocation (`--config Release` on every platform; `%CD%` for `cmd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)