### PR TITLE
Add support for Text PhonemeType

### DIFF
--- a/libpiper/include/piper_impl.hpp
+++ b/libpiper/include/piper_impl.hpp
@@ -51,6 +51,18 @@ const int DEFAULT_HOP_LENGTH = 256;
 #define CLAUSE_COLON (30 | CLAUSE_INTONATION_FULL_STOP | CLAUSE_TYPE_CLAUSE)
 #define CLAUSE_SEMICOLON (30 | CLAUSE_INTONATION_COMMA | CLAUSE_TYPE_CLAUSE)
 
+enum class PhonemeType {
+  Invalid = 0,
+  Text,
+  Espeak,
+};
+
+NLOHMANN_JSON_SERIALIZE_ENUM(PhonemeType, {
+                                              {PhonemeType::Text, nullptr},
+                                              {PhonemeType::Espeak, "espeak"},
+                                              {PhonemeType::Text, "text"},
+                                          })
+
 struct piper_synthesizer {
   // From config JSON file
   std::string espeak_voice;
@@ -58,6 +70,7 @@ struct piper_synthesizer {
   int num_speakers;
   PhonemeIdMap phoneme_id_map;
   int hop_length = DEFAULT_HOP_LENGTH;
+  PhonemeType phoneme_type = PhonemeType::Espeak;
 
   // Default synthesis settings for the voice
   float synth_length_scale = DEFAULT_LENGTH_SCALE;

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -43,12 +43,18 @@ struct piper_synthesizer *piper_create(const char *model_path,
 
   std::ifstream config_stream(config_path_str);
   auto config = json::parse(config_stream);
+  PhonemeType phoneme_type = PhonemeType::Espeak;
+  if (config.contains("phoneme_type")) {
+    phoneme_type = config["phoneme_type"].get<PhonemeType>();
+  }
 
-  if (espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 0, espeak_data_path, 0) < 0) {
+  if (phoneme_type == PhonemeType::Espeak &&
+      espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 0, espeak_data_path, 0) < 0) {
     return nullptr;
   }
 
   piper_synthesizer *synth = new piper_synthesizer();
+  synth->phoneme_type = phoneme_type;
 
   // Load config options
   synth->espeak_voice = "en-us"; // default
@@ -124,10 +130,12 @@ struct piper_synthesizer *piper_create(const char *model_path,
 }
 
 void piper_free(struct piper_synthesizer *synth) {
-  espeak_Terminate();
-
   if (!synth) {
     return;
+  }
+
+  if (synth->phoneme_type == PhonemeType::Espeak) {
+    espeak_Terminate();
   }
 
   delete synth;
@@ -156,7 +164,8 @@ int piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
     return PIPER_ERR_GENERIC;
   }
 
-  if (espeak_SetVoiceByName(synth->espeak_voice.c_str()) != EE_OK) {
+  if (synth->phoneme_type == PhonemeType::Espeak &&
+      espeak_SetVoiceByName(synth->espeak_voice.c_str()) != EE_OK) {
     return PIPER_ERR_GENERIC;
   }
 
@@ -180,42 +189,57 @@ int piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
 
   // phonemize
   std::vector<std::string> sentence_phonemes{""};
-  std::size_t current_idx = 0;
-  const void *text_ptr = text;
-  while (text_ptr != nullptr) {
-    int terminator = 0;
-    std::string terminator_str = "";
+  switch (synth->phoneme_type) {
+  case PhonemeType::Espeak: {
+    std::size_t current_idx = 0;
+    const void *text_ptr = text;
+    while (text_ptr != nullptr) {
+      int terminator = 0;
+      std::string terminator_str = "";
 
-    const char *phonemes = espeak_TextToPhonemesWithTerminator(
-        &text_ptr, espeakCHARS_AUTO, espeakPHONEMES_IPA, &terminator);
+      const char *phonemes = espeak_TextToPhonemesWithTerminator(
+          &text_ptr, espeakCHARS_AUTO, espeakPHONEMES_IPA, &terminator);
 
-    if (phonemes) {
-      sentence_phonemes[current_idx] += phonemes;
+      if (phonemes) {
+        sentence_phonemes[current_idx] += phonemes;
+      }
+
+      // Categorize terminator
+      terminator &= 0x000FFFFF;
+
+      if (terminator == CLAUSE_PERIOD) {
+        terminator_str = ".";
+      } else if (terminator == CLAUSE_QUESTION) {
+        terminator_str = "?";
+      } else if (terminator == CLAUSE_EXCLAMATION) {
+        terminator_str = "!";
+      } else if (terminator == CLAUSE_COMMA) {
+        terminator_str = ", ";
+      } else if (terminator == CLAUSE_COLON) {
+        terminator_str = ": ";
+      } else if (terminator == CLAUSE_SEMICOLON) {
+        terminator_str = "; ";
+      }
+
+      sentence_phonemes[current_idx] += terminator_str;
+
+      if ((terminator & CLAUSE_TYPE_SENTENCE) == CLAUSE_TYPE_SENTENCE) {
+        sentence_phonemes.push_back("");
+        current_idx = sentence_phonemes.size() - 1;
+      }
     }
-
-    // Categorize terminator
-    terminator &= 0x000FFFFF;
-
-    if (terminator == CLAUSE_PERIOD) {
-      terminator_str = ".";
-    } else if (terminator == CLAUSE_QUESTION) {
-      terminator_str = "?";
-    } else if (terminator == CLAUSE_EXCLAMATION) {
-      terminator_str = "!";
-    } else if (terminator == CLAUSE_COMMA) {
-      terminator_str = ", ";
-    } else if (terminator == CLAUSE_COLON) {
-      terminator_str = ": ";
-    } else if (terminator == CLAUSE_SEMICOLON) {
-      terminator_str = "; ";
-    }
-
-    sentence_phonemes[current_idx] += terminator_str;
-
-    if ((terminator & CLAUSE_TYPE_SENTENCE) == CLAUSE_TYPE_SENTENCE) {
-      sentence_phonemes.push_back("");
-      current_idx = sentence_phonemes.size() - 1;
-    }
+    break;
+  }
+  case PhonemeType::Text: {
+    std::string lower_text = una::cases::to_lowercase_utf8(text);
+    std::string nfd_text = una::norm::to_nfd_utf8(lower_text);
+    sentence_phonemes.clear();
+    sentence_phonemes.push_back(nfd_text);
+    break;
+  }
+  case PhonemeType::Invalid: {
+    return PIPER_ERR_GENERIC;
+  }
   }
 
   // phonemes to ids

--- a/libpiper/tests/CMakeLists.txt
+++ b/libpiper/tests/CMakeLists.txt
@@ -19,6 +19,9 @@ include(DownloadModel.cmake)
 download_piper_model(VOICE "en/en_US/lessac/medium/en_US-lessac-medium"
                      OUTPUT_DIR EN_MODEL_DIR)
 
+download_piper_model(VOICE "uk/uk_UA/ukrainian_tts/medium/uk_UA-ukrainian_tts-medium"
+                     OUTPUT_DIR TEXT_MODEL_DIR)
+
 add_executable(piper_test
    test_piper.cpp
    utils/piper_test_assets.h
@@ -32,6 +35,7 @@ add_executable(piper_test
 target_compile_definitions(piper_test
     PRIVATE "ESPEAK_DATA_PATH=\"${CMAKE_BINARY_DIR}/espeak_ng-install/share/espeak-ng-data\""
     PRIVATE "EN_TEST_MODEL_DIR=\"${EN_MODEL_DIR}\""
+    PRIVATE "TEXT_TEST_MODEL_DIR=\"${TEXT_MODEL_DIR}\""
 )
 
 target_link_libraries(piper_test

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "piper.h"
+#include "piper_impl.hpp"
 #include "utils/piper_test_assets.h"
 
 class PiperTest : public ::testing::Test {
@@ -43,6 +44,29 @@ TEST_F(PiperTest, PiperSynthesis) {
 
   // Start synthesis
   int result = piper_synthesize_start(synth, "This is a test.", nullptr);
+  ASSERT_EQ(result, PIPER_OK);
+
+  // Get audio chunks
+  piper_audio_chunk chunk;
+  do {
+    result = piper_synthesize_next(synth, &chunk);
+    ASSERT_EQ(result, chunk.is_last ? PIPER_DONE : PIPER_OK);
+    ASSERT_GT(chunk.num_samples, 0);
+  } while (!chunk.is_last);
+
+  piper_free(synth);
+}
+
+TEST_F(PiperTest, PiperSynthesisText) {
+  auto textAssets = PiperTestAssets::textModel();
+  piper_synthesizer *synth =
+      piper_create(textAssets->modelPath().string().c_str(),
+                   textAssets->configPath().string().c_str(), nullptr);
+  ASSERT_NE(synth, nullptr);
+  ASSERT_EQ(synth->phoneme_type, PhonemeType::Text);
+
+  // Start synthesis
+  int result = piper_synthesize_start(synth, "Це є тест.", nullptr);
   ASSERT_EQ(result, PIPER_OK);
 
   // Get audio chunks

--- a/libpiper/tests/utils/piper_test_assets.cpp
+++ b/libpiper/tests/utils/piper_test_assets.cpp
@@ -19,3 +19,7 @@ std::filesystem::path PiperTestAssets::espeakDataPath() {
 std::unique_ptr<PiperTestAssets> PiperTestAssets::enModel() {
   return std::make_unique<PiperTestAssets>(EN_TEST_MODEL_DIR);
 }
+
+std::unique_ptr<PiperTestAssets> PiperTestAssets::textModel() {
+  return std::make_unique<PiperTestAssets>(TEXT_TEST_MODEL_DIR);
+}

--- a/libpiper/tests/utils/piper_test_assets.h
+++ b/libpiper/tests/utils/piper_test_assets.h
@@ -23,6 +23,11 @@ public:
    */
   static std::unique_ptr<PiperTestAssets> enModel();
 
+  /**
+   * @brief Static factory method to get the model with Text phonemes assets.
+   */
+  static std::unique_ptr<PiperTestAssets> textModel();
+
 private:
   std::filesystem::path modelDir;
 };


### PR DESCRIPTION
This pull request introduces support for a new PhonemeType::Text. This allows Piper to work with models that perform their own text-to-phoneme conversion, bypassing the need for eSpeak-ng for certain languages or use cases.

This is a key step towards supporting a wider variety of languages and custom phonemization schemes.