### PR TITLE
ci: install training requirements for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Piper
         run: |
-          script/setup --dev --zh --torch-cpu
+          script/setup --dev --train --zh --torch-cpu
           script/dev_build
 
       - name: Run tests


### PR DESCRIPTION
The `Test` workflow has been failing with:

```
ModuleNotFoundError: No module named 'librosa'
src/piper/train/vits/dataset.py:14: ModuleNotFoundError
FAILED tests/test_piper.py::test_training_phonemize_matches_inference_with_vowel_clusters
```

`test_training_phonemize_matches_inference_with_vowel_clusters` imports `from piper.train.vits.dataset import VitsDataModule`, and that module imports `librosa`, `lightning`, `torch`, and `pysilero_vad` — all from the `train` extra. The test job only ran `script/setup --dev --zh --torch-cpu`, so those weren't installed.

This adds `--train` to the setup step. Verified locally: the test passes once the training requirements are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)