### PR TITLE
Add --extra-models-dir flag for extra downloadable models

### DIFF
--- a/src/piper/__main__.py
+++ b/src/piper/__main__.py
@@ -97,6 +97,12 @@ def main() -> None:
     )
     #
     parser.add_argument(
+        "--extra-models-dir",
+        "--extra_models_dir",
+        help="Directory for downloadable resources like the Chinese g2pW model (default: current directory)",
+    )
+    #
+    parser.add_argument(
         "--debug", action="store_true", help="Print DEBUG messages to console"
     )
     args, unknown_args = parser.parse_known_args()
@@ -146,7 +152,11 @@ def main() -> None:
 
     # Load voice
     _LOGGER.debug("Loading voice: '%s'", model_path)
-    voice = PiperVoice.load(model_path, use_cuda=args.cuda)
+    voice = PiperVoice.load(
+        model_path,
+        use_cuda=args.cuda,
+        download_dir=args.extra_models_dir,
+    )
     syn_config = SynthesisConfig(
         speaker_id=args.speaker,
         length_scale=args.length_scale,

--- a/src/piper/http_server.py
+++ b/src/piper/http_server.py
@@ -66,6 +66,12 @@ def main() -> None:
     )
     #
     parser.add_argument(
+        "--extra-models-dir",
+        "--extra_models_dir",
+        help="Directory for downloadable resources like the Chinese g2pW model (default: current directory)",
+    )
+    #
+    parser.add_argument(
         "--debug", action="store_true", help="Print DEBUG messages to console"
     )
     args = parser.parse_args()
@@ -99,7 +105,10 @@ def main() -> None:
 
     # Load voice
     default_voice = PiperVoice.load(
-        model_path, use_cuda=args.cuda, include_alignments=True
+        model_path,
+        use_cuda=args.cuda,
+        include_alignments=True,
+        download_dir=args.extra_models_dir,
     )
     loaded_voices: Dict[str, PiperVoice] = {default_model_id: default_voice}
 
@@ -242,7 +251,11 @@ def main() -> None:
                 maybe_model_path = Path(data_dir) / f"{model_id}.onnx"
                 if maybe_model_path.exists():
                     _LOGGER.debug("Loading voice %s", model_id)
-                    voice = PiperVoice.load(maybe_model_path, use_cuda=args.cuda)
+                    voice = PiperVoice.load(
+                        maybe_model_path,
+                        use_cuda=args.cuda,
+                        download_dir=args.extra_models_dir,
+                    )
                     loaded_voices[model_id] = voice
                     break
 


### PR DESCRIPTION
## Summary

Adds a `--extra-models-dir` CLI flag to `piper` and to the http server.
This is done, so users can point Piper at a directory containing a prefetched g2pW model, instead of relying on automatic download at runtime.

## Motivation

I'm packaging all of the Piper voices for Nix. Two of the Chinese voices require the g2pW model, which Piper currently looks up in the current working directory and downloads there if missing. Network access is not permitted inside the Nix build sandbox, so this download step fails when packaging those voices.

This flag lets the g2pW model be prefetched ahead of time (e.g. as a build input) and passed to Piper explicitly, avoiding that particular runtime download. It's also useful more generally for offline use.

This also gives users a place to download the `g2pW` model, that is not the current directory.
Thereby, keeping it clean and the user does not have to download the model in different directories if they what to use the voice in different directories.

## Details

- `--extra-models-dir` is threaded through to `PiperVoice.load()`'s existing `download_dir` parameter.
- Behavior is unchanged if the flag is omitted: `download_dir` defaults to the current working directory, same as before.
- The prefetched model must be placed at `<extra-models-dir>/g2pW/g2pw.onnx`, since  the `g2pW` subdirectory is required (`self.download_dir / "g2pW"`).  Pointing `--extra-models-dir` directly at a flat directory containing `g2pw.onnx` will not be found and will trigger a fresh download attempt into the download directory.
- The flag is named generically rather than tied to g2pW specifically, since it's meant to cover any future downloadable model resources.
- There is still a separate HTTP request to Hugging Face for the `bert-base-chinese` tokenizer, independent of this flag. This is how the `g2pW` module resolves its tokenizer, and can be worked around by editing that model's bundled `config.py` to point `model_source` at a local path. Out of scope for this PR.

## Testing

With `--extra-models-dir`, the g2pW model is found locally and not re-downloaded (tokenizer request still occurs, see note above):

```shell
❯ pwd
/home/rasmus/Downloads/random_dir
❯ piper --data-dir ~/Downloads/xiao --extra-models-dir ~/Downloads/g2pw-model -m zh_CN-xiao_ya-medium -- "你好"
WARNING:__main__:Audio playback is not available (ffplay). Writing audio to output.wav.
INFO:httpx:HTTP Request: HEAD https://huggingface.co/bert-base-chinese/resolve/main/tokenizer_config.json "HTTP/1.1 200 OK"
...
❯ ls
output.wav
```

Without the flag (default, unchanged behavior), the model downloads into whichever directory the shell happens to be in:

```shell
❯ piper --data-dir ~/Downloads/xiao -m zh_CN-xiao_ya-medium -- "你好"
INFO:piper.phonemize_chinese:Downloading g2pW model from '...' to '/home/rasmus/Downloads/random_dir/g2pW'
...
❯ ls
g2pW   output.wav
```
