### PR TITLE
Use GTest from system if available

### DIFF
--- a/libpiper/tests/CMakeLists.txt
+++ b/libpiper/tests/CMakeLists.txt
@@ -1,18 +1,21 @@
 cmake_minimum_required(VERSION 3.26)
 
 message(STATUS "Building piper tests")
-include(FetchContent)
-FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.17.0
-)
 
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+find_package(GTest QUIET)
 
-enable_testing()
+if(NOT GTest_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.17.0
+    )
+
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+endif()
 
 include(DownloadModel.cmake)
 


### PR DESCRIPTION
While at it, remove `enable_testing()` which is already called in parent CMakeLists.txt.