### PR TITLE
Fix odd-byte inter-sentence silence corrupting multi-sentence audio

### DIFF
--- a/src/piper/__main__.py
+++ b/src/piper/__main__.py
@@ -158,9 +158,12 @@ def main() -> None:
 
     wav_file: wave.Wave_write
 
-    # 16-bit samples for silence
+    # 16-bit samples for silence.
+    # Compute whole samples first, then multiply by 2 bytes/sample so the byte
+    # count is always even. Otherwise an odd byte count would write a half frame
+    # of 16-bit PCM and misalign every subsequent sample (see issue #253).
     silence_int16_bytes = bytes(
-        int(voice.config.sample_rate * args.sentence_silence * 2)
+        int(voice.config.sample_rate * args.sentence_silence) * 2
     )
 
     def lines_to_wav() -> None:

--- a/tests/test_piper.py
+++ b/tests/test_piper.py
@@ -2,6 +2,8 @@
 
 import io
 import shutil
+import struct
+import sys
 import wave
 from pathlib import Path
 from unittest.mock import patch
@@ -160,6 +162,61 @@ def test_synthesize_wav() -> None:
                 == voice.config.sample_rate * wav_input.getsampwidth() * 2
             )
             assert not any(audio_data)
+
+
+@pytest.mark.parametrize(
+    "sentence_silence",
+    # At 22050 Hz these all made int(rate * s * 2) odd under the old code, which
+    # wrote a half frame of 16-bit PCM between sentences and misaligned the rest
+    # of the stream (issue #253). 0.30 is an even control.
+    [0.15, 0.25, 0.30, 0.45, 0.75],
+)
+def test_sentence_silence_even_byte_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sentence_silence: float
+) -> None:
+    """Inter-sentence silence must never leave the WAV data chunk odd-length."""
+    from piper.__main__ import main
+
+    output_path = tmp_path / "out.wav"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "piper",
+            "-m",
+            str(_TEST_VOICE),
+            "-f",
+            str(output_path),
+            "--sentence-silence",
+            str(sentence_silence),
+        ],
+    )
+    # Two sentences => silence is written once, between the chunks.
+    monkeypatch.setattr(sys, "stdin", io.StringIO("This is a test. This is another."))
+
+    main()
+
+    with wave.open(str(output_path), "rb") as wav_input:
+        assert wav_input.getsampwidth() == 2
+        assert wav_input.getnchannels() == 1
+
+    # Read the on-disk `data` chunk size field directly. This is the byte the
+    # bug leaves odd; wave's own reader hides it because readframes() returns
+    # getnframes() * frame_size, silently dropping the trailing orphan byte.
+    raw = output_path.read_bytes()
+    data_idx = raw.find(b"data")
+    data_size = struct.unpack("<I", raw[data_idx + 4 : data_idx + 8])[0]
+
+    # A 16-bit mono data chunk must be a whole number of frames (even byte count).
+    assert data_size % 2 == 0, f"odd data chunk ({data_size} bytes)"
+
+    # No trailing orphan byte was written: the data chunk is exactly the two
+    # one-second chunks (test voice emits 1 s of silence per sentence at 22050 Hz)
+    # plus a whole number of silence samples.
+    sample_rate = 22050
+    silence_samples = int(sample_rate * sentence_silence)
+    expected_bytes = (sample_rate * 2 * 2) + (silence_samples * 2)
+    assert data_size == expected_bytes
 
 
 def test_ar_tashkeel() -> None:


### PR DESCRIPTION
## Summary

Fixes #253.

`--sentence-silence` sized the inter-sentence silence buffer as `int(sample_rate * silence * 2)` — a **byte** count that is only accidentally even. When it's odd (e.g. `int(22050 * 0.25 * 2) == 11025` for the common 22050 Hz `en_US` voices), `wave.writeframes` emits a trailing orphan byte, misaligning every subsequent 16-bit sample into byte-swapped white noise and leaving the WAV `data` chunk an odd length.

The failure is silent — exit 0, well-formed header, plausible size/duration; only a strict decoder (`ffmpeg -v error`) complains. Single-sentence input and the default `--sentence-silence 0.0` are unaffected.

## Fix

```diff
-        int(voice.config.sample_rate * args.sentence_silence * 2)
+        int(voice.config.sample_rate * args.sentence_silence) * 2
```

Compute whole samples first, then multiply by 2 bytes/sample so the count can never be odd. This also sidesteps the float-truncation parity flip noted in the issue (`22050 * 0.35 * 2` → `15434.999…`). Cost is at most half a sample of silence (~23 µs). The buffer is shared, so this covers the WAV, `--output-raw`, and `--output-dir` paths at once.

## Test

Adds `test_sentence_silence_even_byte_count`, parametrized over silence values that made the byte count odd at 22050 Hz (`0.15, 0.25, 0.45, 0.75`) plus an even control (`0.30`). It drives the CLI `main()` end-to-end and asserts the on-disk `data`-chunk size field is even and exactly the expected length.

Note for reviewers: the obvious check — reading back via `wave.readframes(getnframes())` — does **not** catch this, because `wave` counts frames as `len(data) // frame_size` and silently drops the orphan byte. The test therefore parses the raw `data`-chunk size field from disk, as the issue's stdlib snippet does. Verified failing on all four odd values with the fix reverted, passing with it applied; full `test_piper.py` (19 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)