### PR TITLE
Avoid fixed timeout for long CLI audio playback

### DIFF
--- a/src/piper/audio_playback.py
+++ b/src/piper/audio_playback.py
@@ -4,6 +4,11 @@ import shutil
 import subprocess
 from typing import Optional
 
+_BYTES_PER_SAMPLE = 2
+_MIN_PROCESS_WAIT_SECONDS = 5.0
+_PROCESS_WAIT_MARGIN_SECONDS = 1.0
+_PROCESS_KILL_WAIT_SECONDS = 1.0
+
 
 class AudioPlayer:
     """Plays raw audio using ffplay."""
@@ -12,9 +17,11 @@ class AudioPlayer:
         """Initializes audio player."""
         self.sample_rate = sample_rate
         self._proc: Optional[subprocess.Popen] = None
+        self._audio_bytes_written = 0
 
     def __enter__(self):
         """Starts ffplay subprocess and returns player."""
+        self._audio_bytes_written = 0
         self._proc = subprocess.Popen(
             [
                 "ffplay",
@@ -42,14 +49,28 @@ class AudioPlayer:
                     self._proc.stdin.close()
             except Exception:
                 pass
-            self._proc.wait(timeout=5)
+
+            audio_duration = self._audio_bytes_written / (
+                self.sample_rate * _BYTES_PER_SAMPLE
+            )
+            wait_timeout = max(
+                _MIN_PROCESS_WAIT_SECONDS,
+                audio_duration + _PROCESS_WAIT_MARGIN_SECONDS,
+            )
+            try:
+                self._proc.wait(timeout=wait_timeout)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=_PROCESS_KILL_WAIT_SECONDS)
+                raise
 
     def play(self, audio_bytes: bytes) -> None:
         """Plays raw audio using ffplay."""
         assert self._proc is not None
         assert self._proc.stdin is not None
 
-        self._proc.stdin.write(audio_bytes)
+        bytes_written = self._proc.stdin.write(audio_bytes)
+        self._audio_bytes_written += bytes_written
         self._proc.stdin.flush()
 
     @staticmethod

--- a/tests/test_audio_playback.py
+++ b/tests/test_audio_playback.py
@@ -1,0 +1,95 @@
+"""Tests for ffplay audio playback."""
+
+import subprocess
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from piper.audio_playback import AudioPlayer
+
+
+def _process_mock() -> MagicMock:
+    process = MagicMock(spec=subprocess.Popen)
+    process.stdin = MagicMock()
+    return process
+
+
+@pytest.mark.parametrize(
+    ("chunks", "expected_timeout"),
+    [
+        ([], 5.0),
+        ([2 * 10], 5.0),
+        ([2 * 10 * 12], 13.0),
+        ([2 * 10 * 6, 2 * 10 * 6], 13.0),
+    ],
+)
+def test_wait_timeout_scales_with_audio_duration(
+    chunks: list[int], expected_timeout: float
+) -> None:
+    """Wait long enough for ffplay to drain all streamed audio."""
+    process = _process_mock()
+    process.stdin.write.side_effect = chunks
+    events = []
+    process.stdin.close.side_effect = lambda: events.append("close")
+    process.wait.side_effect = lambda **kwargs: events.append("wait")
+
+    with patch("piper.audio_playback.subprocess.Popen", return_value=process):
+        with AudioPlayer(sample_rate=10) as player:
+            for chunk_size in chunks:
+                player.play(bytes(chunk_size))
+
+    assert events == ["close", "wait"]
+    process.wait.assert_called_once_with(timeout=expected_timeout)
+
+
+def test_failed_write_does_not_extend_wait_timeout() -> None:
+    """Do not count bytes that ffplay did not accept."""
+    process = _process_mock()
+    process.stdin.write.side_effect = OSError("write failed")
+
+    with patch("piper.audio_playback.subprocess.Popen", return_value=process):
+        with pytest.raises(OSError, match="write failed"):
+            with AudioPlayer(sample_rate=10) as player:
+                player.play(bytes(2 * 10 * 12))
+
+    process.wait.assert_called_once_with(timeout=5.0)
+
+
+def test_timeout_kills_ffplay_and_remains_bounded() -> None:
+    """Clean up ffplay when it does not exit within the calculated timeout."""
+    process = _process_mock()
+    process.wait.side_effect = [
+        subprocess.TimeoutExpired("ffplay", 5.0),
+        None,
+    ]
+
+    with patch("piper.audio_playback.subprocess.Popen", return_value=process):
+        with pytest.raises(subprocess.TimeoutExpired):
+            with AudioPlayer(sample_rate=10):
+                pass
+
+    process.kill.assert_called_once_with()
+    assert process.wait.call_args_list == [
+        call(timeout=5.0),
+        call(timeout=1.0),
+    ]
+
+
+def test_reentering_player_resets_audio_duration() -> None:
+    """Track duration per ffplay process instead of per player instance."""
+    first_process = _process_mock()
+    first_process.stdin.write.return_value = 2 * 10 * 12
+    second_process = _process_mock()
+    player = AudioPlayer(sample_rate=10)
+
+    with patch(
+        "piper.audio_playback.subprocess.Popen",
+        side_effect=[first_process, second_process],
+    ):
+        with player:
+            player.play(bytes(2 * 10 * 12))
+        with player:
+            pass
+
+    first_process.wait.assert_called_once_with(timeout=13.0)
+    second_process.wait.assert_called_once_with(timeout=5.0)


### PR DESCRIPTION
## Summary

- track the signed 16-bit mono bytes successfully written to `ffplay`
- scale the bounded process-exit wait to the streamed audio duration while preserving the existing five-second minimum
- kill a genuinely stuck player and use a second bounded wait for cleanup
- add mocked regression coverage for short, long, accumulated, failed-write, timeout, and reused-player paths

## Problem

`AudioPlayer.__exit__` always waits five seconds, regardless of how much audio was streamed. Long synthesized output can therefore raise `subprocess.TimeoutExpired` even when synthesis and playback are otherwise working.

## Testing

- `python script\test -k audio_playback -vv` — 7 passed, 1 skipped, 26 deselected
- `.venv\Scripts\python.exe -m black src\piper\audio_playback.py tests\test_audio_playback.py --check` — passed
- `.venv\Scripts\python.exe -m isort src\piper\audio_playback.py tests\test_audio_playback.py --check-only` — passed
- `.venv\Scripts\python.exe -m flake8 src\piper\audio_playback.py tests\test_audio_playback.py` — passed
- `.venv\Scripts\python.exe -m pylint src\piper\audio_playback.py tests\test_audio_playback.py` — passed, 10.00/10
- `.venv\Scripts\python.exe -m mypy src\piper\audio_playback.py tests\test_audio_playback.py` — passed

## Validation gaps

- `python script\dev_build` could not complete on the Windows validation host because no Visual Studio C compiler is installed.
- Consequently, the full `python script\test` run reported 11 failures, 21 passes, and 1 skip because the existing `piper.espeakbridge` extension was unavailable.
- Full `python script\lint` passed Black across 44 files, then stopped on an existing isort mismatch in untouched `src/piper/hebrew/hebrew_ipa.py`.
- Native, training, GPU, model, wheel, Linux, and real `ffplay` coverage were not exercised.

Closes #18
