### PR TITLE
Add default speaker id

### DIFF
--- a/src/piper/config.py
+++ b/src/piper/config.py
@@ -58,6 +58,9 @@ class PiperConfig:
     The final cluster phoneme must be present in the id map.
     """
 
+    default_speaker_id: int = 0
+    """Id of the default speaker for multi-speaker voices."""
+
     @staticmethod
     def from_dict(config: dict[str, Any]) -> "PiperConfig":
         """Load configuration from a dictionary."""
@@ -84,6 +87,8 @@ class PiperConfig:
             vowel_clusters=(
                 {tuple(vc) for vc in vowel_clusters} if vowel_clusters else None
             ),
+            #
+            default_speaker_id=config.get("default_speaker_id", 0),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -106,6 +111,7 @@ class PiperConfig:
             "phoneme_id_map": self.phoneme_id_map,
             "speaker_id_map": self.speaker_id_map,
             "hop_length": self.hop_length,
+            "default_speaker_id": self.default_speaker_id,
         }
 
         if self.piper_version:

--- a/src/piper/http_server.py
+++ b/src/piper/http_server.py
@@ -262,7 +262,7 @@ def main() -> None:
                     speaker,
                     voice.config.speaker_id_map.keys(),
                 )
-                speaker_id = args.speaker or 0
+                speaker_id = args.speaker or voice.config.default_speaker_id
 
         if (speaker_id is not None) and (speaker_id > voice.config.num_speakers):
             speaker_id = 0

--- a/src/piper/phonemize_espeak.py
+++ b/src/piper/phonemize_espeak.py
@@ -2,13 +2,12 @@
 
 import re
 import unicodedata
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
 _DIR = Path(__file__).parent
 ESPEAK_DATA_DIR = _DIR / "espeak-ng-data"
-
-from collections.abc import Sequence
 
 
 class EspeakPhonemizer:

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -504,7 +504,7 @@ class PiperVoice:
 
         if (self.config.num_speakers > 1) and (speaker_id is None):
             # Default speaker
-            speaker_id = 0
+            speaker_id = self.config.default_speaker_id
 
         if speaker_id is not None:
             sid = np.array([speaker_id], dtype=np.int64)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,6 @@
-EN_US_VOWEL_CLUSTERS = {
+from typing import Set, Tuple
+
+EN_US_VOWEL_CLUSTERS: Set[Tuple[str, ...]] = {
     ("a", "ɪ"),
     ("a", "ʊ"),
     ("ɔ", "ɪ"),

--- a/tests/test_piper.py
+++ b/tests/test_piper.py
@@ -13,6 +13,7 @@ from onnx import TensorProto, helper
 from piper import PiperVoice
 from piper.const import BOS, EOS
 from piper.phonemize_espeak import EspeakPhonemizer
+from piper.train.vits.dataset import VitsDataModule
 
 from . import EN_US_VOWEL_CLUSTERS
 
@@ -554,9 +555,6 @@ def test_training_phonemize_matches_inference_with_vowel_clusters() -> None:
     diphthong ids it never saw during training).
     """
     import json
-
-    from piper.phonemize_espeak import EspeakPhonemizer
-    from piper.train.vits.dataset import VitsDataModule
 
     data_module = VitsDataModule(
         csv_path="dataset.csv",


### PR DESCRIPTION
Adds a `default_speaker_id` field to the voice config that lets you set a different speaker than 0.