### PR TITLE
Refactor: introduce piper_create_options and piper_create_with_options

### DIFF
--- a/libpiper/include/piper.h
+++ b/libpiper/include/piper.h
@@ -18,6 +18,10 @@ typedef uint32_t char32_t;
 #define __char32_t_defined
 #endif
 
+#if !defined(__cplusplus)
+#include <stddef.h>
+#endif
+
 #if defined(WIN32) && (defined(__GNUC__) || defined(_MSC_VER))
 #if defined(BUILDING_LIBPIPER)
 #define EXPORT_SYMBOL __declspec(dllexport)
@@ -163,6 +167,63 @@ typedef struct piper_synthesize_options {
    */
   float noise_w_scale;
 } piper_synthesize_options;
+
+/**
+ * \brief Options for creating a synthesizer.
+ *
+ * This struct is versioned by struct_size. Set struct_size =
+ * sizeof(piper_create_options) before passing to piper_create_with_options.
+ * Future fields will be appended at the end and gated by struct_size.
+ */
+typedef struct piper_create_options {
+  /**
+   * \brief Size of this struct in bytes, for versioning.
+   */
+  size_t struct_size;
+
+  /**
+   * \brief Path to ONNX voice model file.
+   */
+  const char *model_path;
+
+  /**
+   * \brief Path to JSON voice config file or NULL if it's model_path + .json
+   */
+  const char *config_path;
+
+  /**
+   * \brief Path to espeak-ng data directory, or NULL if not needed (text
+   * phonemes).
+   */
+  const char *espeak_data_path;
+} piper_create_options;
+
+/**
+ * \brief Initialize piper_create_options with defaults.
+ *
+ * Sets struct_size and nulls paths. Caller must fill model_path at least.
+ */
+static inline void piper_init_create_options(piper_create_options *opts) {
+  if (opts) {
+    opts->struct_size = sizeof(piper_create_options);
+    opts->model_path = NULL;
+    opts->config_path = NULL;
+    opts->espeak_data_path = NULL;
+  }
+}
+
+/**
+ * \brief Create a Piper text-to-speech synthesizer from a voice model (options
+ * version).
+ *
+ * \param options creation options, must have struct_size set.
+ *
+ * \return a Piper text-to-speech synthesizer for the voice model, or NULL on
+ * failure.
+ */
+EXPORT_SYMBOL
+piper_synthesizer *
+piper_create_with_options(const piper_create_options *options);
 
 /**
  * \brief Create a Piper text-to-speech synthesizer from a voice model.

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -23,11 +23,25 @@
 
 using json = nlohmann::json;
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity,bugprone-easily-swappable-parameters)
-auto piper_create(const char *model_path, const char *config_path,
-                  const char *espeak_data_path) -> struct piper_synthesizer * {
+auto piper_create_with_options(const piper_create_options *options)
+    -> struct piper_synthesizer * {
   // onnx
   static Ort::Env ort_env{ORT_LOGGING_LEVEL_WARNING, "piper"};
+
+  if (options == nullptr) {
+    return nullptr;
+  }
+
+  // Basic version check - allow forward compatible larger structs
+  if (options->struct_size < offsetof(piper_create_options, espeak_data_path) +
+                                 sizeof(options->espeak_data_path)) {
+    // Struct too small to contain required fields
+    return nullptr;
+  }
+
+  const char *model_path = options->model_path;
+  const char *config_path = options->config_path;
+  const char *espeak_data_path = options->espeak_data_path;
 
   if (model_path == nullptr) {
     return nullptr;
@@ -133,6 +147,16 @@ auto piper_create(const char *model_path, const char *config_path,
       Ort::Session(ort_env, model_path_ort, synth->session_options));
 
   return synth;
+}
+
+auto piper_create(const char *model_path, const char *config_path,
+                  const char *espeak_data_path) -> struct piper_synthesizer * {
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  opts.model_path = model_path;
+  opts.config_path = config_path;
+  opts.espeak_data_path = espeak_data_path;
+  return piper_create_with_options(&opts);
 }
 
 void piper_free(struct piper_synthesizer *synth) {


### PR DESCRIPTION
- Add piper_create_options struct with struct_size versioning for forward compat
- Add piper_create_with_options() as new core creation API
- Keep legacy piper_create(model,config,espeak) as wrapper for ABI compat (unchanged in header)
- C and C++ callers use piper_create_with_options(&opts) for extended options
- Prep for g2pw_model_dir / data_dir fields in next PR

Tests: 21/21 pass, format target clean
