### PR TITLE
Add --version/-V flag to the CLI

### DIFF
--- a/src/piper/__main__.py
+++ b/src/piper/__main__.py
@@ -9,6 +9,7 @@ import time
 import wave
 from collections.abc import Iterable
 from pathlib import Path
+from importlib.metadata import version
 
 from pathvalidate import sanitize_filename
 
@@ -22,6 +23,9 @@ _LOGGER = logging.getLogger(_FILE.stem)
 def main() -> None:
     """Run piper text-to-speech engine."""
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {version('piper-tts')}"
+    )
     parser.add_argument("-m", "--model", required=True, help="Path to Onnx model file")
     parser.add_argument("-c", "--config", help="Path to model config file")
     parser.add_argument(
@@ -99,6 +103,7 @@ def main() -> None:
     parser.add_argument(
         "--debug", action="store_true", help="Print DEBUG messages to console"
     )
+    #
     args, unknown_args = parser.parse_known_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
     _LOGGER.debug(args)


### PR DESCRIPTION
This commit adds a version flag to the CLI.
This is a very common nice to have.
It does not add to the maintenance burden, since it reads the version from installed package metadata via importlib.metadata, which is generated from the version field in setup.py .
```
setup(
    name="piper-tts",
    version="1.5.0",
```

I chose the capital v (`-V`) to mirror cargo, python, and curl. 

```shell
❯ ./result/bin/piper -h
usage: piper [-h] [-V] -m MODEL [-c CONFIG] ...
options:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
...
❯ ./result/bin/piper -V
piper 1.5.0
```
ps. 
This would also be useful for the base of a version test in nixpkgs.