### PR TITLE
README: Add piper-jni

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ People/projects using Piper:
 * [Narration Studio](https://github.com/phyce/Narration-Studio)
 * [Basic TTS](https://basictts.com/) - Simple online text-to-speech converter.
 
+Bindings to use Piper in programming languages other than Python and C/C++:
+
+* Java: [Piper JNI](https://github.com/jvoice-project/piper-jni)
+
 [![A library from the Open Home Foundation](https://www.openhomefoundation.org/badges/ohf-library.png)](https://www.openhomefoundation.org/)
 
 <!-- Links -->


### PR DESCRIPTION
This adds a section to the README that lists language bindings for Piper and adds piper-jni (Java):
https://github.com/jvoice-project/piper-jni