### PR TITLE
Add missing entry points, guard optional imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,7 @@ setup(
             "piper-server = piper.http_server:main",
             "piper-train = piper.train.__main__:main",
             "piper-alignment = piper.patch_voice_with_alignment:main",
+            "piper-download-voices = piper.download_voices:main",
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ setup(
         "console_scripts": [
             "piper = piper.__main__:main",
             "piper-server = piper.http_server:main",
+            "piper-train = piper.train.__main__:main",
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
     entry_points={
         "console_scripts": [
             "piper = piper.__main__:main",
+            "piper-server = piper.http_server:main",
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
             "piper = piper.__main__:main",
             "piper-server = piper.http_server:main",
             "piper-train = piper.train.__main__:main",
+            "piper-alignment = piper.patch_voice_with_alignment:main",
         ]
     },
 )

--- a/src/piper/http_server.py
+++ b/src/piper/http_server.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.request import urlopen
 
-from flask import Flask, render_template, request
-
 from . import PiperVoice, SynthesisConfig
 from .download_voices import VOICES_JSON, download_voice
 
@@ -20,6 +18,15 @@ _LOGGER = logging.getLogger()
 
 def main() -> None:
     """Run HTTP server."""
+
+    try:
+        from flask import Flask, render_template, request
+    except ImportError as e:
+        raise SystemExit(
+            "The HTTP server requires additional dependencies. "
+            "Install with: pip install piper-tts[http]"
+        ) from e
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="0.0.0.0", help="HTTP server host")
     parser.add_argument("--port", type=int, default=5000, help="HTTP server port")

--- a/src/piper/patch_voice_with_alignment.py
+++ b/src/piper/patch_voice_with_alignment.py
@@ -7,7 +7,13 @@ import argparse
 import logging
 from typing import Optional, Set
 
-import onnx
+try:
+    import onnx
+except ImportError as e:
+    raise SystemExit(
+        "Alignment requires additional dependencies. "
+        "Install with: pip install piper-tts[alignment]"
+    ) from e
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/piper/train/__main__.py
+++ b/src/piper/train/__main__.py
@@ -1,8 +1,14 @@
 import logging
 
-import torch
-from lightning.pytorch.callbacks import ModelCheckpoint
-from lightning.pytorch.cli import LightningCLI
+try:
+    import torch
+    from lightning.pytorch.callbacks import ModelCheckpoint
+    from lightning.pytorch.cli import LightningCLI
+except ImportError as e:
+    raise SystemExit(
+        "Training requires additional dependencies. "
+        "Install with: pip install piper-tts[train]"
+    ) from e
 
 from .vits.dataset import VitsDataModule
 from .vits.lightning import VitsModel


### PR DESCRIPTION
When packaging piper-tts for NixOS, the `piper` binary is installed
for free because it has a console_scripts entry point. The rest of
piper's functionality, however, is only reachable via `python3 -m`:
`piper.train`, `piper.http_server`, `piper.patch_voice_with_alignment`,
and `piper.download_voices`.

This commit adds entry points for all four, mirroring the existing
`piper` entry point.

Since these entry points can now be installed without their optional
dependencies (train, http, alignment), each module now raises a clear
error on missing imports instead of a raw traceback, e.g.:

```shell
pip install piper-tts[train]
```