### PR TITLE
Make libpiper formatting opt-in

### DIFF
--- a/.github/workflows/build-libpiper.yml
+++ b/.github/workflows/build-libpiper.yml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Configure and build with clang-tidy and Clang
         run: |
-          cmake -B build -DPIPER_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PWD/install" -DENABLE_CLANG_TIDY=ON
+          # A regular build must not invoke the opt-in format target.
+          cmake -B build -DPIPER_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PWD/install" -DENABLE_CLANG_TIDY=ON -DCLANG_FORMAT=/usr/bin/false
           cmake --build build --config Release
         env:
           CC: clang

--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -236,7 +236,6 @@ if(CLANG_FORMAT)
         COMMENT "Formatting C/C++ files with clang-format"
     )
     message(STATUS "Added 'format' target to run clang-format.")
-    add_dependencies(piper format)
 else()
     message(WARNING "clang-format not found. The 'format' target will not be available.")
 endif()


### PR DESCRIPTION
Fixes #258.

## Summary

- remove the `piper -> format` dependency so regular CMake builds do not invoke source formatting
- keep the explicit `format` target and the existing formatting check unchanged
- add a guard using `CLANG_FORMAT=/usr/bin/false`, so the clang-tidy build succeeds only while formatting remains outside the default build graph

## Validation

- current `main` Ubuntu and Windows build logs execute `format` before compiling `piper`
- in a focused CMake/Ninja graph, the previous dependency with the failing formatter exits non-zero, while this build graph succeeds
- explicitly building the `format` target still invokes the failing formatter
- the updated YAML parses successfully and its shell block passes `bash -n`
- `git diff --check` passed

The full native build was not run locally; the cross-platform checks on this PR should validate it.
