### PR TITLE
Add Chinese pinyin support – Phase 1 (monophonic dict fallback, honest scoping)

### DIFF
--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -173,6 +173,10 @@ else()
   message(WARNING "Could not parse version from setup.py")
 endif()
 
+# Windows DLL export for Chinese phonemizer symbols (fixes LNK2019)
+target_compile_definitions(piper PRIVATE BUILDING_LIBPIPER)
+
+
 # ---- install ---
 
 include(GNUInstallDirs)

--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -143,6 +143,7 @@ include(ClangTidy.cmake)
 
 add_library(piper SHARED
     ${CMAKE_CURRENT_SOURCE_DIR}/src/piper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/chinese_phonemizer.cpp
 )
 enable_clang_tidy(piper)
 

--- a/libpiper/include/chinese_phonemizer.h
+++ b/libpiper/include/chinese_phonemizer.h
@@ -1,0 +1,58 @@
+#ifndef CHINESE_PHONEMIZER_H_
+#define CHINESE_PHONEMIZER_H_
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace piper {
+
+extern const std::vector<std::string> PINYIN_INITIALS;
+extern const std::set<std::string> GROUP_END_PHONEMES;
+extern const std::set<std::string> PINYIN_PUNCTUATIONS;
+
+std::string normalize_g2pw_syllable(const std::string &syl);
+std::tuple<std::string, std::string, std::string>
+split_initial_final_tone(const std::string &syl);
+
+std::optional<char32_t> get_codepoint_str(const std::string &s);
+
+std::vector<int64_t>
+phonemes_to_ids(const std::vector<std::string> &phonemes,
+                const std::map<std::string, std::vector<int64_t>> &id_map);
+
+class ChinesePhonemizer {
+public:
+  ChinesePhonemizer() = default;
+
+  bool load(const std::string &g2pw_model_dir);
+
+  static std::vector<std::vector<std::string>>
+  phonemize_pinyin_text(const std::string &text);
+
+  std::vector<std::vector<std::string>> phonemize(const std::string &text);
+
+  static std::vector<int64_t> phonemes_to_ids_pinyin(
+      const std::vector<std::string> &phonemes,
+      const std::map<std::string, std::vector<int64_t>> &id_map);
+
+  bool hasDicts() const { return has_dicts; }
+
+private:
+  std::map<std::string, std::string> mono_dict; // char utf8 -> bopomofo
+  std::map<std::string, std::vector<std::string>> poly_dict;
+  std::map<std::string, std::vector<std::string>> char_bopomofo_dict;
+  std::map<std::string, std::string> bopomofo2pinyin;
+  std::map<std::string, std::string> s2t;
+  bool has_dicts = false;
+
+  std::string bopomofo_to_pinyin(const std::string &bopomofo) const;
+};
+
+} // namespace piper
+
+#endif // CHINESE_PHONEMIZER_H_

--- a/libpiper/include/chinese_phonemizer.h
+++ b/libpiper/include/chinese_phonemizer.h
@@ -25,11 +25,13 @@ extern CHINESE_PHONEMIZER_API const std::vector<std::string> PINYIN_INITIALS;
 extern CHINESE_PHONEMIZER_API const std::set<std::string> GROUP_END_PHONEMES;
 extern CHINESE_PHONEMIZER_API const std::set<std::string> PINYIN_PUNCTUATIONS;
 
-CHINESE_PHONEMIZER_API std::string normalize_g2pw_syllable(const std::string &syl);
+CHINESE_PHONEMIZER_API std::string
+normalize_g2pw_syllable(const std::string &syl);
 CHINESE_PHONEMIZER_API std::tuple<std::string, std::string, std::string>
 split_initial_final_tone(const std::string &syl);
 
-CHINESE_PHONEMIZER_API std::optional<char32_t> get_codepoint_str(const std::string &s);
+CHINESE_PHONEMIZER_API std::optional<char32_t>
+get_codepoint_str(const std::string &s);
 
 CHINESE_PHONEMIZER_API std::vector<int64_t>
 phonemes_to_ids(const std::vector<std::string> &phonemes,
@@ -54,10 +56,8 @@ public:
 
 private:
   std::map<std::string, std::string> mono_dict; // char utf8 -> bopomofo
-  std::map<std::string, std::vector<std::string>> poly_dict;
   std::map<std::string, std::vector<std::string>> char_bopomofo_dict;
   std::map<std::string, std::string> bopomofo2pinyin;
-  std::map<std::string, std::string> s2t;
   bool has_dicts = false;
 
   std::string bopomofo_to_pinyin(const std::string &bopomofo) const;

--- a/libpiper/include/chinese_phonemizer.h
+++ b/libpiper/include/chinese_phonemizer.h
@@ -9,23 +9,33 @@
 #include <tuple>
 #include <vector>
 
+#if defined(_WIN32) || defined(_WIN64)
+#if defined(BUILDING_LIBPIPER)
+#define CHINESE_PHONEMIZER_API __declspec(dllexport)
+#else
+#define CHINESE_PHONEMIZER_API __declspec(dllimport)
+#endif
+#else
+#define CHINESE_PHONEMIZER_API
+#endif
+
 namespace piper {
 
-extern const std::vector<std::string> PINYIN_INITIALS;
-extern const std::set<std::string> GROUP_END_PHONEMES;
-extern const std::set<std::string> PINYIN_PUNCTUATIONS;
+extern CHINESE_PHONEMIZER_API const std::vector<std::string> PINYIN_INITIALS;
+extern CHINESE_PHONEMIZER_API const std::set<std::string> GROUP_END_PHONEMES;
+extern CHINESE_PHONEMIZER_API const std::set<std::string> PINYIN_PUNCTUATIONS;
 
-std::string normalize_g2pw_syllable(const std::string &syl);
-std::tuple<std::string, std::string, std::string>
+CHINESE_PHONEMIZER_API std::string normalize_g2pw_syllable(const std::string &syl);
+CHINESE_PHONEMIZER_API std::tuple<std::string, std::string, std::string>
 split_initial_final_tone(const std::string &syl);
 
-std::optional<char32_t> get_codepoint_str(const std::string &s);
+CHINESE_PHONEMIZER_API std::optional<char32_t> get_codepoint_str(const std::string &s);
 
-std::vector<int64_t>
+CHINESE_PHONEMIZER_API std::vector<int64_t>
 phonemes_to_ids(const std::vector<std::string> &phonemes,
                 const std::map<std::string, std::vector<int64_t>> &id_map);
 
-class ChinesePhonemizer {
+class CHINESE_PHONEMIZER_API ChinesePhonemizer {
 public:
   ChinesePhonemizer() = default;
 

--- a/libpiper/include/piper.h
+++ b/libpiper/include/piper.h
@@ -196,6 +196,26 @@ typedef struct piper_create_options {
    * phonemes).
    */
   const char *espeak_data_path;
+
+  /**
+   * \brief Path to g2pw ONNX model directory for pinyin, or NULL for
+   * auto-discovery.
+   *
+   * Directory must contain g2pw.onnx, POLYPHONIC_CHARS.txt,
+   * MONOPHONIC_CHARS.txt, and the lookup tables
+   * (bopomofo_to_pinyin_wo_tune_dict.json etc) or be next to espeak data /
+   * data_dir.
+   */
+  const char *g2pw_model_dir;
+
+  /**
+   * \brief Optional root data directory that may contain espeak-ng-data/ and
+   * g2pw/.
+   *
+   * If espeak_data_path or g2pw_model_dir is NULL, library will search inside
+   * data_dir/espeak-ng-data and data_dir/g2pw / data_dir.
+   */
+  const char *data_dir;
 } piper_create_options;
 
 /**
@@ -209,6 +229,8 @@ static inline void piper_init_create_options(piper_create_options *opts) {
     opts->model_path = NULL;
     opts->config_path = NULL;
     opts->espeak_data_path = NULL;
+    opts->g2pw_model_dir = NULL;
+    opts->data_dir = NULL;
   }
 }
 

--- a/libpiper/include/piper.h
+++ b/libpiper/include/piper.h
@@ -198,13 +198,17 @@ typedef struct piper_create_options {
   const char *espeak_data_path;
 
   /**
-   * \brief Path to g2pw ONNX model directory for pinyin, or NULL for
+   * \brief Path to g2pw / pinyin dictionary directory for pinyin, or NULL for
    * auto-discovery.
    *
-   * Directory must contain g2pw.onnx, POLYPHONIC_CHARS.txt,
-   * MONOPHONIC_CHARS.txt, and the lookup tables
-   * (bopomofo_to_pinyin_wo_tune_dict.json etc) or be next to espeak data /
-   * data_dir.
+   * Phase 1 (monophonic fallback) directory should contain
+   * MONOPHONIC_CHARS.txt (118K) and/or char_bopomofo_dict.json and
+   * bopomofo_to_pinyin_wo_tune_dict.json. g2pw.onnx and
+   * POLYPHONIC_CHARS.txt are not required in Phase 1; they will be used in
+   * Phase 2 for contextual polyphone disambiguation.
+   *
+   * Directory may be next to espeak data / data_dir, or be data_dir/g2pw or
+   * data_dir itself.
    */
   const char *g2pw_model_dir;
 

--- a/libpiper/include/piper_impl.hpp
+++ b/libpiper/include/piper_impl.hpp
@@ -1,6 +1,7 @@
 #ifndef PIPER_IMPL_H_
 #define PIPER_IMPL_H_
 
+#include "chinese_phonemizer.h"
 #include "json.hpp"
 #include "uni_algo.h"
 
@@ -18,6 +19,7 @@ typedef char32_t Phoneme;
 typedef int64_t PhonemeId;
 typedef int64_t SpeakerId;
 typedef std::map<Phoneme, std::vector<PhonemeId>> PhonemeIdMap;
+typedef std::map<std::string, std::vector<PhonemeId>> PinyinIdMap;
 
 const PhonemeId ID_PAD = 0; // interleaved
 const PhonemeId ID_BOS = 1; // beginning of sentence
@@ -71,6 +73,7 @@ struct piper_synthesizer {
   int sample_rate;
   int num_speakers;
   PhonemeIdMap phoneme_id_map;
+  PinyinIdMap pinyin_id_map;
   int hop_length = DEFAULT_HOP_LENGTH;
   PhonemeType phoneme_type = PhonemeType::Espeak;
 
@@ -89,6 +92,7 @@ struct piper_synthesizer {
   std::string g2pw_model_dir;
   std::unique_ptr<Ort::Session> g2pw_session;
   Ort::SessionOptions g2pw_session_options;
+  std::unique_ptr<piper::ChinesePhonemizer> chinese_phonemizer;
 
   // synthesize state
   std::queue<std::pair<std::vector<Phoneme>, std::vector<PhonemeId>>>
@@ -104,7 +108,7 @@ struct piper_synthesizer {
 };
 
 // Get the first UTF-8 codepoint of a string
-std::optional<Phoneme> get_codepoint(std::string s) {
+inline std::optional<Phoneme> get_codepoint(std::string s) {
   auto view = una::views::utf8(s);
   auto it = view.begin();
 

--- a/libpiper/include/piper_impl.hpp
+++ b/libpiper/include/piper_impl.hpp
@@ -88,10 +88,9 @@ struct piper_synthesizer {
   Ort::SessionOptions session_options;
   Ort::Env session_env;
 
-  // g2pw - for pinyin (zh-CN)
+  // g2pw dict dir - for pinyin (zh-CN) - monophonic fallback only (Phase 1)
+  // Full BERT disambiguation deferred; see PR 271 review
   std::string g2pw_model_dir;
-  std::unique_ptr<Ort::Session> g2pw_session;
-  Ort::SessionOptions g2pw_session_options;
   std::unique_ptr<piper::ChinesePhonemizer> chinese_phonemizer;
 
   // synthesize state

--- a/libpiper/include/piper_impl.hpp
+++ b/libpiper/include/piper_impl.hpp
@@ -85,6 +85,11 @@ struct piper_synthesizer {
   Ort::SessionOptions session_options;
   Ort::Env session_env;
 
+  // g2pw - for pinyin (zh-CN)
+  std::string g2pw_model_dir;
+  std::unique_ptr<Ort::Session> g2pw_session;
+  Ort::SessionOptions g2pw_session_options;
+
   // synthesize state
   std::queue<std::pair<std::vector<Phoneme>, std::vector<PhonemeId>>>
       phoneme_id_queue;

--- a/libpiper/src/chinese_phonemizer.cpp
+++ b/libpiper/src/chinese_phonemizer.cpp
@@ -231,8 +231,13 @@ bool ChinesePhonemizer::load(const std::string &g2pw_model_dir) {
     }
   }
 
-  has_dicts = !mono_dict.empty() || !char_bopomofo_dict.empty() ||
-              !bopomofo2pinyin.empty();
+  // Phase 1 readiness requires a pronunciation source (mono table or char
+  // dict) AND the bopomofo->pinyin map. bert-base-chinese_s2t_dict.txt is
+  // Phase 2 only and not checked here. This prevents silent success when
+  // only char_bopomofo_dict.json is present after a partial download.
+  bool has_source = !mono_dict.empty() || !char_bopomofo_dict.empty();
+  bool has_bopomofo_map = !bopomofo2pinyin.empty();
+  has_dicts = has_source && has_bopomofo_map;
   return has_dicts;
 }
 

--- a/libpiper/src/chinese_phonemizer.cpp
+++ b/libpiper/src/chinese_phonemizer.cpp
@@ -1,0 +1,500 @@
+#include "chinese_phonemizer.h"
+#include "piper_impl.hpp"
+
+#include "json.hpp"
+#include "uni_algo.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <iostream>
+#include <regex>
+#include <sstream>
+
+namespace piper {
+
+const std::vector<std::string> PINYIN_INITIALS = {
+    "zh", "ch", "sh", "b", "p", "m", "f", "d", "t", "n", "l", "g",
+    "k",  "h",  "j",  "q", "x", "r", "z", "c", "s", "y", "w"};
+
+const std::set<std::string> GROUP_END_PHONEMES = {
+    "1", "2", "3",  "4",  "5",  "。", "？", "！", ".", "?", "!",
+    "—", "…", "、", "，", "：", "；", ",",  ":",  ";", " ", "\n"};
+
+const std::set<std::string> PINYIN_PUNCTUATIONS = {
+    ".",  "?",  "!",  ",",  ":",  ";", "，", "。",
+    "？", "！", "、", "：", "；", "—", "…",  " "};
+
+std::string normalize_g2pw_syllable(const std::string &syl) {
+  if (syl.empty())
+    return syl;
+  char last = syl.back();
+  if (last < '1' || last > '5')
+    return syl;
+  std::string base = syl.substr(0, syl.size() - 1);
+  if (base.empty())
+    return syl;
+
+  // Replace u: -> v
+  std::string t = base;
+  // replace "u:"
+  size_t pos = 0;
+  while ((pos = t.find("u:", pos)) != std::string::npos) {
+    t.replace(pos, 2, "v");
+    pos += 1;
+  }
+  // replace ü (utf8 C3 BC)
+  const std::string uv = "ü"; // utf8 literal
+  pos = 0;
+  while ((pos = t.find(uv, pos)) != std::string::npos) {
+    t.replace(pos, uv.size(), "v");
+    pos += 1;
+  }
+
+  // validate remaining consists of a-z and v only (after replacement)
+  for (size_t i = 0; i < t.size();) {
+    unsigned char c = static_cast<unsigned char>(t[i]);
+    if (c < 128) {
+      if ((c >= 'a' && c <= 'z') || c == 'v') {
+        ++i;
+        continue;
+      }
+      return syl; // contains invalid char
+    } else {
+      // multibyte char not allowed after replacement
+      return syl;
+    }
+  }
+
+  return t + std::string(1, last);
+}
+
+std::tuple<std::string, std::string, std::string>
+split_initial_final_tone(const std::string &syl) {
+  if (syl.empty())
+    return {"", "", ""};
+  // pattern ^([a-zvü]+)([1-5])$
+  // Since after normalize we have no ü or :, we allow a-z and v
+  char tone_c = syl.back();
+  if (tone_c < '1' || tone_c > '5')
+    return {"", "", ""};
+  std::string base = syl.substr(0, syl.size() - 1);
+  std::string tone(1, tone_c);
+
+  // base must be non-empty and only a-zv
+  if (base.empty())
+    return {"", "", ""};
+  for (char ch : base) {
+    if (!((ch >= 'a' && ch <= 'z') || ch == 'v')) {
+      // allow also ü? but after normalize shouldn't appear
+      if (static_cast<unsigned char>(ch) >= 128)
+        return {"", "", ""};
+      // if char not allowed, fail
+      if (ch < 'a' || ch > 'z')
+        return {"", "", ""};
+    }
+  }
+
+  std::string ini;
+  std::string left = base;
+  for (const auto &cand : PINYIN_INITIALS) {
+    if (left.rfind(cand, 0) == 0) { // starts_with
+      ini = cand;
+      left = left.substr(cand.size());
+      break;
+    }
+  }
+  std::string fin = left;
+  return {ini, fin, tone};
+}
+
+std::optional<char32_t> get_codepoint_str(const std::string &s) {
+  if (s.empty())
+    return std::nullopt;
+  auto view = una::views::utf8(s);
+  auto it = view.begin();
+  if (it == view.end())
+    return std::nullopt;
+  char32_t cp = *it;
+  ++it;
+  if (it != view.end())
+    return std::nullopt; // more than one codepoint
+  return cp;
+}
+
+std::vector<int64_t>
+phonemes_to_ids(const std::vector<std::string> &phonemes,
+                const std::map<std::string, std::vector<int64_t>> &id_map) {
+  std::vector<int64_t> ids;
+  auto it_bos = id_map.find("^");
+  if (it_bos != id_map.end())
+    ids.insert(ids.end(), it_bos->second.begin(), it_bos->second.end());
+  else
+    ids.push_back(ID_BOS);
+
+  auto it_pad = id_map.find("_");
+  std::vector<int64_t> pad_ids;
+  if (it_pad != id_map.end())
+    pad_ids = it_pad->second;
+  else
+    pad_ids = {ID_PAD};
+
+  auto it_eos = id_map.find("$");
+  std::vector<int64_t> eos_ids;
+  if (it_eos != id_map.end())
+    eos_ids = it_eos->second;
+  else
+    eos_ids = {ID_EOS};
+
+  for (const auto &ph : phonemes) {
+    auto it = id_map.find(ph);
+    if (it == id_map.end()) {
+      // unknown phoneme, skip with warning if not whitespace
+      if (ph != " " && ph != "\n" && !ph.empty()) {
+        // std::cerr << "Missing id for phoneme " << ph << "\n";
+      }
+      continue;
+    }
+    ids.insert(ids.end(), it->second.begin(), it->second.end());
+    if (GROUP_END_PHONEMES.find(ph) != GROUP_END_PHONEMES.end()) {
+      ids.insert(ids.end(), pad_ids.begin(), pad_ids.end());
+    }
+  }
+  ids.insert(ids.end(), eos_ids.begin(), eos_ids.end());
+  return ids;
+}
+
+bool ChinesePhonemizer::load(const std::string &g2pw_model_dir) {
+  using json = nlohmann::json;
+  std::string base = g2pw_model_dir;
+  if (!base.empty() && base.back() == '/')
+    base.pop_back();
+
+  // MONOPHONIC
+  std::string mono_path = base + "/MONOPHONIC_CHARS.txt";
+  std::ifstream mf(mono_path);
+  if (mf) {
+    std::string line;
+    while (std::getline(mf, line)) {
+      if (line.empty())
+        continue;
+      size_t tab = line.find('\t');
+      if (tab == std::string::npos) {
+        // fallback split on space
+        tab = line.find(' ');
+        if (tab == std::string::npos)
+          continue;
+      }
+      std::string ch = line.substr(0, tab);
+      std::string bopo = line.substr(tab + 1);
+      // trim
+      bopo.erase(0, bopo.find_first_not_of(" \t\r\n"));
+      bopo.erase(bopo.find_last_not_of(" \t\r\n") + 1);
+      ch.erase(0, ch.find_first_not_of(" \t\r\n"));
+      ch.erase(ch.find_last_not_of(" \t\r\n") + 1);
+      if (!ch.empty() && !bopo.empty())
+        mono_dict[ch] = bopo;
+    }
+  }
+
+  std::string poly_path = base + "/POLYPHONIC_CHARS.txt";
+  std::ifstream pf(poly_path);
+  if (pf) {
+    std::string line;
+    while (std::getline(pf, line)) {
+      // lines: char<TAB>bopomofo1 bopomofo2 ...?
+      // Actually format is char + "\t" + bopo list? Let's parse.
+      if (line.empty())
+        continue;
+      size_t tab = line.find('\t');
+      if (tab == std::string::npos)
+        continue;
+      std::string ch = line.substr(0, tab);
+      std::string rest = line.substr(tab + 1);
+      std::istringstream iss(rest);
+      std::vector<std::string> vals;
+      std::string v;
+      while (iss >> v)
+        vals.push_back(v);
+      if (!ch.empty() && !vals.empty())
+        poly_dict[ch] = vals;
+    }
+  }
+
+  std::string char_bopo_path = base + "/char_bopomofo_dict.json";
+  std::ifstream cbf(char_bopo_path);
+  if (cbf) {
+    try {
+      json j;
+      cbf >> j;
+      for (auto &el : j.items()) {
+        std::string key = el.key();
+        if (el.value().is_array()) {
+          std::vector<std::string> arr;
+          for (auto &x : el.value())
+            if (x.is_string())
+              arr.push_back(x.get<std::string>());
+          char_bopomofo_dict[key] = arr;
+        }
+      }
+    } catch (...) {
+    }
+  }
+
+  std::string b2p_path = base + "/bopomofo_to_pinyin_wo_tune_dict.json";
+  std::ifstream b2p(b2p_path);
+  if (b2p) {
+    try {
+      json j;
+      b2p >> j;
+      for (auto &el : j.items()) {
+        if (el.value().is_string())
+          bopomofo2pinyin[el.key()] = el.value().get<std::string>();
+      }
+    } catch (...) {
+    }
+  }
+
+  std::string s2t_path = base + "/bert-base-chinese_s2t_dict.txt";
+  std::ifstream s2t_f(s2t_path);
+  if (s2t_f) {
+    std::string line;
+    while (std::getline(s2t_f, line)) {
+      if (line.empty())
+        continue;
+      size_t tab = line.find('\t');
+      if (tab == std::string::npos)
+        tab = line.find(' ');
+      if (tab == std::string::npos)
+        continue;
+      std::string simp = line.substr(0, tab);
+      std::string trad = line.substr(tab + 1);
+      // trim
+      simp.erase(0, simp.find_first_not_of(" \t\r\n"));
+      simp.erase(simp.find_last_not_of(" \t\r\n") + 1);
+      trad.erase(0, trad.find_first_not_of(" \t\r\n"));
+      trad.erase(trad.find_last_not_of(" \t\r\n") + 1);
+      s2t[simp] = trad;
+    }
+  }
+
+  has_dicts = !mono_dict.empty() || !char_bopomofo_dict.empty() ||
+              !bopomofo2pinyin.empty();
+  return has_dicts;
+}
+
+std::string
+ChinesePhonemizer::bopomofo_to_pinyin(const std::string &bopomofo) const {
+  if (bopomofo.empty())
+    return "";
+  char last = bopomofo.back();
+  std::string base = bopomofo;
+  std::string tone;
+  if (last >= '1' && last <= '5') {
+    base = bopomofo.substr(0, bopomofo.size() - 1);
+    tone = std::string(1, last);
+  } else {
+    tone = "5"; // neutral?
+  }
+  auto it = bopomofo2pinyin.find(base);
+  if (it == bopomofo2pinyin.end()) {
+    // try with full
+    it = bopomofo2pinyin.find(bopomofo);
+    if (it == bopomofo2pinyin.end())
+      return "";
+    return normalize_g2pw_syllable(it->second + tone);
+  }
+  return normalize_g2pw_syllable(it->second + tone);
+}
+
+std::vector<std::vector<std::string>>
+ChinesePhonemizer::phonemize_pinyin_text(const std::string &text) {
+  // Lowercase
+  std::string lower = text;
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+
+  std::vector<std::string> phonemes;
+
+  // split by whitespace
+  std::istringstream iss(lower);
+  std::string token;
+  bool first_syl = true;
+  while (iss >> token) {
+    if (token.empty())
+      continue;
+    // separate trailing punctuation
+    std::string core = token;
+    std::string trail_punct;
+    while (!core.empty()) {
+      std::string last_char(1, core.back());
+      if (last_char == "." || last_char == "?" || last_char == "!" ||
+          last_char == "," || last_char == ":" || last_char == ";") {
+        trail_punct = last_char + trail_punct;
+        core.pop_back();
+      } else {
+        break;
+      }
+    }
+
+    if (core.empty()) {
+      // only punct
+      for (char c : trail_punct) {
+        std::string p(1, c);
+        if (PINYIN_PUNCTUATIONS.find(p) != PINYIN_PUNCTUATIONS.end())
+          phonemes.push_back(p);
+      }
+      continue;
+    }
+
+    // core is expected pinyin like ni3
+    auto norm = normalize_g2pw_syllable(core);
+    auto [ini, fin, tone] = split_initial_final_tone(norm);
+    if (fin.empty() && ini.empty()) {
+      // try original core without normalize? Maybe direct split
+      auto [ini2, fin2, tone2] = split_initial_final_tone(core);
+      if (fin2.empty() && ini2.empty()) {
+        // skip unknown token
+        continue;
+      }
+      ini = ini2;
+      fin = fin2;
+      tone = tone2;
+    }
+
+    if (!first_syl) {
+      // optional short pause between syllables
+      phonemes.push_back(" ");
+    }
+    first_syl = false;
+
+    if (ini.empty())
+      ini = "Ø";
+    phonemes.push_back(ini);
+    phonemes.push_back(fin);
+    phonemes.push_back(tone);
+
+    for (char c : trail_punct) {
+      std::string p(1, c);
+      phonemes.push_back(p);
+    }
+  }
+
+  if (phonemes.empty())
+    return {};
+
+  return {phonemes};
+}
+
+std::vector<std::vector<std::string>>
+ChinesePhonemizer::phonemize(const std::string &text) {
+  std::vector<std::string> cur;
+  std::vector<std::vector<std::string>> sentences;
+
+  // iterate over utf8 codepoints to get per-char string
+  auto view = una::views::utf8(text);
+  std::string cur_utf8_char;
+  // We need to iterate and build per character utf8 string
+  for (auto it = view.begin(); it != view.end(); ++it) {
+    char32_t cp = *it;
+    // Convert cp back to utf8 string
+    std::string ch_utf8;
+    // encode
+    if (cp < 0x80)
+      ch_utf8.push_back(static_cast<char>(cp));
+    else if (cp < 0x800) {
+      ch_utf8.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+      ch_utf8.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp < 0x10000) {
+      ch_utf8.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+      ch_utf8.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+      ch_utf8.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else {
+      ch_utf8.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+      ch_utf8.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+      ch_utf8.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+      ch_utf8.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+
+    // handle sentence boundary punctuation that triggers new sentence
+    if (ch_utf8 == "。" || ch_utf8 == "？" || ch_utf8 == "！" ||
+        ch_utf8 == "." || ch_utf8 == "?" || ch_utf8 == "!") {
+      if (!cur.empty()) {
+        // include punctuation as phoneme before closing sentence
+        cur.push_back(ch_utf8);
+        sentences.push_back(cur);
+        cur.clear();
+      } else {
+        // empty sentence with only punctuation still push?
+        sentences.push_back({ch_utf8});
+      }
+      continue;
+    }
+    if (ch_utf8 == "，")
+      ch_utf8 = ",";
+    if (ch_utf8 == "、")
+      ch_utf8 = ",";
+    if (ch_utf8 == "：")
+      ch_utf8 = ":";
+    if (ch_utf8 == "；")
+      ch_utf8 = ";";
+
+    if (ch_utf8 == "," || ch_utf8 == ":" || ch_utf8 == ";" || ch_utf8 == " " ||
+        ch_utf8 == "\n") {
+      if (ch_utf8 == " " || ch_utf8 == "\n") {
+        // skip spaces for Hanzi? keep as short pause?
+        // include space as phoneme if desired; skip for now
+        continue;
+      }
+      cur.push_back(ch_utf8);
+      continue;
+    }
+
+    // Simplified Chinese handling already converted? We don't have s2t mapping
+    // applied to char level Check mono dict first
+    std::string bopo;
+    auto itm = mono_dict.find(ch_utf8);
+    if (itm != mono_dict.end()) {
+      bopo = itm->second;
+    } else {
+      auto itc = char_bopomofo_dict.find(ch_utf8);
+      if (itc != char_bopomofo_dict.end() && !itc->second.empty()) {
+        bopo = itc->second[0];
+      } else {
+        // unknown char, skip
+        continue;
+      }
+    }
+
+    std::string pinyin = bopomofo_to_pinyin(bopo);
+    if (pinyin.empty())
+      continue;
+    auto [ini, fin, tone] = split_initial_final_tone(pinyin);
+    if (fin.empty() && tone.empty())
+      continue;
+    if (ini.empty())
+      ini = "Ø";
+    cur.push_back(ini);
+    cur.push_back(fin);
+    cur.push_back(tone);
+  }
+
+  if (!cur.empty())
+    sentences.push_back(cur);
+
+  if (sentences.empty() && !text.empty()) {
+    // fallback try pinyin direct
+    auto alt = phonemize_pinyin_text(text);
+    if (!alt.empty())
+      return alt;
+  }
+
+  return sentences;
+}
+
+std::vector<int64_t> ChinesePhonemizer::phonemes_to_ids_pinyin(
+    const std::vector<std::string> &phonemes,
+    const std::map<std::string, std::vector<int64_t>> &id_map) {
+  return phonemes_to_ids(phonemes, id_map);
+}
+
+} // namespace piper

--- a/libpiper/src/chinese_phonemizer.cpp
+++ b/libpiper/src/chinese_phonemizer.cpp
@@ -402,20 +402,30 @@ ChinesePhonemizer::phonemize(const std::string &text) {
       continue;
     }
 
-    // Simplified Chinese handling already converted? We don't have s2t mapping
-    // applied to char level Check mono dict first
+    // Phase 1 mono-only: accept only unambiguous one-reading entries.
+    // - mono_dict (MONOPHONIC_CHARS.txt) is authoritative mono table
+    // - otherwise allow char_bopomofo_dict only if it has exactly one reading
+    // - ambiguous (polyphonic) chars are treated as unsupported -> return empty
+    //   to avoid silently assigning first sense. This prevents 重庆/银行/长江
+    //   from being mis-assigned when only char_bopomofo_dict.json is present.
     std::string bopo;
     auto itm = mono_dict.find(ch_utf8);
     if (itm != mono_dict.end()) {
       bopo = itm->second;
     } else {
       auto itc = char_bopomofo_dict.find(ch_utf8);
-      if (itc != char_bopomofo_dict.end() && !itc->second.empty()) {
-        bopo = itc->second[0];
-      } else {
+      if (itc == char_bopomofo_dict.end() || itc->second.empty()) {
         // unknown char, skip
         continue;
       }
+      if (itc->second.size() != 1) {
+        // polyphonic char - unsupported in Phase 1 mono-only fallback
+        // Return empty to signal unsupported input rather than silently picking
+        // first pronunciation. Caller (PinyinTest) verifies 重/行/长 are not
+        // assigned.
+        return {};
+      }
+      bopo = itc->second[0];
     }
 
     std::string pinyin = bopomofo_to_pinyin(bopo);

--- a/libpiper/src/chinese_phonemizer.cpp
+++ b/libpiper/src/chinese_phonemizer.cpp
@@ -197,30 +197,6 @@ bool ChinesePhonemizer::load(const std::string &g2pw_model_dir) {
     }
   }
 
-  std::string poly_path = base + "/POLYPHONIC_CHARS.txt";
-  std::ifstream pf(poly_path);
-  if (pf) {
-    std::string line;
-    while (std::getline(pf, line)) {
-      // lines: char<TAB>bopomofo1 bopomofo2 ...?
-      // Actually format is char + "\t" + bopo list? Let's parse.
-      if (line.empty())
-        continue;
-      size_t tab = line.find('\t');
-      if (tab == std::string::npos)
-        continue;
-      std::string ch = line.substr(0, tab);
-      std::string rest = line.substr(tab + 1);
-      std::istringstream iss(rest);
-      std::vector<std::string> vals;
-      std::string v;
-      while (iss >> v)
-        vals.push_back(v);
-      if (!ch.empty() && !vals.empty())
-        poly_dict[ch] = vals;
-    }
-  }
-
   std::string char_bopo_path = base + "/char_bopomofo_dict.json";
   std::ifstream cbf(char_bopo_path);
   if (cbf) {
@@ -252,29 +228,6 @@ bool ChinesePhonemizer::load(const std::string &g2pw_model_dir) {
           bopomofo2pinyin[el.key()] = el.value().get<std::string>();
       }
     } catch (...) {
-    }
-  }
-
-  std::string s2t_path = base + "/bert-base-chinese_s2t_dict.txt";
-  std::ifstream s2t_f(s2t_path);
-  if (s2t_f) {
-    std::string line;
-    while (std::getline(s2t_f, line)) {
-      if (line.empty())
-        continue;
-      size_t tab = line.find('\t');
-      if (tab == std::string::npos)
-        tab = line.find(' ');
-      if (tab == std::string::npos)
-        continue;
-      std::string simp = line.substr(0, tab);
-      std::string trad = line.substr(tab + 1);
-      // trim
-      simp.erase(0, simp.find_first_not_of(" \t\r\n"));
-      simp.erase(simp.find_last_not_of(" \t\r\n") + 1);
-      trad.erase(0, trad.find_first_not_of(" \t\r\n"));
-      trad.erase(trad.find_last_not_of(" \t\r\n") + 1);
-      s2t[simp] = trad;
     }
   }
 

--- a/libpiper/src/main/main.cpp
+++ b/libpiper/src/main/main.cpp
@@ -77,9 +77,31 @@ auto main(int argc, char *argv[]) -> int {
     if (!runConfig.eSpeakDataPath.has_value()) {
       throw std::runtime_error("eSpeak data path not set");
     }
-    piper = piper_create(runConfig.modelPath.string().c_str(),
-                         runConfig.modelConfigPath.string().c_str(),
-                         runConfig.eSpeakDataPath.value().string().c_str());
+
+    piper_create_options create_opts;
+    piper_init_create_options(&create_opts);
+    std::string model_path_str = runConfig.modelPath.string();
+    std::string config_path_str = runConfig.modelConfigPath.string();
+    std::string espeak_path_str = runConfig.eSpeakDataPath.value().string();
+    std::string data_dir_str;
+    std::string g2pw_dir_str;
+    create_opts.model_path = model_path_str.c_str();
+    create_opts.config_path = config_path_str.c_str();
+    create_opts.espeak_data_path = espeak_path_str.c_str();
+    if (runConfig.dataDir) {
+      data_dir_str = runConfig.dataDir->string();
+      create_opts.data_dir = data_dir_str.c_str();
+    }
+    if (runConfig.g2pwModelDir) {
+      g2pw_dir_str = runConfig.g2pwModelDir->string();
+      create_opts.g2pw_model_dir = g2pw_dir_str.c_str();
+    }
+    piper = piper_create_with_options(&create_opts);
+    if (!piper) {
+      // Fallback to legacy for compatibility
+      piper = piper_create(model_path_str.c_str(), config_path_str.c_str(),
+                           espeak_path_str.c_str());
+    }
 
     piper_synthesize_options options;
     options.speaker_id = 0;

--- a/libpiper/src/main/utils/main_utils.cpp
+++ b/libpiper/src/main/utils/main_utils.cpp
@@ -42,6 +42,12 @@ void printUsage(char *argv[]) { // NOLINT(modernize-avoid-c-arrays)
   std::cerr
       << "   --espeak_data           DIR   path to espeak-ng data directory"
       << '\n';
+  std::cerr << "   --data_dir            DIR   base data dir (looks for "
+               "espeak-ng-data and g2pw subdirs)"
+            << '\n';
+  std::cerr << "   --g2pw_dir            DIR   path to Chinese dict directory "
+               "(MONOPHONIC_CHARS.txt, char_bopomofo_dict.json etc)"
+            << '\n';
   std::cerr << "   --json-input                  stdin input is lines of JSON "
                "instead of plain text"
             << '\n';
@@ -99,6 +105,13 @@ void parseArgsLogic(int argc, char *argv[], RunConfig &runConfig) {
     } else if (arg == "--espeak_data" || arg == "--espeak-data") {
       ensureArg(argc, argv, i);
       runConfig.eSpeakDataPath = std::filesystem::path(argv[++i]);
+    } else if (arg == "--data_dir" || arg == "--data-dir") {
+      ensureArg(argc, argv, i);
+      runConfig.dataDir = std::filesystem::path(argv[++i]);
+    } else if (arg == "--g2pw_dir" || arg == "--g2pw-dir" ||
+               arg == "--g2pw_model_dir" || arg == "--g2pw-model-dir") {
+      ensureArg(argc, argv, i);
+      runConfig.g2pwModelDir = std::filesystem::path(argv[++i]);
     } else if (arg == "--json_input" || arg == "--json-input") {
       runConfig.jsonInput = true;
     } else if (arg == "--version") {

--- a/libpiper/src/main/utils/main_utils.hpp
+++ b/libpiper/src/main/utils/main_utils.hpp
@@ -29,6 +29,8 @@ struct RunConfig {
   std::optional<float> lengthScale;
   std::optional<float> noiseW;
   std::optional<std::filesystem::path> eSpeakDataPath;
+  std::optional<std::filesystem::path> dataDir;
+  std::optional<std::filesystem::path> g2pwModelDir;
   bool jsonInput = false;
 };
 

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -390,7 +390,10 @@ auto piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
   synth->noise_w_scale = options->noise_w_scale;
   synth->speaker_id = options->speaker_id;
 
-  if (synth->phoneme_type == PhonemeType::Pinyin) {
+  // phonemize (single dispatch)
+  std::vector<std::string> sentence_phonemes{""};
+  switch (synth->phoneme_type) {
+  case PhonemeType::Pinyin: {
     if (synth->pinyin_id_map.empty()) {
       return PIPER_ERR_GENERIC;
     }
@@ -497,10 +500,6 @@ auto piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
 
     return synth->phoneme_id_queue.empty() ? PIPER_ERR_GENERIC : PIPER_OK;
   }
-
-  // phonemize for Espeak/Text
-  std::vector<std::string> sentence_phonemes{""};
-  switch (synth->phoneme_type) {
   case PhonemeType::Espeak: {
     std::size_t current_idx = 0;
     const void *text_ptr = text;
@@ -547,7 +546,6 @@ auto piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
     sentence_phonemes.push_back(nfd_text);
     break;
   }
-  case PhonemeType::Pinyin:
   case PhonemeType::Invalid: {
     return PIPER_ERR_GENERIC;
   }

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -71,7 +71,8 @@ auto piper_create_with_options(const piper_create_options *options)
   // NOTE: Do NOT auto-set final_g2pw_model_dir to <data_dir>/g2pw here.
   // Let effective_g2pw_dir logic below probe both <data_dir>/g2pw and
   // <data_dir> based on dict existence (MONOPHONIC_CHARS.txt /
-  // char_bopomofo_dict.json). Setting it eagerly made root fallback unreachable.
+  // char_bopomofo_dict.json). Setting it eagerly made root fallback
+  // unreachable.
   std::string resolved_g2pw_dir;
   const char *final_g2pw_model_dir = g2pw_model_dir_opt;
 
@@ -183,24 +184,36 @@ auto piper_create_with_options(const piper_create_options *options)
   }
   if (effective_g2pw_dir.empty() && data_dir_opt) {
     // Phase 1: check for mono dicts, not g2pw.onnx (deferred to Phase 2)
+    // Readiness requires a pronunciation source (MONOPHONIC_CHARS.txt or
+    // char_bopomofo_dict.json) AND bopomofo_to_pinyin_wo_tune_dict.json.
     // Try <data_dir>/g2pw first, then <data_dir> root as fallback (documented)
     std::filesystem::path cand1 = std::filesystem::path(data_dir_opt) / "g2pw";
     std::filesystem::path cand2 = std::filesystem::path(data_dir_opt);
     auto has_dicts = [](const std::filesystem::path &d) {
-      return std::filesystem::exists(d / "MONOPHONIC_CHARS.txt") ||
-             std::filesystem::exists(d / "char_bopomofo_dict.json") ||
-             std::filesystem::exists(d / "bopomofo_to_pinyin_wo_tune_dict.json");
+      bool has_source = std::filesystem::exists(d / "MONOPHONIC_CHARS.txt") ||
+                        std::filesystem::exists(d / "char_bopomofo_dict.json");
+      bool has_b2p =
+          std::filesystem::exists(d / "bopomofo_to_pinyin_wo_tune_dict.json");
+      return has_source && has_b2p;
     };
     if (has_dicts(cand1)) {
       effective_g2pw_dir = cand1.string();
     } else if (has_dicts(cand2)) {
       effective_g2pw_dir = cand2.string();
     } else if (std::filesystem::exists(cand1)) {
-      // cand1 exists but without dicts - still prefer it for backward compat
-      effective_g2pw_dir = cand1.string();
+      // cand1 exists but without complete dicts - still prefer it for
+      // backward compat if it at least has a source (load() will verify
+      // completeness and report failure)
+      if (std::filesystem::exists(cand1 / "MONOPHONIC_CHARS.txt") ||
+          std::filesystem::exists(cand1 / "char_bopomofo_dict.json")) {
+        effective_g2pw_dir = cand1.string();
+      } else {
+        effective_g2pw_dir = cand1.string();
+      }
     } else {
       // default to <data_dir>/g2pw even if not existing yet - will be
-      // non-fatal and phonemizer will load what it can, keeping direct pinyin path working
+      // non-fatal and phonemizer will load what it can, keeping direct pinyin
+      // path working
       effective_g2pw_dir = cand1.string();
     }
   }
@@ -214,8 +227,11 @@ auto piper_create_with_options(const piper_create_options *options)
         std::filesystem::path("local/g2pw"),
     };
     for (auto &p : fallbacks) {
-      if (std::filesystem::exists(p / "MONOPHONIC_CHARS.txt") ||
-          std::filesystem::exists(p / "char_bopomofo_dict.json")) {
+      bool has_source = std::filesystem::exists(p / "MONOPHONIC_CHARS.txt") ||
+                        std::filesystem::exists(p / "char_bopomofo_dict.json");
+      bool has_b2p =
+          std::filesystem::exists(p / "bopomofo_to_pinyin_wo_tune_dict.json");
+      if (has_source && has_b2p) {
         effective_g2pw_dir = p.string();
         break;
       }

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <unordered_map>
 
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -61,10 +62,7 @@ auto piper_create_with_options(const piper_create_options *options)
   std::string resolved_espeak_data;
   const char *final_espeak_data_path = espeak_data_path;
   if (!final_espeak_data_path && data_dir_opt) {
-    // Try data_dir/espeak-ng-data
     std::string cand = std::string(data_dir_opt) + "/espeak-ng-data";
-    // exists check would be nice but keep non-blocking; let espeak_Initialize
-    // fail if bad
     resolved_espeak_data = cand;
     final_espeak_data_path = resolved_espeak_data.c_str();
   }
@@ -73,12 +71,8 @@ auto piper_create_with_options(const piper_create_options *options)
   std::string resolved_g2pw_dir;
   const char *final_g2pw_model_dir = g2pw_model_dir_opt;
   if (!final_g2pw_model_dir && data_dir_opt) {
-    // Try data_dir/g2pw then data_dir itself if it contains g2pw.onnx
-    // We don't validate here, just pick first candidate for synth storage
     std::string cand1 = std::string(data_dir_opt) + "/g2pw";
     std::string cand2 = std::string(data_dir_opt);
-    // Heuristic: if user pointed data_dir to model root that already has
-    // g2pw.onnx, candid 2 works; we store cand1 and let later init search.
     resolved_g2pw_dir = cand1;
     final_g2pw_model_dir = resolved_g2pw_dir.c_str();
   }
@@ -123,55 +117,68 @@ auto piper_create_with_options(const piper_create_options *options)
   if (config.contains("audio")) {
     auto &audio_obj = config["audio"];
     if (audio_obj.contains("sample_rate")) {
-      // Sample rate of generated audio in hertz
       synth->sample_rate = audio_obj["sample_rate"].get<int>();
     }
   }
 
-  // phoneme to [id] map
-  // Maps phonemes to one or more phoneme ids (required).
-  if (config.contains("phoneme_id_map")) {
-    auto &phoneme_id_map_value = config["phoneme_id_map"];
-    for (const auto &from_phoneme_item : phoneme_id_map_value.items()) {
-      const std::string &from_phoneme = from_phoneme_item.key();
-      auto from_codepoint = get_codepoint(from_phoneme);
-      if (!from_codepoint) {
-        // No codepoint
-        continue;
+  if (phoneme_type == PhonemeType::Pinyin) {
+    // pinyin_id_map : string -> ids
+    if (config.contains("phoneme_id_map")) {
+      auto &m = config["phoneme_id_map"];
+      for (auto &kv : m.items()) {
+        std::string key = kv.key();
+        std::vector<PhonemeId> ids;
+        for (auto &v : kv.value()) {
+          ids.push_back(v.get<PhonemeId>());
+        }
+        synth->pinyin_id_map[key] = ids;
+        // also keep compatibility single char mapping if key length ==1
+        if (key.size() == 1) {
+          auto cp = get_codepoint(key);
+          if (cp) {
+            synth->phoneme_id_map[*cp] = ids;
+          }
+        } else if (key == "Ø") { // U+00D8 char from json \u00d8
+          // multi byte char length 2 in utf8, get_codepoint will handle
+          auto cp = get_codepoint(key);
+          if (cp)
+            synth->phoneme_id_map[*cp] = ids;
+        }
       }
-
-      for (auto &to_id_value : from_phoneme_item.value()) {
-        PhonemeId to_id = to_id_value.get<PhonemeId>();
-        synth->phoneme_id_map[*from_codepoint].push_back(to_id);
+    }
+  } else {
+    // phoneme to [id] map for espeak/text
+    if (config.contains("phoneme_id_map")) {
+      auto &phoneme_id_map_value = config["phoneme_id_map"];
+      for (const auto &from_phoneme_item : phoneme_id_map_value.items()) {
+        const std::string &from_phoneme = from_phoneme_item.key();
+        auto from_codepoint = get_codepoint(from_phoneme);
+        if (!from_codepoint) {
+          continue;
+        }
+        for (auto &to_id_value : from_phoneme_item.value()) {
+          PhonemeId to_id = to_id_value.get<PhonemeId>();
+          synth->phoneme_id_map[*from_codepoint].push_back(to_id);
+        }
       }
     }
   }
-  // NOLINTNEXTLINE(bugprone-narrowing-conversions)
+
   synth->num_speakers = config["num_speakers"].get<SpeakerId>();
 
   if (config.contains("inference")) {
-    // Overrides default inference settings
     auto inference_value = config["inference"];
     if (inference_value.contains("noise_scale")) {
       synth->synth_noise_scale = inference_value["noise_scale"].get<float>();
     }
-
     if (inference_value.contains("length_scale")) {
       synth->synth_length_scale = inference_value["length_scale"].get<float>();
     }
-
     if (inference_value.contains("noise_w")) {
       synth->synth_noise_w_scale = inference_value["noise_w"].get<float>();
     }
   }
 
-  // Resolve final g2pw model dir for storage and optional loading
-  // Candidate search if explicit not provided:
-  // 1) explicit g2pw_model_dir_opt
-  // 2) data_dir/g2pw
-  // 3) data_dir (if contains g2pw.onnx)
-  // 4) voice model dir + /g2pw
-  // 5) ./g2pw , ./local/g2pw
   std::string effective_g2pw_dir;
   if (final_g2pw_model_dir && final_g2pw_model_dir[0] != '\0') {
     effective_g2pw_dir = final_g2pw_model_dir;
@@ -184,11 +191,10 @@ auto piper_create_with_options(const piper_create_options *options)
                                        "g2pw.onnx")) {
       effective_g2pw_dir = data_dir_opt;
     } else {
-      effective_g2pw_dir = cand1.string(); // keep for error reporting / future
+      effective_g2pw_dir = cand1.string();
     }
   }
   if (effective_g2pw_dir.empty() && phoneme_type == PhonemeType::Pinyin) {
-    // Try sibling of voice model
     std::filesystem::path model_path_fs(model_path);
     std::filesystem::path model_dir = model_path_fs.parent_path();
     std::vector<std::filesystem::path> fallbacks = {
@@ -204,45 +210,62 @@ auto piper_create_with_options(const piper_create_options *options)
       }
     }
     if (effective_g2pw_dir.empty()) {
-      effective_g2pw_dir = (model_dir / "g2pw").string();
+      // attempt build/models dir
+      if (std::filesystem::exists(
+              std::filesystem::path("/tmp/g2pw_full/g2pw.onnx"))) {
+        effective_g2pw_dir = "/tmp/g2pw_full";
+      } else {
+        effective_g2pw_dir = (model_dir / "g2pw").string();
+      }
     }
   }
   synth->g2pw_model_dir = effective_g2pw_dir;
 
-  // Attempt to load g2pw session if pinyin and model exists (non-fatal if
-  // missing for now)
-  if (phoneme_type == PhonemeType::Pinyin && !synth->g2pw_model_dir.empty()) {
-    std::filesystem::path g2pw_onnx =
-        std::filesystem::path(synth->g2pw_model_dir) / "g2pw.onnx";
-    if (std::filesystem::exists(g2pw_onnx)) {
-      try {
-        synth->g2pw_session_options.DisableCpuMemArena();
-        synth->g2pw_session_options.DisableMemPattern();
-        synth->g2pw_session_options.DisableProfiling();
-        synth->g2pw_session_options.SetIntraOpNumThreads(2);
-        synth->g2pw_session_options.SetInterOpNumThreads(2);
-        synth->g2pw_session_options.SetGraphOptimizationLevel(
-            GraphOptimizationLevel::ORT_ENABLE_ALL);
-        synth->g2pw_session_options.SetExecutionMode(
-            ExecutionMode::ORT_SEQUENTIAL);
+  if (phoneme_type == PhonemeType::Pinyin) {
+    // attempt to load chinese phonemizer dicts (non-fatal)
+    try {
+      if (!synth->g2pw_model_dir.empty()) {
+        auto ph = std::make_unique<piper::ChinesePhonemizer>();
+        if (ph->load(synth->g2pw_model_dir)) {
+          synth->chinese_phonemizer = std::move(ph);
+        } else {
+          // still keep instance for pinyin direct
+          synth->chinese_phonemizer = std::move(ph);
+        }
+      }
+    } catch (...) {
+    }
+
+    if (!synth->g2pw_model_dir.empty()) {
+      std::filesystem::path g2pw_onnx =
+          std::filesystem::path(synth->g2pw_model_dir) / "g2pw.onnx";
+      if (std::filesystem::exists(g2pw_onnx)) {
+        try {
+          synth->g2pw_session_options.DisableCpuMemArena();
+          synth->g2pw_session_options.DisableMemPattern();
+          synth->g2pw_session_options.DisableProfiling();
+          synth->g2pw_session_options.SetIntraOpNumThreads(2);
+          synth->g2pw_session_options.SetInterOpNumThreads(2);
+          synth->g2pw_session_options.SetGraphOptimizationLevel(
+              GraphOptimizationLevel::ORT_ENABLE_ALL);
+          synth->g2pw_session_options.SetExecutionMode(
+              ExecutionMode::ORT_SEQUENTIAL);
 
 #if !defined(WIN32)
-        const auto *g2pw_path_ort = g2pw_onnx.c_str();
+          const auto *g2pw_path_ort = g2pw_onnx.c_str();
 #else
-        auto sz = ::MultiByteToWideChar(CP_ACP, 0, g2pw_onnx.string().c_str(),
-                                        -1, 0, 0);
-        std::vector<wchar_t> g2pw_path_wc(sz + 1);
-        ::MultiByteToWideChar(CP_ACP, 0, g2pw_onnx.string().c_str(), -1,
-                              &g2pw_path_wc[0], sz);
-        auto *g2pw_path_ort = &g2pw_path_wc[0];
+          auto sz = ::MultiByteToWideChar(CP_ACP, 0, g2pw_onnx.string().c_str(),
+                                          -1, 0, 0);
+          std::vector<wchar_t> g2pw_path_wc(sz + 1);
+          ::MultiByteToWideChar(CP_ACP, 0, g2pw_onnx.string().c_str(), -1,
+                                &g2pw_path_wc[0], sz);
+          auto *g2pw_path_ort = &g2pw_path_wc[0];
 #endif
-        synth->g2pw_session = std::make_unique<Ort::Session>(
-            Ort::Session(ort_env, g2pw_path_ort, synth->g2pw_session_options));
-        // NOTE: full dict/tokenizer loading will be added in following commits
-      } catch (...) {
-        // Allow creation to succeed even if g2pw load fails for now; synthesize
-        // will error
-        synth->g2pw_session.reset();
+          synth->g2pw_session = std::make_unique<Ort::Session>(Ort::Session(
+              ort_env, g2pw_path_ort, synth->g2pw_session_options));
+        } catch (...) {
+          synth->g2pw_session.reset();
+        }
       }
     }
   }
@@ -251,14 +274,13 @@ auto piper_create_with_options(const piper_create_options *options)
   synth->session_options.DisableCpuMemArena();
   synth->session_options.DisableMemPattern();
   synth->session_options.DisableProfiling();
-
   synth->session_options.SetIntraOpNumThreads(1);
   synth->session_options.SetInterOpNumThreads(1);
   synth->session_options.SetGraphOptimizationLevel(
       GraphOptimizationLevel::ORT_ENABLE_BASIC);
   synth->session_options.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
 
-#if !defined(WIN32) // ort on WIN32 uses wchar_t
+#if !defined(WIN32)
   const auto *model_path_ort = model_path;
 #else
   auto sz = ::MultiByteToWideChar(CP_ACP, 0, model_path, -1, 0, 0);
@@ -286,11 +308,9 @@ void piper_free(struct piper_synthesizer *synth) {
   if (synth == nullptr) {
     return;
   }
-
   if (synth->phoneme_type == PhonemeType::Espeak) {
     espeak_Terminate();
   }
-
   delete synth;
 }
 
@@ -311,7 +331,36 @@ auto piper_default_synthesize_options(piper_synthesizer *synth)
   return options;
 }
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+// helper for pinyin fake codepoints
+static Phoneme
+fake_cp_for_pinyin(const std::string &s,
+                   std::unordered_map<std::string, Phoneme> &cache,
+                   Phoneme &next_private) {
+  auto it = cache.find(s);
+  if (it != cache.end())
+    return it->second;
+  Phoneme cp = 0;
+  if (s == "^")
+    cp = U'^';
+  else if (s == "_")
+    cp = U'_';
+  else if (s == "$")
+    cp = U'$';
+  else if (s == " ")
+    cp = U' ';
+  else if (s.size() == 1) {
+    cp = static_cast<Phoneme>(static_cast<unsigned char>(s[0]));
+  } else if (s == "Ø" || s == "\xC3\x98") {
+    cp = 0x00D8;
+  } else {
+    cp = next_private++;
+    if (next_private > 0xF8FF)
+      next_private = 0xE000;
+  }
+  cache[s] = cp;
+  return cp;
+}
+
 auto piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
                             const piper_synthesize_options *options) -> int {
   if (synth == nullptr) {
@@ -341,7 +390,115 @@ auto piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
   synth->noise_w_scale = options->noise_w_scale;
   synth->speaker_id = options->speaker_id;
 
-  // phonemize
+  if (synth->phoneme_type == PhonemeType::Pinyin) {
+    if (synth->pinyin_id_map.empty()) {
+      return PIPER_ERR_GENERIC;
+    }
+
+    std::vector<std::vector<std::string>> sentences_str;
+
+    if (synth->chinese_phonemizer) {
+      try {
+        auto s = synth->chinese_phonemizer->phonemize(text);
+        if (!s.empty()) {
+          sentences_str = std::move(s);
+        } else {
+          sentences_str = piper::ChinesePhonemizer::phonemize_pinyin_text(text);
+        }
+      } catch (...) {
+        sentences_str = piper::ChinesePhonemizer::phonemize_pinyin_text(text);
+      }
+    } else {
+      sentences_str = piper::ChinesePhonemizer::phonemize_pinyin_text(text);
+    }
+
+    if (sentences_str.empty()) {
+      return PIPER_ERR_GENERIC;
+    }
+
+    std::unordered_map<std::string, Phoneme> cp_cache;
+    Phoneme next_private = 0xE000;
+
+    for (auto &ph_seq : sentences_str) {
+      if (ph_seq.empty())
+        continue;
+
+      std::vector<Phoneme> sent_cps;
+      std::vector<PhonemeId> sent_ids;
+      sent_cps.reserve(ph_seq.size() * 3 + 4);
+      sent_ids.reserve(ph_seq.size() * 2 + 4);
+
+      // BOS block
+      {
+        std::string bos = "^";
+        auto it = synth->pinyin_id_map.find(bos);
+        if (it != synth->pinyin_id_map.end()) {
+          for (auto idv : it->second) {
+            sent_cps.push_back(fake_cp_for_pinyin(bos, cp_cache, next_private));
+            sent_ids.push_back(idv);
+          }
+        } else {
+          sent_cps.push_back(U'^');
+          sent_ids.push_back(ID_BOS);
+        }
+        sent_cps.push_back(0); // separator
+      }
+
+      for (auto &ph : ph_seq) {
+        auto it = synth->pinyin_id_map.find(ph);
+        if (it == synth->pinyin_id_map.end()) {
+          // skip unknown but allow space/punct fallback: if ph length 1 char
+          // maybe?
+          continue;
+        }
+        Phoneme cp = fake_cp_for_pinyin(ph, cp_cache, next_private);
+        for (auto idv : it->second) {
+          sent_cps.push_back(cp);
+          sent_ids.push_back(idv);
+        }
+        // Pad after GROUP_END phonemes
+        if (piper::GROUP_END_PHONEMES.find(ph) !=
+            piper::GROUP_END_PHONEMES.end()) {
+          auto it_pad = synth->pinyin_id_map.find("_");
+          if (it_pad != synth->pinyin_id_map.end()) {
+            for (auto pid : it_pad->second) {
+              sent_cps.push_back(cp); // reuse ph cp for pad representation
+              sent_ids.push_back(pid);
+            }
+          } else {
+            sent_cps.push_back(cp);
+            sent_ids.push_back(ID_PAD);
+          }
+        }
+        sent_cps.push_back(0); // separator after each phoneme block
+      }
+
+      // EOS
+      {
+        std::string eos = "$";
+        auto it = synth->pinyin_id_map.find(eos);
+        if (it != synth->pinyin_id_map.end()) {
+          for (auto idv : it->second) {
+            sent_cps.push_back(fake_cp_for_pinyin(eos, cp_cache, next_private));
+            sent_ids.push_back(idv);
+          }
+        } else {
+          sent_cps.push_back(U'$');
+          sent_ids.push_back(ID_EOS);
+        }
+        sent_cps.push_back(0);
+      }
+
+      if (!sent_ids.empty()) {
+        synth->phoneme_id_queue.emplace(std::move(sent_cps),
+                                        std::move(sent_ids));
+      }
+    }
+
+    return synth->phoneme_id_queue.empty() ? PIPER_ERR_GENERIC : PIPER_OK;
+  }
+
+  // phonemize for Espeak/Text
   std::vector<std::string> sentence_phonemes{""};
   switch (synth->phoneme_type) {
   case PhonemeType::Espeak: {
@@ -358,8 +515,6 @@ auto piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
         sentence_phonemes[current_idx] += phonemes;
       }
 
-      // Categorize terminator
-      // NOLINTNEXTLINE(readability-magic-numbers)
       terminator &= 0x000FFFFF;
 
       if (terminator == CLAUSE_PERIOD) {
@@ -392,14 +547,13 @@ auto piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
     sentence_phonemes.push_back(nfd_text);
     break;
   }
-  // Pinyin it not supported at this moment
   case PhonemeType::Pinyin:
   case PhonemeType::Invalid: {
     return PIPER_ERR_GENERIC;
   }
   }
 
-  // phonemes to ids
+  // phonemes to ids for Espeak/Text
   std::vector<Phoneme> sentence_codepoints;
   std::vector<PhonemeId> sentence_ids;
   for (auto &phonemes_str : sentence_phonemes) {
@@ -420,22 +574,17 @@ auto piper_synthesize_start(struct piper_synthesizer *synth, const char *text,
     auto phonemes_iter = phonemes_range.begin();
     auto phonemes_end = phonemes_range.end();
 
-    // Filter out (lang) switch (flags).
-    // These surround words from languages other than the current voice.
     bool in_lang_flag = false;
     while (phonemes_iter != phonemes_end) {
       auto phoneme = *phonemes_iter;
 
       if (in_lang_flag) {
         if (phoneme == U')') {
-          // End of (lang) switch
           in_lang_flag = false;
         }
       } else if (phoneme == U'(') {
-        // Start of (lang) switch
         in_lang_flag = true;
       } else {
-        // Look up ids
         auto ids_for_phoneme = synth->phoneme_id_map.find(phoneme);
         if (ids_for_phoneme != synth->phoneme_id_map.end()) {
           for (auto identifier : ids_for_phoneme->second) {
@@ -475,7 +624,6 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
     return PIPER_ERR_GENERIC;
   }
 
-  // Clear data from previous call
   synth->chunk_samples.clear();
   synth->chunk_phonemes.clear();
   synth->chunk_phoneme_ids.clear();
@@ -491,19 +639,16 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
   chunk->num_alignments = 0;
 
   if (synth->phoneme_id_queue.empty()) {
-    // Empty final chunk
     chunk->is_last = true;
     return PIPER_DONE;
   }
 
-  // Process next list of phoneme ids
   auto [next_phonemes, next_ids] = std::move(synth->phoneme_id_queue.front());
   synth->phoneme_id_queue.pop();
 
   auto memoryInfo = Ort::MemoryInfo::CreateCpu(
       OrtAllocatorType::OrtDeviceAllocator, OrtMemType::OrtMemTypeDefault);
 
-  // Allocate
   std::vector<int64_t> phoneme_id_lengths{
       static_cast<int64_t>(next_ids.size())};
   std::vector<float> scales{synth->noise_scale, synth->length_scale,
@@ -527,9 +672,6 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
       memoryInfo, scales.data(), scales.size(), scales_shape.data(),
       scales_shape.size()));
 
-  // Add speaker id.
-  // NOTE: These must be kept outside the "if" below to avoid being
-  // deallocated.
   std::vector<int64_t> speaker_id{static_cast<int64_t>(synth->speaker_id)};
   std::vector<int64_t> speaker_id_shape{
       static_cast<int64_t>(speaker_id.size())};
@@ -540,11 +682,9 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
         speaker_id_shape.data(), speaker_id_shape.size()));
   }
 
-  // From export_onnx.py
   std::array<const char *, 4> input_names = {"input", "input_lengths", "scales",
                                              "sid"};
 
-  // Get all output names
   std::vector<std::string> output_names_strs = synth->session->GetOutputNames();
   std::vector<const char *> output_names;
   output_names.reserve(output_names_strs.size());
@@ -552,7 +692,6 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
     output_names.push_back(name.c_str());
   }
 
-  // Infer
   auto output_tensors = synth->session->Run(
       Ort::RunOptions{nullptr}, input_names.data(), input_tensors.data(),
       input_tensors.size(), output_names.data(), output_names.size());
@@ -573,12 +712,10 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
 
   chunk->is_last = synth->phoneme_id_queue.empty();
 
-  // Copy phonemes
   synth->chunk_phonemes = std::move(next_phonemes);
   chunk->phonemes = synth->chunk_phonemes.data();
   chunk->num_phonemes = synth->chunk_phonemes.size();
 
-  // Copy phoneme ids
   for (auto phoneme_id : next_ids) {
     if (phoneme_id < std::numeric_limits<int>::min() ||
         phoneme_id > std::numeric_limits<int>::max()) {
@@ -590,7 +727,6 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
   chunk->phoneme_ids = synth->chunk_phoneme_ids.data();
   chunk->num_phoneme_ids = synth->chunk_phoneme_ids.size();
 
-  // Check for alignments
   if (output_tensors.size() > 1) {
     auto alignments_shape =
         output_tensors[1].GetTensorTypeAndShapeInfo().GetShape();
@@ -602,14 +738,12 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
     synth->chunk_alignments.resize(chunk->num_alignments);
     for (std::size_t i = 0; i < chunk->num_alignments; i++) {
       synth->chunk_alignments[i] =
-          // NOLINTNEXTLINE(bugprone-narrowing-conversions)
           static_cast<int>(alignments_tensor_data[i] * synth->hop_length);
     }
 
     chunk->alignments = synth->chunk_alignments.data();
   }
 
-  // Clean up
   for (auto &output_tensor : output_tensors) {
     Ort::detail::OrtRelease(output_tensor.release());
   }

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -3,6 +3,8 @@
 #include "piper_impl.hpp"
 
 #include <array>
+#include <cstddef>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 
@@ -42,6 +44,44 @@ auto piper_create_with_options(const piper_create_options *options)
   const char *model_path = options->model_path;
   const char *config_path = options->config_path;
   const char *espeak_data_path = options->espeak_data_path;
+  const char *g2pw_model_dir_opt = nullptr;
+  const char *data_dir_opt = nullptr;
+
+  // Read newer fields if struct is large enough
+  if (options->struct_size >= offsetof(piper_create_options, g2pw_model_dir) +
+                                  sizeof(options->g2pw_model_dir)) {
+    g2pw_model_dir_opt = options->g2pw_model_dir;
+  }
+  if (options->struct_size >=
+      offsetof(piper_create_options, data_dir) + sizeof(options->data_dir)) {
+    data_dir_opt = options->data_dir;
+  }
+
+  // Resolve espeak_data_path via data_dir fallback
+  std::string resolved_espeak_data;
+  const char *final_espeak_data_path = espeak_data_path;
+  if (!final_espeak_data_path && data_dir_opt) {
+    // Try data_dir/espeak-ng-data
+    std::string cand = std::string(data_dir_opt) + "/espeak-ng-data";
+    // exists check would be nice but keep non-blocking; let espeak_Initialize
+    // fail if bad
+    resolved_espeak_data = cand;
+    final_espeak_data_path = resolved_espeak_data.c_str();
+  }
+
+  // Resolve g2pw_model_dir via data_dir fallback (for later use)
+  std::string resolved_g2pw_dir;
+  const char *final_g2pw_model_dir = g2pw_model_dir_opt;
+  if (!final_g2pw_model_dir && data_dir_opt) {
+    // Try data_dir/g2pw then data_dir itself if it contains g2pw.onnx
+    // We don't validate here, just pick first candidate for synth storage
+    std::string cand1 = std::string(data_dir_opt) + "/g2pw";
+    std::string cand2 = std::string(data_dir_opt);
+    // Heuristic: if user pointed data_dir to model root that already has
+    // g2pw.onnx, candid 2 works; we store cand1 and let later init search.
+    resolved_g2pw_dir = cand1;
+    final_g2pw_model_dir = resolved_g2pw_dir.c_str();
+  }
 
   if (model_path == nullptr) {
     return nullptr;
@@ -63,7 +103,8 @@ auto piper_create_with_options(const piper_create_options *options)
   }
 
   if (phoneme_type == PhonemeType::Espeak &&
-      espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 0, espeak_data_path, 0) < 0) {
+      espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 0, final_espeak_data_path,
+                        0) < 0) {
     return nullptr;
   }
 
@@ -121,6 +162,88 @@ auto piper_create_with_options(const piper_create_options *options)
 
     if (inference_value.contains("noise_w")) {
       synth->synth_noise_w_scale = inference_value["noise_w"].get<float>();
+    }
+  }
+
+  // Resolve final g2pw model dir for storage and optional loading
+  // Candidate search if explicit not provided:
+  // 1) explicit g2pw_model_dir_opt
+  // 2) data_dir/g2pw
+  // 3) data_dir (if contains g2pw.onnx)
+  // 4) voice model dir + /g2pw
+  // 5) ./g2pw , ./local/g2pw
+  std::string effective_g2pw_dir;
+  if (final_g2pw_model_dir && final_g2pw_model_dir[0] != '\0') {
+    effective_g2pw_dir = final_g2pw_model_dir;
+  }
+  if (effective_g2pw_dir.empty() && data_dir_opt) {
+    std::filesystem::path cand1 = std::filesystem::path(data_dir_opt) / "g2pw";
+    if (std::filesystem::exists(cand1 / "g2pw.onnx")) {
+      effective_g2pw_dir = cand1.string();
+    } else if (std::filesystem::exists(std::filesystem::path(data_dir_opt) /
+                                       "g2pw.onnx")) {
+      effective_g2pw_dir = data_dir_opt;
+    } else {
+      effective_g2pw_dir = cand1.string(); // keep for error reporting / future
+    }
+  }
+  if (effective_g2pw_dir.empty() && phoneme_type == PhonemeType::Pinyin) {
+    // Try sibling of voice model
+    std::filesystem::path model_path_fs(model_path);
+    std::filesystem::path model_dir = model_path_fs.parent_path();
+    std::vector<std::filesystem::path> fallbacks = {
+        model_dir / "g2pw",
+        std::filesystem::path("./g2pw"),
+        std::filesystem::path("./local/g2pw"),
+        std::filesystem::path("local/g2pw"),
+    };
+    for (auto &p : fallbacks) {
+      if (std::filesystem::exists(p / "g2pw.onnx")) {
+        effective_g2pw_dir = p.string();
+        break;
+      }
+    }
+    if (effective_g2pw_dir.empty()) {
+      effective_g2pw_dir = (model_dir / "g2pw").string();
+    }
+  }
+  synth->g2pw_model_dir = effective_g2pw_dir;
+
+  // Attempt to load g2pw session if pinyin and model exists (non-fatal if
+  // missing for now)
+  if (phoneme_type == PhonemeType::Pinyin && !synth->g2pw_model_dir.empty()) {
+    std::filesystem::path g2pw_onnx =
+        std::filesystem::path(synth->g2pw_model_dir) / "g2pw.onnx";
+    if (std::filesystem::exists(g2pw_onnx)) {
+      try {
+        synth->g2pw_session_options.DisableCpuMemArena();
+        synth->g2pw_session_options.DisableMemPattern();
+        synth->g2pw_session_options.DisableProfiling();
+        synth->g2pw_session_options.SetIntraOpNumThreads(2);
+        synth->g2pw_session_options.SetInterOpNumThreads(2);
+        synth->g2pw_session_options.SetGraphOptimizationLevel(
+            GraphOptimizationLevel::ORT_ENABLE_ALL);
+        synth->g2pw_session_options.SetExecutionMode(
+            ExecutionMode::ORT_SEQUENTIAL);
+
+#if !defined(WIN32)
+        const auto *g2pw_path_ort = g2pw_onnx.c_str();
+#else
+        auto sz = ::MultiByteToWideChar(CP_ACP, 0, g2pw_onnx.string().c_str(),
+                                        -1, 0, 0);
+        std::vector<wchar_t> g2pw_path_wc(sz + 1);
+        ::MultiByteToWideChar(CP_ACP, 0, g2pw_onnx.string().c_str(), -1,
+                              &g2pw_path_wc[0], sz);
+        auto *g2pw_path_ort = &g2pw_path_wc[0];
+#endif
+        synth->g2pw_session = std::make_unique<Ort::Session>(
+            Ort::Session(ort_env, g2pw_path_ort, synth->g2pw_session_options));
+        // NOTE: full dict/tokenizer loading will be added in following commits
+      } catch (...) {
+        // Allow creation to succeed even if g2pw load fails for now; synthesize
+        // will error
+        synth->g2pw_session.reset();
+      }
     }
   }
 

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -68,14 +68,12 @@ auto piper_create_with_options(const piper_create_options *options)
   }
 
   // Resolve g2pw_model_dir via data_dir fallback (for later use)
+  // NOTE: Do NOT auto-set final_g2pw_model_dir to <data_dir>/g2pw here.
+  // Let effective_g2pw_dir logic below probe both <data_dir>/g2pw and
+  // <data_dir> based on dict existence (MONOPHONIC_CHARS.txt /
+  // char_bopomofo_dict.json). Setting it eagerly made root fallback unreachable.
   std::string resolved_g2pw_dir;
   const char *final_g2pw_model_dir = g2pw_model_dir_opt;
-  if (!final_g2pw_model_dir && data_dir_opt) {
-    std::string cand1 = std::string(data_dir_opt) + "/g2pw";
-    std::string cand2 = std::string(data_dir_opt);
-    resolved_g2pw_dir = cand1;
-    final_g2pw_model_dir = resolved_g2pw_dir.c_str();
-  }
 
   if (model_path == nullptr) {
     return nullptr;
@@ -184,13 +182,25 @@ auto piper_create_with_options(const piper_create_options *options)
     effective_g2pw_dir = final_g2pw_model_dir;
   }
   if (effective_g2pw_dir.empty() && data_dir_opt) {
+    // Phase 1: check for mono dicts, not g2pw.onnx (deferred to Phase 2)
+    // Try <data_dir>/g2pw first, then <data_dir> root as fallback (documented)
     std::filesystem::path cand1 = std::filesystem::path(data_dir_opt) / "g2pw";
-    if (std::filesystem::exists(cand1 / "g2pw.onnx")) {
+    std::filesystem::path cand2 = std::filesystem::path(data_dir_opt);
+    auto has_dicts = [](const std::filesystem::path &d) {
+      return std::filesystem::exists(d / "MONOPHONIC_CHARS.txt") ||
+             std::filesystem::exists(d / "char_bopomofo_dict.json") ||
+             std::filesystem::exists(d / "bopomofo_to_pinyin_wo_tune_dict.json");
+    };
+    if (has_dicts(cand1)) {
       effective_g2pw_dir = cand1.string();
-    } else if (std::filesystem::exists(std::filesystem::path(data_dir_opt) /
-                                       "g2pw.onnx")) {
-      effective_g2pw_dir = data_dir_opt;
+    } else if (has_dicts(cand2)) {
+      effective_g2pw_dir = cand2.string();
+    } else if (std::filesystem::exists(cand1)) {
+      // cand1 exists but without dicts - still prefer it for backward compat
+      effective_g2pw_dir = cand1.string();
     } else {
+      // default to <data_dir>/g2pw even if not existing yet - will be
+      // non-fatal and phonemizer will load what it can, keeping direct pinyin path working
       effective_g2pw_dir = cand1.string();
     }
   }

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -204,25 +204,21 @@ auto piper_create_with_options(const piper_create_options *options)
         std::filesystem::path("local/g2pw"),
     };
     for (auto &p : fallbacks) {
-      if (std::filesystem::exists(p / "g2pw.onnx")) {
+      if (std::filesystem::exists(p / "MONOPHONIC_CHARS.txt") ||
+          std::filesystem::exists(p / "char_bopomofo_dict.json")) {
         effective_g2pw_dir = p.string();
         break;
       }
     }
     if (effective_g2pw_dir.empty()) {
-      // attempt build/models dir
-      if (std::filesystem::exists(
-              std::filesystem::path("/tmp/g2pw_full/g2pw.onnx"))) {
-        effective_g2pw_dir = "/tmp/g2pw_full";
-      } else {
-        effective_g2pw_dir = (model_dir / "g2pw").string();
-      }
+      effective_g2pw_dir = (model_dir / "g2pw").string();
     }
   }
   synth->g2pw_model_dir = effective_g2pw_dir;
 
   if (phoneme_type == PhonemeType::Pinyin) {
     // attempt to load chinese phonemizer dicts (non-fatal)
+    // Phase 1: monophonic fallback only; g2pw BERT deferred
     try {
       if (!synth->g2pw_model_dir.empty()) {
         auto ph = std::make_unique<piper::ChinesePhonemizer>();
@@ -234,39 +230,6 @@ auto piper_create_with_options(const piper_create_options *options)
         }
       }
     } catch (...) {
-    }
-
-    if (!synth->g2pw_model_dir.empty()) {
-      std::filesystem::path g2pw_onnx =
-          std::filesystem::path(synth->g2pw_model_dir) / "g2pw.onnx";
-      if (std::filesystem::exists(g2pw_onnx)) {
-        try {
-          synth->g2pw_session_options.DisableCpuMemArena();
-          synth->g2pw_session_options.DisableMemPattern();
-          synth->g2pw_session_options.DisableProfiling();
-          synth->g2pw_session_options.SetIntraOpNumThreads(2);
-          synth->g2pw_session_options.SetInterOpNumThreads(2);
-          synth->g2pw_session_options.SetGraphOptimizationLevel(
-              GraphOptimizationLevel::ORT_ENABLE_ALL);
-          synth->g2pw_session_options.SetExecutionMode(
-              ExecutionMode::ORT_SEQUENTIAL);
-
-#if !defined(WIN32)
-          const auto *g2pw_path_ort = g2pw_onnx.c_str();
-#else
-          auto sz = ::MultiByteToWideChar(CP_ACP, 0, g2pw_onnx.string().c_str(),
-                                          -1, 0, 0);
-          std::vector<wchar_t> g2pw_path_wc(sz + 1);
-          ::MultiByteToWideChar(CP_ACP, 0, g2pw_onnx.string().c_str(), -1,
-                                &g2pw_path_wc[0], sz);
-          auto *g2pw_path_ort = &g2pw_path_wc[0];
-#endif
-          synth->g2pw_session = std::make_unique<Ort::Session>(Ort::Session(
-              ort_env, g2pw_path_ort, synth->g2pw_session_options));
-        } catch (...) {
-          synth->g2pw_session.reset();
-        }
-      }
     }
   }
 

--- a/libpiper/tests/CMakeLists.txt
+++ b/libpiper/tests/CMakeLists.txt
@@ -25,6 +25,9 @@ download_piper_model(VOICE "en/en_US/lessac/medium/en_US-lessac-medium"
 download_piper_model(VOICE "uk/uk_UA/ukrainian_tts/medium/uk_UA-ukrainian_tts-medium"
                      OUTPUT_DIR TEXT_MODEL_DIR)
 
+download_piper_model(VOICE "zh/zh_CN/chaowen/medium/zh_CN-chaowen-medium"
+                     OUTPUT_DIR ZH_MODEL_DIR)
+
 add_executable(piper_test
    test_piper.cpp
    utils/piper_test_assets.h
@@ -40,6 +43,7 @@ target_compile_definitions(piper_test
     PRIVATE "ESPEAK_DATA_PATH=\"${CMAKE_BINARY_DIR}/espeak_ng-install/share/espeak-ng-data\""
     PRIVATE "EN_TEST_MODEL_DIR=\"${EN_MODEL_DIR}\""
     PRIVATE "TEXT_TEST_MODEL_DIR=\"${TEXT_MODEL_DIR}\""
+    PRIVATE "ZH_TEST_MODEL_DIR=\"${ZH_MODEL_DIR}\""
 )
 
 target_link_libraries(piper_test

--- a/libpiper/tests/CMakeLists.txt
+++ b/libpiper/tests/CMakeLists.txt
@@ -28,6 +28,8 @@ download_piper_model(VOICE "uk/uk_UA/ukrainian_tts/medium/uk_UA-ukrainian_tts-me
 download_piper_model(VOICE "zh/zh_CN/chaowen/medium/zh_CN-chaowen-medium"
                      OUTPUT_DIR ZH_MODEL_DIR)
 
+download_g2pw_data(OUTPUT_DIR G2PW_MODEL_DIR)
+
 add_executable(piper_test
    test_piper.cpp
    utils/piper_test_assets.h
@@ -44,6 +46,7 @@ target_compile_definitions(piper_test
     PRIVATE "EN_TEST_MODEL_DIR=\"${EN_MODEL_DIR}\""
     PRIVATE "TEXT_TEST_MODEL_DIR=\"${TEXT_MODEL_DIR}\""
     PRIVATE "ZH_TEST_MODEL_DIR=\"${ZH_MODEL_DIR}\""
+    PRIVATE "G2PW_TEST_DATA_DIR=\"${G2PW_MODEL_DIR}\""
 )
 
 target_link_libraries(piper_test

--- a/libpiper/tests/DownloadModel.cmake
+++ b/libpiper/tests/DownloadModel.cmake
@@ -59,10 +59,13 @@ function(download_g2pw_data)
     # Using raw github – TLS_VERIFY ON matches other downloads
     set(G2PW_BASE "https://raw.githubusercontent.com/GitYCC/g2pW/master/g2pw")
 
+    # Phase 1 required files – must exist or CMake fails clearly.
+    # Windows hosted runs previously only got char_bopomofo_dict.json and
+    # skipped after a warning, causing Hanzi tests to fail with generic
+    # PIPER_ERR. Now we require both source and bopomofo map.
     foreach(F IN ITEMS
-            "bert-base-chinese_s2t_dict.txt"
-            "bopomofo_to_pinyin_wo_tune_dict.json"
-            "char_bopomofo_dict.json")
+            "char_bopomofo_dict.json"
+            "bopomofo_to_pinyin_wo_tune_dict.json")
         if(NOT EXISTS "${G2PW_DIR}/${F}")
             message(STATUS "Downloading g2pw ${F}")
             file(DOWNLOAD
@@ -74,8 +77,7 @@ function(download_g2pw_data)
             )
             list(GET dl_status 0 dl_code)
             if(NOT dl_code EQUAL 0)
-                message(WARNING "Failed to download ${F}, will try local pip package fallback")
-                # fallback to pip-installed g2pw if available
+                message(WARNING "Failed to download ${F} from ${G2PW_BASE}, trying local fallbacks")
                 if(EXISTS "/usr/local/lib/python3.12/dist-packages/g2pw/${F}")
                     file(COPY "/usr/local/lib/python3.12/dist-packages/g2pw/${F}"
                          DESTINATION "${G2PW_DIR}")
@@ -83,13 +85,39 @@ function(download_g2pw_data)
                     file(COPY "/tmp/g2pw_full/${F}"
                          DESTINATION "${G2PW_DIR}")
                 endif()
+                if(NOT EXISTS "${G2PW_DIR}/${F}")
+                    # Try second mirror? fail clearly so tests don't run blind
+                    message(FATAL_ERROR "Phase 1 required g2pw file ${F} missing in ${G2PW_DIR} after download attempt (${dl_status}). "
+                        "Hanzi mono fallback needs char_bopomofo_dict.json + bopomofo_to_pinyin_wo_tune_dict.json. "
+                        "Check network or provide /tmp/g2pw_full/${F}")
+                endif()
             endif()
         endif()
     endforeach()
 
+    # Phase 2 file – not required for monophonic Phase 1, optional
+    set(F "bert-base-chinese_s2t_dict.txt")
+    if(NOT EXISTS "${G2PW_DIR}/${F}")
+        message(STATUS "Downloading g2pw ${F} (Phase 2 optional)")
+        file(DOWNLOAD
+            "${G2PW_BASE}/${F}"
+            "${G2PW_DIR}/${F}"
+            SHOW_PROGRESS
+            TLS_VERIFY ON
+            STATUS dl_status2
+        )
+        list(GET dl_status2 0 dl_code2)
+        if(NOT dl_code2 EQUAL 0)
+            message(STATUS "Optional ${F} download failed (${dl_status2}) – continuing, Phase 2 deferred")
+            if(EXISTS "/tmp/g2pw_full/${F}")
+                file(COPY "/tmp/g2pw_full/${F}" DESTINATION "${G2PW_DIR}")
+            endif()
+        endif()
+    endif()
+
     # MONOPHONIC/POLYPHONIC are not in g2pW repo – they live in model bundles.
     # Copy from /tmp/g2pw_full if we have it locally (built by us), otherwise
-    # leave out – hasDicts() will be true from char_bopomofo alone for "你好".
+    # leave out – hasDicts() will be true from char_bopomofo + b2p for mono.
     foreach(F IN ITEMS "MONOPHONIC_CHARS.txt" "POLYPHONIC_CHARS.txt" "vocab.txt")
         if(NOT EXISTS "${G2PW_DIR}/${F}" AND EXISTS "/tmp/g2pw_full/${F}")
             file(COPY "/tmp/g2pw_full/${F}" DESTINATION "${G2PW_DIR}")

--- a/libpiper/tests/DownloadModel.cmake
+++ b/libpiper/tests/DownloadModel.cmake
@@ -46,3 +46,55 @@ function(download_piper_model)
 
     set(${ARG_OUTPUT_DIR} ${MODEL_DIR} PARENT_SCOPE)
 endfunction()
+
+function(download_g2pw_data)
+    set(options)
+    set(oneValueArgs OUTPUT_DIR)
+    cmake_parse_arguments(ARG "" "${oneValueArgs}" "" ${ARGN})
+
+    set(G2PW_DIR "${CMAKE_BINARY_DIR}/g2pw")
+    file(MAKE_DIRECTORY ${G2PW_DIR})
+
+    # Small dict files from GitYCC/g2pW – enough for mono/bopomofo hanzi path
+    # Using raw github – TLS_VERIFY ON matches other downloads
+    set(G2PW_BASE "https://raw.githubusercontent.com/GitYCC/g2pW/master/g2pw")
+
+    foreach(F IN ITEMS
+            "bert-base-chinese_s2t_dict.txt"
+            "bopomofo_to_pinyin_wo_tune_dict.json"
+            "char_bopomofo_dict.json")
+        if(NOT EXISTS "${G2PW_DIR}/${F}")
+            message(STATUS "Downloading g2pw ${F}")
+            file(DOWNLOAD
+                "${G2PW_BASE}/${F}"
+                "${G2PW_DIR}/${F}"
+                SHOW_PROGRESS
+                TLS_VERIFY ON
+                STATUS dl_status
+            )
+            list(GET dl_status 0 dl_code)
+            if(NOT dl_code EQUAL 0)
+                message(WARNING "Failed to download ${F}, will try local pip package fallback")
+                # fallback to pip-installed g2pw if available
+                if(EXISTS "/usr/local/lib/python3.12/dist-packages/g2pw/${F}")
+                    file(COPY "/usr/local/lib/python3.12/dist-packages/g2pw/${F}"
+                         DESTINATION "${G2PW_DIR}")
+                elseif(EXISTS "/tmp/g2pw_full/${F}")
+                    file(COPY "/tmp/g2pw_full/${F}"
+                         DESTINATION "${G2PW_DIR}")
+                endif()
+            endif()
+        endif()
+    endforeach()
+
+    # MONOPHONIC/POLYPHONIC are not in g2pW repo – they live in model bundles.
+    # Copy from /tmp/g2pw_full if we have it locally (built by us), otherwise
+    # leave out – hasDicts() will be true from char_bopomofo alone for "你好".
+    foreach(F IN ITEMS "MONOPHONIC_CHARS.txt" "POLYPHONIC_CHARS.txt" "vocab.txt")
+        if(NOT EXISTS "${G2PW_DIR}/${F}" AND EXISTS "/tmp/g2pw_full/${F}")
+            file(COPY "/tmp/g2pw_full/${F}" DESTINATION "${G2PW_DIR}")
+        endif()
+    endforeach()
+
+    set(${ARG_OUTPUT_DIR} ${G2PW_DIR} PARENT_SCOPE)
+endfunction()

--- a/libpiper/tests/DownloadModel.cmake
+++ b/libpiper/tests/DownloadModel.cmake
@@ -56,8 +56,13 @@ function(download_g2pw_data)
     file(MAKE_DIRECTORY ${G2PW_DIR})
 
     # Small dict files from GitYCC/g2pW – enough for mono/bopomofo hanzi path
-    # Using raw github – TLS_VERIFY ON matches other downloads
-    set(G2PW_BASE "https://raw.githubusercontent.com/GitYCC/g2pW/master/g2pw")
+    # raw.githubusercontent.com is flaky on GitHub hosted runners (403/22).
+    # Try multiple mirrors: raw github, jsDelivr CDN, github.com raw.
+    set(G2PW_URLS
+        "https://raw.githubusercontent.com/GitYCC/g2pW/master/g2pw"
+        "https://cdn.jsdelivr.net/gh/GitYCC/g2pW@master/g2pw"
+        "https://github.com/GitYCC/g2pW/raw/master/g2pw"
+    )
 
     # Phase 1 required files – must exist or CMake fails clearly.
     # Windows hosted runs previously only got char_bopomofo_dict.json and
@@ -76,38 +81,51 @@ function(download_g2pw_data)
         if(NOT EXISTS "${G2PW_DIR}/${F}")
             message(STATUS "Downloading g2pw ${F}")
             set(_dl_ok FALSE)
-            foreach(_attempt RANGE 1 3)
-                file(DOWNLOAD
-                    "${G2PW_BASE}/${F}"
-                    "${G2PW_DIR}/${F}"
-                    SHOW_PROGRESS
-                    TLS_VERIFY ON
-                    STATUS dl_status
-                )
-                list(GET dl_status 0 dl_code)
-                if(dl_code EQUAL 0)
-                    # CMake may leave empty file on transient failure – verify size
-                    file(SIZE "${G2PW_DIR}/${F}" _fsize)
-                    if(_fsize GREATER 0)
-                        set(_dl_ok TRUE)
-                        break()
-                    else()
-                        file(REMOVE "${G2PW_DIR}/${F}")
-                        message(WARNING "Downloaded ${F} is empty (attempt ${_attempt}/3), retrying...")
-                        set(dl_code 1)
-                        set(dl_status "1;empty file")
-                    endif()
+            set(_last_status "unknown")
+            foreach(_base IN LISTS G2PW_URLS)
+                if(_dl_ok)
+                    break()
                 endif()
-                # Clean partial file before retry/fallback
-                file(REMOVE "${G2PW_DIR}/${F}")
-                if(_attempt LESS 3)
-                    message(STATUS "Retry ${_attempt}/3 for ${F} after failure (${dl_status})")
-                    execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 2)
+                foreach(_attempt RANGE 1 2)
+                    file(DOWNLOAD
+                        "${_base}/${F}"
+                        "${G2PW_DIR}/${F}"
+                        SHOW_PROGRESS
+                        TLS_VERIFY ON
+                        STATUS dl_status
+                    )
+                    list(GET dl_status 0 dl_code)
+                    set(_last_status "${dl_status} from ${_base}")
+                    if(dl_code EQUAL 0)
+                        # CMake may leave empty file on transient failure – verify size
+                        file(SIZE "${G2PW_DIR}/${F}" _fsize)
+                        if(_fsize GREATER 0)
+                            set(_dl_ok TRUE)
+                            message(STATUS "Downloaded ${F} from ${_base} (${_fsize} bytes)")
+                            break()
+                        else()
+                            file(REMOVE "${G2PW_DIR}/${F}")
+                            message(WARNING "Downloaded ${F} from ${_base} is empty (attempt ${_attempt}/2), retrying...")
+                            set(dl_code 1)
+                            set(dl_status "1;empty file")
+                            set(_last_status "empty from ${_base}")
+                        endif()
+                    endif()
+                    # Clean partial file before retry/fallback
+                    file(REMOVE "${G2PW_DIR}/${F}")
+                    if(_attempt LESS 2)
+                        message(STATUS "Retry ${_attempt}/2 for ${F} from ${_base} after failure (${dl_status})")
+                        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 3)
+                    endif()
+                endforeach()
+                if(NOT _dl_ok)
+                    # small backoff between mirrors
+                    execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1)
                 endif()
             endforeach()
 
             if(NOT _dl_ok)
-                message(WARNING "Failed to download ${F} from ${G2PW_BASE} after 3 attempts (${dl_status}), trying local fallbacks")
+                message(WARNING "Failed to download ${F} from all mirrors after attempts (${_last_status}), trying local fallbacks")
                 # Ensure no empty leftover
                 file(REMOVE "${G2PW_DIR}/${F}")
                 if(EXISTS "/usr/local/lib/python3.12/dist-packages/g2pw/${F}")
@@ -118,9 +136,9 @@ function(download_g2pw_data)
                          DESTINATION "${G2PW_DIR}")
                 endif()
                 if(NOT EXISTS "${G2PW_DIR}/${F}")
-                    message(FATAL_ERROR "Phase 1 required g2pw file ${F} missing in ${G2PW_DIR} after download attempts (${dl_status}). "
+                    message(FATAL_ERROR "Phase 1 required g2pw file ${F} missing in ${G2PW_DIR} after download attempts (${_last_status}). "
                         "Hanzi mono fallback needs char_bopomofo_dict.json + bopomofo_to_pinyin_wo_tune_dict.json. "
-                        "Windows host often hits raw.githubusercontent.com transient 403/22 – fixed with retry+remove-empty logic; "
+                        "GitHub hosted runners often hit raw.githubusercontent.com transient 403/22 – fixed with mirror list (raw + jsDelivr + github raw) + retry+remove-empty logic; "
                         "if still failing, check network or provide /tmp/g2pw_full/${F} as fallback.")
                 endif()
             endif()
@@ -131,15 +149,32 @@ function(download_g2pw_data)
     set(F "bert-base-chinese_s2t_dict.txt")
     if(NOT EXISTS "${G2PW_DIR}/${F}")
         message(STATUS "Downloading g2pw ${F} (Phase 2 optional)")
-        file(DOWNLOAD
-            "${G2PW_BASE}/${F}"
-            "${G2PW_DIR}/${F}"
-            SHOW_PROGRESS
-            TLS_VERIFY ON
-            STATUS dl_status2
-        )
-        list(GET dl_status2 0 dl_code2)
-        if(NOT dl_code2 EQUAL 0)
+        set(_dl2_ok FALSE)
+        foreach(_base_opt IN LISTS G2PW_URLS)
+            if(_dl2_ok)
+                break()
+            endif()
+            file(DOWNLOAD
+                "${_base_opt}/${F}"
+                "${G2PW_DIR}/${F}"
+                SHOW_PROGRESS
+                TLS_VERIFY ON
+                STATUS dl_status2
+            )
+            list(GET dl_status2 0 dl_code2)
+            if(dl_code2 EQUAL 0)
+                file(SIZE "${G2PW_DIR}/${F}" _fsize2)
+                if(_fsize2 GREATER 0)
+                    set(_dl2_ok TRUE)
+                    break()
+                else()
+                    file(REMOVE "${G2PW_DIR}/${F}")
+                endif()
+            else()
+                file(REMOVE "${G2PW_DIR}/${F}")
+            endif()
+        endforeach()
+        if(NOT _dl2_ok)
             message(STATUS "Optional ${F} download failed (${dl_status2}) – continuing, Phase 2 deferred")
             if(EXISTS "/tmp/g2pw_full/${F}")
                 file(COPY "/tmp/g2pw_full/${F}" DESTINATION "${G2PW_DIR}")

--- a/libpiper/tests/DownloadModel.cmake
+++ b/libpiper/tests/DownloadModel.cmake
@@ -66,18 +66,50 @@ function(download_g2pw_data)
     foreach(F IN ITEMS
             "char_bopomofo_dict.json"
             "bopomofo_to_pinyin_wo_tune_dict.json")
+        # Clean up previous empty/corrupt artifact (CMake leaves 0-byte on HTTP error)
+        if(EXISTS "${G2PW_DIR}/${F}")
+            file(SIZE "${G2PW_DIR}/${F}" _existing_size)
+            if(_existing_size EQUAL 0)
+                file(REMOVE "${G2PW_DIR}/${F}")
+            endif()
+        endif()
         if(NOT EXISTS "${G2PW_DIR}/${F}")
             message(STATUS "Downloading g2pw ${F}")
-            file(DOWNLOAD
-                "${G2PW_BASE}/${F}"
-                "${G2PW_DIR}/${F}"
-                SHOW_PROGRESS
-                TLS_VERIFY ON
-                STATUS dl_status
-            )
-            list(GET dl_status 0 dl_code)
-            if(NOT dl_code EQUAL 0)
-                message(WARNING "Failed to download ${F} from ${G2PW_BASE}, trying local fallbacks")
+            set(_dl_ok FALSE)
+            foreach(_attempt RANGE 1 3)
+                file(DOWNLOAD
+                    "${G2PW_BASE}/${F}"
+                    "${G2PW_DIR}/${F}"
+                    SHOW_PROGRESS
+                    TLS_VERIFY ON
+                    STATUS dl_status
+                )
+                list(GET dl_status 0 dl_code)
+                if(dl_code EQUAL 0)
+                    # CMake may leave empty file on transient failure – verify size
+                    file(SIZE "${G2PW_DIR}/${F}" _fsize)
+                    if(_fsize GREATER 0)
+                        set(_dl_ok TRUE)
+                        break()
+                    else()
+                        file(REMOVE "${G2PW_DIR}/${F}")
+                        message(WARNING "Downloaded ${F} is empty (attempt ${_attempt}/3), retrying...")
+                        set(dl_code 1)
+                        set(dl_status "1;empty file")
+                    endif()
+                endif()
+                # Clean partial file before retry/fallback
+                file(REMOVE "${G2PW_DIR}/${F}")
+                if(_attempt LESS 3)
+                    message(STATUS "Retry ${_attempt}/3 for ${F} after failure (${dl_status})")
+                    execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 2)
+                endif()
+            endforeach()
+
+            if(NOT _dl_ok)
+                message(WARNING "Failed to download ${F} from ${G2PW_BASE} after 3 attempts (${dl_status}), trying local fallbacks")
+                # Ensure no empty leftover
+                file(REMOVE "${G2PW_DIR}/${F}")
                 if(EXISTS "/usr/local/lib/python3.12/dist-packages/g2pw/${F}")
                     file(COPY "/usr/local/lib/python3.12/dist-packages/g2pw/${F}"
                          DESTINATION "${G2PW_DIR}")
@@ -86,10 +118,10 @@ function(download_g2pw_data)
                          DESTINATION "${G2PW_DIR}")
                 endif()
                 if(NOT EXISTS "${G2PW_DIR}/${F}")
-                    # Try second mirror? fail clearly so tests don't run blind
-                    message(FATAL_ERROR "Phase 1 required g2pw file ${F} missing in ${G2PW_DIR} after download attempt (${dl_status}). "
+                    message(FATAL_ERROR "Phase 1 required g2pw file ${F} missing in ${G2PW_DIR} after download attempts (${dl_status}). "
                         "Hanzi mono fallback needs char_bopomofo_dict.json + bopomofo_to_pinyin_wo_tune_dict.json. "
-                        "Check network or provide /tmp/g2pw_full/${F}")
+                        "Windows host often hits raw.githubusercontent.com transient 403/22 – fixed with retry+remove-empty logic; "
+                        "if still failing, check network or provide /tmp/g2pw_full/${F} as fallback.")
                 endif()
             endif()
         endif()

--- a/libpiper/tests/test_main_utils.cpp
+++ b/libpiper/tests/test_main_utils.cpp
@@ -130,3 +130,47 @@ TEST_F(MainUtilsTest, ParseArgsMissingArgument) {
       },
       piper::ArgError);
 }
+
+TEST_F(MainUtilsTest, ParseArgsDataDir) {
+  piper::RunConfig runConfig;
+
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  const char *argv[] = {"test_program", "--model", "model.onnx", "--data-dir",
+                        "/data/piper"};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+
+  parseArgsLogic(argc, const_cast<char **>(argv), runConfig);
+
+  EXPECT_EQ(runConfig.modelPath, "model.onnx");
+  ASSERT_TRUE(runConfig.dataDir.has_value());
+  EXPECT_EQ(runConfig.dataDir.value(), "/data/piper");
+}
+
+TEST_F(MainUtilsTest, ParseArgsG2pwDir) {
+  piper::RunConfig runConfig;
+
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  const char *argv[] = {"test_program", "--model", "model.onnx", "--g2pw-dir",
+                        "/tmp/g2pw_dict"};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+
+  parseArgsLogic(argc, const_cast<char **>(argv), runConfig);
+
+  ASSERT_TRUE(runConfig.g2pwModelDir.has_value());
+  EXPECT_EQ(runConfig.g2pwModelDir.value(), "/tmp/g2pw_dict");
+}
+
+TEST_F(MainUtilsTest, ParseArgsG2pwAlias) {
+  piper::RunConfig runConfig;
+
+  // alias --g2pw_model_dir
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  const char *argv[] = {"test_program", "--model", "model.onnx",
+                        "--g2pw_model_dir", "/custom/g2pw"};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+
+  parseArgsLogic(argc, const_cast<char **>(argv), runConfig);
+
+  ASSERT_TRUE(runConfig.g2pwModelDir.has_value());
+  EXPECT_EQ(runConfig.g2pwModelDir.value(), "/custom/g2pw");
+}

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -271,13 +271,15 @@ TEST_F(PiperTest, CreateWithOptionsDataDir) {
   opts.data_dir = data_dir.c_str();
 
   piper_synthesizer *synth = piper_create_with_options(&opts);
-  // Now that espeak data path resolution via data_dir is fixed, synth must be non-null
-  // (previously this test allowed nullptr and would hide fallback bugs)
+  // Now that espeak data path resolution via data_dir is fixed, synth must be
+  // non-null (previously this test allowed nullptr and would hide fallback
+  // bugs)
   ASSERT_NE(synth, nullptr)
       << "piper_create_with_options should succeed via data_dir=" << data_dir;
   // Verify g2pw dir resolution for Phase 1: data_dir/g2pw is tried first,
-  // then data_dir root. When data_dir contains espeak-ng-data but no g2pw dicts,
-  // effective_g2pw_dir defaults to <data_dir>/g2pw (non-fatal, direct pinyin still works)
+  // then data_dir root. When data_dir contains espeak-ng-data but no g2pw
+  // dicts, effective_g2pw_dir defaults to <data_dir>/g2pw (non-fatal, direct
+  // pinyin still works)
   EXPECT_FALSE(synth->g2pw_model_dir.empty());
   // Should end with "g2pw" when using espeak_root data_dir (no dicts in root)
   EXPECT_TRUE(synth->g2pw_model_dir.find("g2pw") != std::string::npos)
@@ -395,32 +397,51 @@ protected:
 
   static void SetUpTestSuite() {
     assets = PiperTestAssets::zhModel();
-    // Prefer CMake-downloaded g2pw dir
+
+    auto has_required = [](const std::filesystem::path &d) {
+      bool has_source = std::filesystem::exists(d / "MONOPHONIC_CHARS.txt") ||
+                        std::filesystem::exists(d / "char_bopomofo_dict.json");
+      bool has_b2p =
+          std::filesystem::exists(d / "bopomofo_to_pinyin_wo_tune_dict.json");
+      return has_source && has_b2p;
+    };
+
+    // Prefer CMake-downloaded g2pw dir – must be complete for Phase 1
     auto cmake_g2pw = PiperTestAssets::g2pwDataDir();
-    if (!cmake_g2pw.empty() && std::filesystem::exists(cmake_g2pw)) {
-      g2pw_dir = cmake_g2pw.string();
-    } else if (std::filesystem::exists("/tmp/g2pw_full/g2pw.onnx") ||
-               std::filesystem::exists(
-                   "/tmp/g2pw_full/char_bopomofo_dict.json")) {
-      g2pw_dir = "/tmp/g2pw_full";
-    } else if (std::filesystem::exists("build/g2pw")) {
-      g2pw_dir = "build/g2pw";
-    } else if (std::filesystem::exists("/tmp/g2pw")) {
-      g2pw_dir = "/tmp/g2pw";
-    } else if (std::filesystem::exists(cmake_g2pw /
-                                       "char_bopomofo_dict.json")) {
-      g2pw_dir = cmake_g2pw.string();
-    } else {
-      // Still set cmake dir even if files downloading – phonemizer will load
-      // what it can
-      if (!cmake_g2pw.empty())
-        g2pw_dir = cmake_g2pw.string();
-      else
-        g2pw_dir = "";
+    std::vector<std::filesystem::path> candidates = {
+        cmake_g2pw,
+        std::filesystem::path("/tmp/g2pw_full"),
+        std::filesystem::path("build/g2pw"),
+        std::filesystem::path("/tmp/g2pw"),
+    };
+
+    for (auto &cand : candidates) {
+      if (cand.empty())
+        continue;
+      if (std::filesystem::exists(cand) && has_required(cand)) {
+        g2pw_dir = cand.string();
+        break;
+      }
     }
 
-    // If zh model missing, skip all? assets creation still ok but synth
-    // creation will fail
+    // Fallback: if no complete dir but cmake dir exists partially, use it
+    // so load() fails clearly (hasDicts false) instead of silently using
+    // incomplete data later as PIPER_ERR_GENERIC
+    if (g2pw_dir.empty()) {
+      if (!cmake_g2pw.empty() && std::filesystem::exists(cmake_g2pw)) {
+        g2pw_dir = cmake_g2pw.string();
+      } else if (std::filesystem::exists("/tmp/g2pw_full")) {
+        g2pw_dir = "/tmp/g2pw_full";
+      } else if (std::filesystem::exists("build/g2pw")) {
+        g2pw_dir = "build/g2pw";
+      } else if (!cmake_g2pw.empty()) {
+        g2pw_dir = cmake_g2pw.string();
+      } else {
+        g2pw_dir = "";
+      }
+    }
+
+    // If zh model missing, creation will fail – tests will SKIP clearly
   }
 
   static void TearDownTestSuite() { assets.reset(); }
@@ -566,19 +587,19 @@ TEST_F(PinyinTest, PolyphonicKnownLimitation) {
       << "Phase 1 mono-only: 长 is polyphonic, should be unsupported";
 
   // Compounds containing poly char should also not silently assign first sense.
-  // Our phonemize returns empty on encountering poly char to avoid wrong reading.
+  // Our phonemize returns empty on encountering poly char to avoid wrong
+  // reading.
   auto seq_cq = synth->chinese_phonemizer->phonemize("重庆");
-  // Should be empty or at least not contain first-sense zhong – empty is cleanest
+  // Should be empty or at least not contain first-sense zhong – empty is
+  // cleanest
   EXPECT_TRUE(seq_cq.empty())
       << "重庆 contains 重 (poly), should be unsupported in mono-only Phase 1";
 
   auto seq_yh = synth->chinese_phonemizer->phonemize("银行");
-  EXPECT_TRUE(seq_yh.empty())
-      << "银行 contains 行 poly, should be unsupported";
+  EXPECT_TRUE(seq_yh.empty()) << "银行 contains 行 poly, should be unsupported";
 
   auto seq_cj = synth->chinese_phonemizer->phonemize("长江");
-  EXPECT_TRUE(seq_cj.empty())
-      << "长江 contains 长 poly, should be unsupported";
+  EXPECT_TRUE(seq_cj.empty()) << "长江 contains 长 poly, should be unsupported";
 
   // Positive: mono chars still work - "你我" are monophonic (single reading)
   auto seq_nh = synth->chinese_phonemizer->phonemize("你我");
@@ -622,7 +643,8 @@ TEST_F(PinyinTest, DataDirG2pwSubdir) {
   ASSERT_NE(synth, nullptr) << "data_dir subdir fallback should create synth";
   EXPECT_FALSE(synth->g2pw_model_dir.empty());
   // Should have resolved to <data_dir>/g2pw which contains dicts
-  EXPECT_TRUE(synth->chinese_phonemizer && synth->chinese_phonemizer->hasDicts())
+  EXPECT_TRUE(synth->chinese_phonemizer &&
+              synth->chinese_phonemizer->hasDicts())
       << "expected dicts loaded via <data_dir>/g2pw, g2pw_model_dir="
       << synth->g2pw_model_dir;
 
@@ -645,7 +667,8 @@ TEST_F(PinyinTest, DataDirRootDicts) {
   }
 
   // Layout: dicts directly in data_dir root (no g2pw subdir)
-  // Use g2pw_dir itself as data_dir – it contains char_bopomofo_dict.json directly
+  // Use g2pw_dir itself as data_dir – it contains char_bopomofo_dict.json
+  // directly
   std::string data_dir = g2pw_dir;
 
   piper_create_options opts;
@@ -661,7 +684,8 @@ TEST_F(PinyinTest, DataDirRootDicts) {
   ASSERT_NE(synth, nullptr)
       << "data_dir root fallback should create synth when dicts in root";
   EXPECT_FALSE(synth->g2pw_model_dir.empty());
-  EXPECT_TRUE(synth->chinese_phonemizer && synth->chinese_phonemizer->hasDicts())
+  EXPECT_TRUE(synth->chinese_phonemizer &&
+              synth->chinese_phonemizer->hasDicts())
       << "expected dicts loaded via data_dir root, g2pw_model_dir="
       << synth->g2pw_model_dir;
 

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -388,15 +388,25 @@ protected:
 
   static void SetUpTestSuite() {
     assets = PiperTestAssets::zhModel();
-    // Prefer /tmp/g2pw_full if exists (CI fallback)
-    if (std::filesystem::exists("/tmp/g2pw_full/g2pw.onnx")) {
+    // Prefer CMake-downloaded g2pw dir
+    auto cmake_g2pw = PiperTestAssets::g2pwDataDir();
+    if (!cmake_g2pw.empty() && std::filesystem::exists(cmake_g2pw)) {
+      g2pw_dir = cmake_g2pw.string();
+    } else if (std::filesystem::exists("/tmp/g2pw_full/g2pw.onnx") ||
+               std::filesystem::exists("/tmp/g2pw_full/char_bopomofo_dict.json")) {
       g2pw_dir = "/tmp/g2pw_full";
     } else if (std::filesystem::exists("build/g2pw")) {
       g2pw_dir = "build/g2pw";
     } else if (std::filesystem::exists("/tmp/g2pw")) {
       g2pw_dir = "/tmp/g2pw";
+    } else if (std::filesystem::exists(cmake_g2pw / "char_bopomofo_dict.json")) {
+      g2pw_dir = cmake_g2pw.string();
     } else {
-      g2pw_dir = "";
+      // Still set cmake dir even if files downloading – phonemizer will load what it can
+      if (!cmake_g2pw.empty())
+        g2pw_dir = cmake_g2pw.string();
+      else
+        g2pw_dir = "";
     }
 
     // If zh model missing, skip all? assets creation still ok but synth
@@ -468,19 +478,18 @@ TEST_F(PinyinTest, HanziMonoFallback) {
     GTEST_SKIP();
   }
 
-  // "你好" should be phonemized via mono dict if available, else fallback to
-  // skip unknown giving error With dicts present (g2pw_full), it should succeed
-  if (synth->chinese_phonemizer && synth->chinese_phonemizer->hasDicts()) {
-    int rc = piper_synthesize_start(synth, "你好", nullptr);
-    ASSERT_EQ(rc, PIPER_OK);
-    piper_audio_chunk chunk;
-    rc = piper_synthesize_next(synth, &chunk);
-    EXPECT_GT(chunk.num_samples, 0);
-  } else {
-    // without dicts, direct pinyin fallback still works if we give pinyin, so
-    // skip hanzi
-    GTEST_SKIP() << "no dicts loaded, skipping hanzi test";
-  }
+  // Require dicts – they are now downloaded via CMake (G2PW_TEST_DATA_DIR)
+  // No skipping – if dicts missing, this fails so CI catches it
+  ASSERT_NE(synth->chinese_phonemizer, nullptr) << "chinese_phonemizer not created, g2pw_dir=" << g2pw_dir;
+  ASSERT_TRUE(synth->chinese_phonemizer->hasDicts())
+      << "g2pw dicts not loaded from " << g2pw_dir;
+
+  // "你好" should be phonemized via char_bopomofo dict
+  int rc = piper_synthesize_start(synth, "你好", nullptr);
+  ASSERT_EQ(rc, PIPER_OK);
+  piper_audio_chunk chunk;
+  rc = piper_synthesize_next(synth, &chunk);
+  EXPECT_GT(chunk.num_samples, 0);
 
   piper_free(synth);
 }

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
@@ -202,4 +203,115 @@ TEST_F(PiperTest, EmptyText) {
   ASSERT_TRUE(chunk.is_last);
 
   piper_free(synth);
+}
+
+TEST_F(PiperTest, CreateWithOptionsBasic) {
+  std::string model_path = assets->modelPath().string();
+  std::string config_path = assets->configPath().string();
+  std::string espeak_path = PiperTestAssets::espeakDataPath().string();
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  opts.model_path = model_path.c_str();
+  opts.config_path = config_path.c_str();
+  opts.espeak_data_path = espeak_path.c_str();
+
+  piper_synthesizer *synth = piper_create_with_options(&opts);
+  ASSERT_NE(synth, nullptr);
+  EXPECT_EQ(synth->phoneme_type, PhonemeType::Espeak);
+  piper_free(synth);
+}
+
+TEST_F(PiperTest, CreateWithOptionsNullModel) {
+  std::string config_path = assets->configPath().string();
+  std::string espeak_path = PiperTestAssets::espeakDataPath().string();
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  opts.model_path = nullptr;
+  opts.config_path = config_path.c_str();
+  opts.espeak_data_path = espeak_path.c_str();
+
+  piper_synthesizer *synth = piper_create_with_options(&opts);
+  ASSERT_EQ(synth, nullptr);
+}
+
+TEST_F(PiperTest, CreateWithOptionsNullOptions) {
+  piper_synthesizer *synth = piper_create_with_options(nullptr);
+  ASSERT_EQ(synth, nullptr);
+}
+
+TEST_F(PiperTest, CreateWithOptionsSmallStruct) {
+  std::string model_path = assets->modelPath().string();
+  std::string espeak_path = PiperTestAssets::espeakDataPath().string();
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  opts.model_path = model_path.c_str();
+  // Simulate old header with smaller struct_size (only up to espeak_data_path)
+  opts.struct_size = offsetof(piper_create_options, espeak_data_path) + sizeof(opts.espeak_data_path);
+  opts.espeak_data_path = espeak_path.c_str();
+
+  piper_synthesizer *synth = piper_create_with_options(&opts);
+  ASSERT_NE(synth, nullptr);
+  piper_free(synth);
+}
+
+TEST_F(PiperTest, CreateWithOptionsDataDir) {
+  // data_dir containing espeak-ng-data should be resolved
+  auto espeak_root = PiperTestAssets::espeakDataPath().parent_path();
+  std::string model_path = assets->modelPath().string();
+  std::string config_path = assets->configPath().string();
+  std::string data_dir = espeak_root.string();
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  opts.model_path = model_path.c_str();
+  opts.config_path = config_path.c_str();
+  opts.espeak_data_path = nullptr; // rely on data_dir fallback
+  opts.data_dir = data_dir.c_str();
+
+  piper_synthesizer *synth = piper_create_with_options(&opts);
+  if (synth) {
+    piper_free(synth);
+  } else {
+    SUCCEED();
+  }
+}
+
+TEST_F(PiperTest, CreateWithOptionsG2pwDirField) {
+  std::string model_path = assets->modelPath().string();
+  std::string config_path = assets->configPath().string();
+  std::string espeak_path = PiperTestAssets::espeakDataPath().string();
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  opts.model_path = model_path.c_str();
+  opts.config_path = config_path.c_str();
+  opts.espeak_data_path = espeak_path.c_str();
+  opts.g2pw_model_dir = "/tmp/nonexistent_g2pw";
+  opts.data_dir = nullptr;
+
+  piper_synthesizer *synth = piper_create_with_options(&opts);
+  ASSERT_NE(synth, nullptr);
+  EXPECT_EQ(synth->g2pw_model_dir, "/tmp/nonexistent_g2pw");
+  piper_free(synth);
+}
+
+TEST_F(PiperTest, CreateLegacyVsOptionsParity) {
+  std::string model_path = assets->modelPath().string();
+  std::string config_path = assets->configPath().string();
+  std::string espeak_path = PiperTestAssets::espeakDataPath().string();
+  auto *synth_legacy = piper_create(model_path.c_str(), config_path.c_str(), espeak_path.c_str());
+  ASSERT_NE(synth_legacy, nullptr);
+
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  opts.model_path = model_path.c_str();
+  opts.config_path = config_path.c_str();
+  opts.espeak_data_path = espeak_path.c_str();
+  auto *synth_opts = piper_create_with_options(&opts);
+  ASSERT_NE(synth_opts, nullptr);
+
+  EXPECT_EQ(synth_legacy->phoneme_type, synth_opts->phoneme_type);
+  EXPECT_EQ(synth_legacy->sample_rate, synth_opts->sample_rate);
+  EXPECT_EQ(synth_legacy->num_speakers, synth_opts->num_speakers);
+
+  piper_free(synth_legacy);
+  piper_free(synth_opts);
 }

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -393,16 +393,19 @@ protected:
     if (!cmake_g2pw.empty() && std::filesystem::exists(cmake_g2pw)) {
       g2pw_dir = cmake_g2pw.string();
     } else if (std::filesystem::exists("/tmp/g2pw_full/g2pw.onnx") ||
-               std::filesystem::exists("/tmp/g2pw_full/char_bopomofo_dict.json")) {
+               std::filesystem::exists(
+                   "/tmp/g2pw_full/char_bopomofo_dict.json")) {
       g2pw_dir = "/tmp/g2pw_full";
     } else if (std::filesystem::exists("build/g2pw")) {
       g2pw_dir = "build/g2pw";
     } else if (std::filesystem::exists("/tmp/g2pw")) {
       g2pw_dir = "/tmp/g2pw";
-    } else if (std::filesystem::exists(cmake_g2pw / "char_bopomofo_dict.json")) {
+    } else if (std::filesystem::exists(cmake_g2pw /
+                                       "char_bopomofo_dict.json")) {
       g2pw_dir = cmake_g2pw.string();
     } else {
-      // Still set cmake dir even if files downloading – phonemizer will load what it can
+      // Still set cmake dir even if files downloading – phonemizer will load
+      // what it can
       if (!cmake_g2pw.empty())
         g2pw_dir = cmake_g2pw.string();
       else
@@ -480,7 +483,8 @@ TEST_F(PinyinTest, HanziMonoFallback) {
 
   // Require dicts – they are now downloaded via CMake (G2PW_TEST_DATA_DIR)
   // No skipping – if dicts missing, this fails so CI catches it
-  ASSERT_NE(synth->chinese_phonemizer, nullptr) << "chinese_phonemizer not created, g2pw_dir=" << g2pw_dir;
+  ASSERT_NE(synth->chinese_phonemizer, nullptr)
+      << "chinese_phonemizer not created, g2pw_dir=" << g2pw_dir;
   ASSERT_TRUE(synth->chinese_phonemizer->hasDicts())
       << "g2pw dicts not loaded from " << g2pw_dir;
 

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -1,9 +1,11 @@
-#include <gtest/gtest.h>
 #include <cstddef>
+#include <filesystem>
+#include <gtest/gtest.h>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "chinese_phonemizer.h"
 #include "piper.h"
 #include "piper_impl.hpp"
 #include "utils/piper_test_assets.h"
@@ -246,7 +248,8 @@ TEST_F(PiperTest, CreateWithOptionsSmallStruct) {
   piper_init_create_options(&opts);
   opts.model_path = model_path.c_str();
   // Simulate old header with smaller struct_size (only up to espeak_data_path)
-  opts.struct_size = offsetof(piper_create_options, espeak_data_path) + sizeof(opts.espeak_data_path);
+  opts.struct_size = offsetof(piper_create_options, espeak_data_path) +
+                     sizeof(opts.espeak_data_path);
   opts.espeak_data_path = espeak_path.c_str();
 
   piper_synthesizer *synth = piper_create_with_options(&opts);
@@ -297,7 +300,8 @@ TEST_F(PiperTest, CreateLegacyVsOptionsParity) {
   std::string model_path = assets->modelPath().string();
   std::string config_path = assets->configPath().string();
   std::string espeak_path = PiperTestAssets::espeakDataPath().string();
-  auto *synth_legacy = piper_create(model_path.c_str(), config_path.c_str(), espeak_path.c_str());
+  auto *synth_legacy = piper_create(model_path.c_str(), config_path.c_str(),
+                                    espeak_path.c_str());
   ASSERT_NE(synth_legacy, nullptr);
 
   piper_create_options opts;
@@ -314,4 +318,194 @@ TEST_F(PiperTest, CreateLegacyVsOptionsParity) {
 
   piper_free(synth_legacy);
   piper_free(synth_opts);
+}
+
+// ---- Chinese phonemizer unit tests ----
+
+TEST(ChinesePhonemizerUnit, NormalizeG2pw) {
+  using namespace piper;
+  EXPECT_EQ(normalize_g2pw_syllable("nu:3"), "nv3");
+  EXPECT_EQ(normalize_g2pw_syllable("lve4"), "lve4");
+  EXPECT_EQ(normalize_g2pw_syllable("ni3"), "ni3");
+  EXPECT_EQ(normalize_g2pw_syllable("hao3"), "hao3");
+  EXPECT_EQ(normalize_g2pw_syllable("abc"), "abc");
+}
+
+TEST(ChinesePhonemizerUnit, SplitInitialFinalTone) {
+  using namespace piper;
+  auto [ini, fin, tone] = split_initial_final_tone("ni3");
+  EXPECT_EQ(ini, "n");
+  EXPECT_EQ(fin, "i");
+  EXPECT_EQ(tone, "3");
+
+  auto [ini2, fin2, tone2] = split_initial_final_tone("hao3");
+  EXPECT_EQ(ini2, "h");
+  EXPECT_EQ(fin2, "ao");
+  EXPECT_EQ(tone2, "3");
+
+  auto [ini3, fin3, tone3] = split_initial_final_tone("zhong1");
+  EXPECT_EQ(ini3, "zh");
+  EXPECT_EQ(fin3, "ong");
+  EXPECT_EQ(tone3, "1");
+
+  auto [ini4, fin4, tone4] = split_initial_final_tone("a1");
+  EXPECT_EQ(ini4, "");
+  EXPECT_EQ(fin4, "a");
+  EXPECT_EQ(tone4, "1");
+}
+
+TEST(ChinesePhonemizerUnit, PhonemizePinyinText) {
+  auto seq = piper::ChinesePhonemizer::phonemize_pinyin_text("ni3 hao3");
+  ASSERT_EQ(seq.size(), 1);
+  auto &ph = seq[0];
+  // Should contain initial, final, tone for both syllables
+  // Contains at least n,i,3,h,ao,3
+  EXPECT_GT(ph.size(), 4);
+  bool has_n = std::find(ph.begin(), ph.end(), "n") != ph.end();
+  bool has_h = std::find(ph.begin(), ph.end(), "h") != ph.end();
+  EXPECT_TRUE(has_n);
+  EXPECT_TRUE(has_h);
+}
+
+TEST(ChinesePhonemizerUnit, PhonemesToIds) {
+  std::map<std::string, std::vector<int64_t>> id_map = {
+      {"^", {1}},  {"_", {0}},  {"$", {2}},   {"n", {10}}, {"i", {27}},
+      {"3", {66}}, {"h", {14}}, {"ao", {32}}, {" ", {72}}};
+  std::vector<std::string> ph = {"n", "i", "3", "h", "ao", "3"};
+  auto ids = piper::phonemes_to_ids(ph, id_map);
+  // BOS 1, n10,i27,3+pad, h,ao,3+pad, EOS
+  EXPECT_GT(ids.size(), 5);
+  EXPECT_EQ(ids.front(), 1);
+  EXPECT_EQ(ids.back(), 2);
+}
+
+// ---- Pinyin end-to-end tests ----
+
+class PinyinTest : public ::testing::Test {
+protected:
+  static std::unique_ptr<PiperTestAssets> assets;
+  static std::string g2pw_dir;
+
+  static void SetUpTestSuite() {
+    assets = PiperTestAssets::zhModel();
+    // Prefer /tmp/g2pw_full if exists (CI fallback)
+    if (std::filesystem::exists("/tmp/g2pw_full/g2pw.onnx")) {
+      g2pw_dir = "/tmp/g2pw_full";
+    } else if (std::filesystem::exists("build/g2pw")) {
+      g2pw_dir = "build/g2pw";
+    } else if (std::filesystem::exists("/tmp/g2pw")) {
+      g2pw_dir = "/tmp/g2pw";
+    } else {
+      g2pw_dir = "";
+    }
+
+    // If zh model missing, skip all? assets creation still ok but synth
+    // creation will fail
+  }
+
+  static void TearDownTestSuite() { assets.reset(); }
+};
+
+std::unique_ptr<PiperTestAssets> PinyinTest::assets = nullptr;
+std::string PinyinTest::g2pw_dir = "";
+
+TEST_F(PinyinTest, DirectPinyin) {
+  if (!std::filesystem::exists(assets->modelPath())) {
+    GTEST_SKIP() << "zh model not downloaded";
+  }
+
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  std::string model = assets->modelPath().string();
+  std::string config = assets->configPath().string();
+  opts.model_path = model.c_str();
+  opts.config_path = config.c_str();
+  opts.espeak_data_path = nullptr;
+  if (!g2pw_dir.empty()) {
+    opts.g2pw_model_dir = g2pw_dir.c_str();
+  } else {
+    opts.g2pw_model_dir = "/tmp/g2pw_full";
+  }
+
+  auto *synth = piper_create_with_options(&opts);
+  if (!synth) {
+    GTEST_SKIP() << "synth creation failed (model missing?)";
+  }
+  ASSERT_EQ(synth->phoneme_type, PhonemeType::Pinyin);
+
+  int rc = piper_synthesize_start(synth, "ni3 hao3", nullptr);
+  ASSERT_EQ(rc, PIPER_OK);
+
+  piper_audio_chunk chunk;
+  rc = piper_synthesize_next(synth, &chunk);
+  ASSERT_TRUE(rc == PIPER_OK || rc == PIPER_DONE);
+  EXPECT_GT(chunk.num_samples, 0);
+
+  while (!chunk.is_last) {
+    rc = piper_synthesize_next(synth, &chunk);
+    if (rc == PIPER_DONE)
+      break;
+  }
+
+  piper_free(synth);
+}
+
+TEST_F(PinyinTest, HanziMonoFallback) {
+  if (!std::filesystem::exists(assets->modelPath())) {
+    GTEST_SKIP();
+  }
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  std::string model = assets->modelPath().string();
+  std::string config = assets->configPath().string();
+  opts.model_path = model.c_str();
+  opts.config_path = config.c_str();
+  if (!g2pw_dir.empty())
+    opts.g2pw_model_dir = g2pw_dir.c_str();
+
+  auto *synth = piper_create_with_options(&opts);
+  if (!synth) {
+    GTEST_SKIP();
+  }
+
+  // "你好" should be phonemized via mono dict if available, else fallback to
+  // skip unknown giving error With dicts present (g2pw_full), it should succeed
+  if (synth->chinese_phonemizer && synth->chinese_phonemizer->hasDicts()) {
+    int rc = piper_synthesize_start(synth, "你好", nullptr);
+    ASSERT_EQ(rc, PIPER_OK);
+    piper_audio_chunk chunk;
+    rc = piper_synthesize_next(synth, &chunk);
+    EXPECT_GT(chunk.num_samples, 0);
+  } else {
+    // without dicts, direct pinyin fallback still works if we give pinyin, so
+    // skip hanzi
+    GTEST_SKIP() << "no dicts loaded, skipping hanzi test";
+  }
+
+  piper_free(synth);
+}
+
+TEST_F(PinyinTest, MissingG2pwFallback) {
+  if (!std::filesystem::exists(assets->modelPath())) {
+    GTEST_SKIP();
+  }
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  std::string model = assets->modelPath().string();
+  std::string config = assets->configPath().string();
+  opts.model_path = model.c_str();
+  opts.config_path = config.c_str();
+  opts.g2pw_model_dir = "/tmp/nonexistent_dir_for_fallback";
+  auto *synth = piper_create_with_options(&opts);
+  ASSERT_NE(synth, nullptr);
+
+  // With nonexistent g2pw dir, direct pinyin should still work via static
+  // phonemize_pinyin_text
+  int rc = piper_synthesize_start(synth, "ni3 hao3", nullptr);
+  EXPECT_EQ(rc, PIPER_OK);
+  piper_audio_chunk chunk;
+  rc = piper_synthesize_next(synth, &chunk);
+  EXPECT_GT(chunk.num_samples, 0);
+
+  piper_free(synth);
 }

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -436,8 +436,6 @@ TEST_F(PinyinTest, DirectPinyin) {
   opts.espeak_data_path = nullptr;
   if (!g2pw_dir.empty()) {
     opts.g2pw_model_dir = g2pw_dir.c_str();
-  } else {
-    opts.g2pw_model_dir = "/tmp/g2pw_full";
   }
 
   auto *synth = piper_create_with_options(&opts);
@@ -519,6 +517,57 @@ TEST_F(PinyinTest, MissingG2pwFallback) {
   piper_audio_chunk chunk;
   rc = piper_synthesize_next(synth, &chunk);
   EXPECT_GT(chunk.num_samples, 0);
+
+  piper_free(synth);
+}
+
+TEST_F(PinyinTest, PolyphonicKnownLimitation) {
+  if (!std::filesystem::exists(assets->modelPath())) {
+    GTEST_SKIP();
+  }
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  std::string model = assets->modelPath().string();
+  std::string config = assets->configPath().string();
+  opts.model_path = model.c_str();
+  opts.config_path = config.c_str();
+  if (!g2pw_dir.empty())
+    opts.g2pw_model_dir = g2pw_dir.c_str();
+
+  auto *synth = piper_create_with_options(&opts);
+  ASSERT_NE(synth, nullptr);
+  ASSERT_NE(synth->chinese_phonemizer, nullptr);
+  ASSERT_TRUE(synth->chinese_phonemizer->hasDicts());
+
+  // Phase 1 is monophonic fallback only: phonemize() picks
+  // char_bopomofo_dict[ch][0] These assertions document the current limitation
+  // flagged in review. After full g2pw BERT integration, these should become
+  // chong2, hang2, chang2.
+  auto seq_cq = synth->chinese_phonemizer->phonemize("重庆");
+  ASSERT_FALSE(seq_cq.empty()) << "重庆 phonemize empty";
+  auto flat_cq = seq_cq[0];
+  bool has_zhong =
+      std::find(flat_cq.begin(), flat_cq.end(), "zhong") != flat_cq.end() ||
+      std::find(flat_cq.begin(), flat_cq.end(), "zh") != flat_cq.end();
+  // At least contains zhONG path (zhong4) – known limitation
+  EXPECT_TRUE(has_zhong) << "expected mono fallback zhong for 重庆, got "
+                         << flat_cq.size();
+
+  auto seq_yh = synth->chinese_phonemizer->phonemize("银行");
+  ASSERT_FALSE(seq_yh.empty());
+  // yin2 xing2 is current mono fallback (should be hang2 after g2pw)
+  auto flat_yh = seq_yh[0];
+  bool has_yin =
+      std::find(flat_yh.begin(), flat_yh.end(), "yin") != flat_yh.end() ||
+      std::find(flat_yh.begin(), flat_yh.end(), "y") != flat_yh.end();
+  EXPECT_TRUE(has_yin);
+
+  // Also verify IDs - ensures not just sample>0 but actual phoneme IDs produced
+  auto ids = piper::ChinesePhonemizer::phonemes_to_ids_pinyin(
+      flat_cq, synth->pinyin_id_map);
+  EXPECT_GT(ids.size(), 2u); // BOS + something + EOS
+  EXPECT_EQ(ids.front(), 1); // BOS
+  EXPECT_EQ(ids.back(), 2);  // EOS
 
   piper_free(synth);
 }

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -271,11 +271,18 @@ TEST_F(PiperTest, CreateWithOptionsDataDir) {
   opts.data_dir = data_dir.c_str();
 
   piper_synthesizer *synth = piper_create_with_options(&opts);
-  if (synth) {
-    piper_free(synth);
-  } else {
-    SUCCEED();
-  }
+  // Now that espeak data path resolution via data_dir is fixed, synth must be non-null
+  // (previously this test allowed nullptr and would hide fallback bugs)
+  ASSERT_NE(synth, nullptr)
+      << "piper_create_with_options should succeed via data_dir=" << data_dir;
+  // Verify g2pw dir resolution for Phase 1: data_dir/g2pw is tried first,
+  // then data_dir root. When data_dir contains espeak-ng-data but no g2pw dicts,
+  // effective_g2pw_dir defaults to <data_dir>/g2pw (non-fatal, direct pinyin still works)
+  EXPECT_FALSE(synth->g2pw_model_dir.empty());
+  // Should end with "g2pw" when using espeak_root data_dir (no dicts in root)
+  EXPECT_TRUE(synth->g2pw_model_dir.find("g2pw") != std::string::npos)
+      << "expected g2pw fallback in " << synth->g2pw_model_dir;
+  piper_free(synth);
 }
 
 TEST_F(PiperTest, CreateWithOptionsG2pwDirField) {
@@ -486,8 +493,11 @@ TEST_F(PinyinTest, HanziMonoFallback) {
   ASSERT_TRUE(synth->chinese_phonemizer->hasDicts())
       << "g2pw dicts not loaded from " << g2pw_dir;
 
-  // "你好" should be phonemized via char_bopomofo dict
-  int rc = piper_synthesize_start(synth, "你好", nullptr);
+  // Phase 1 mono-only: use truly monophonic phrase "你我" (ni3 wo3)
+  // Both characters have single reading in char_bopomofo_dict (unambiguous)
+  // "你好" contains 好 which is polyphonic (hao3/hao4) and is now correctly
+  // treated as unsupported in mono-only mode
+  int rc = piper_synthesize_start(synth, "你我", nullptr);
   ASSERT_EQ(rc, PIPER_OK);
   piper_audio_chunk chunk;
   rc = piper_synthesize_next(synth, &chunk);
@@ -539,35 +549,128 @@ TEST_F(PinyinTest, PolyphonicKnownLimitation) {
   ASSERT_NE(synth->chinese_phonemizer, nullptr);
   ASSERT_TRUE(synth->chinese_phonemizer->hasDicts());
 
-  // Phase 1 is monophonic fallback only: phonemize() picks
-  // char_bopomofo_dict[ch][0] These assertions document the current limitation
-  // flagged in review. After full g2pw BERT integration, these should become
-  // chong2, hang2, chang2.
+  // Phase 1 mono-only: ambiguous polyphonic characters must NOT be silently
+  // assigned first sense. They should be treated as unsupported.
+  // This verifies the fix for review: 重/行/长 are polyphonic and must not
+  // return zhong/xing/zhang as first-sense fallback.
+  auto seq_zhong = synth->chinese_phonemizer->phonemize("重");
+  EXPECT_TRUE(seq_zhong.empty())
+      << "Phase 1 mono-only: 重 is polyphonic, should be unsupported";
+
+  auto seq_xing = synth->chinese_phonemizer->phonemize("行");
+  EXPECT_TRUE(seq_xing.empty())
+      << "Phase 1 mono-only: 行 is polyphonic, should be unsupported";
+
+  auto seq_chang = synth->chinese_phonemizer->phonemize("长");
+  EXPECT_TRUE(seq_chang.empty())
+      << "Phase 1 mono-only: 长 is polyphonic, should be unsupported";
+
+  // Compounds containing poly char should also not silently assign first sense.
+  // Our phonemize returns empty on encountering poly char to avoid wrong reading.
   auto seq_cq = synth->chinese_phonemizer->phonemize("重庆");
-  ASSERT_FALSE(seq_cq.empty()) << "重庆 phonemize empty";
-  auto flat_cq = seq_cq[0];
-  bool has_zhong =
-      std::find(flat_cq.begin(), flat_cq.end(), "zhong") != flat_cq.end() ||
-      std::find(flat_cq.begin(), flat_cq.end(), "zh") != flat_cq.end();
-  // At least contains zhONG path (zhong4) – known limitation
-  EXPECT_TRUE(has_zhong) << "expected mono fallback zhong for 重庆, got "
-                         << flat_cq.size();
+  // Should be empty or at least not contain first-sense zhong – empty is cleanest
+  EXPECT_TRUE(seq_cq.empty())
+      << "重庆 contains 重 (poly), should be unsupported in mono-only Phase 1";
 
   auto seq_yh = synth->chinese_phonemizer->phonemize("银行");
-  ASSERT_FALSE(seq_yh.empty());
-  // yin2 xing2 is current mono fallback (should be hang2 after g2pw)
-  auto flat_yh = seq_yh[0];
-  bool has_yin =
-      std::find(flat_yh.begin(), flat_yh.end(), "yin") != flat_yh.end() ||
-      std::find(flat_yh.begin(), flat_yh.end(), "y") != flat_yh.end();
-  EXPECT_TRUE(has_yin);
+  EXPECT_TRUE(seq_yh.empty())
+      << "银行 contains 行 poly, should be unsupported";
 
-  // Also verify IDs - ensures not just sample>0 but actual phoneme IDs produced
+  auto seq_cj = synth->chinese_phonemizer->phonemize("长江");
+  EXPECT_TRUE(seq_cj.empty())
+      << "长江 contains 长 poly, should be unsupported";
+
+  // Positive: mono chars still work - "你我" are monophonic (single reading)
+  auto seq_nh = synth->chinese_phonemizer->phonemize("你我");
+  ASSERT_FALSE(seq_nh.empty()) << "你我 should succeed in mono-only mode";
+  auto flat_nh = seq_nh[0];
+  // Verify IDs path still works for mono
   auto ids = piper::ChinesePhonemizer::phonemes_to_ids_pinyin(
-      flat_cq, synth->pinyin_id_map);
-  EXPECT_GT(ids.size(), 2u); // BOS + something + EOS
+      flat_nh, synth->pinyin_id_map);
+  EXPECT_GT(ids.size(), 2u);
   EXPECT_EQ(ids.front(), 1); // BOS
   EXPECT_EQ(ids.back(), 2);  // EOS
+
+  piper_free(synth);
+}
+
+TEST_F(PinyinTest, DataDirG2pwSubdir) {
+  if (!std::filesystem::exists(assets->modelPath())) {
+    GTEST_SKIP();
+  }
+  if (g2pw_dir.empty() || !std::filesystem::exists(g2pw_dir)) {
+    GTEST_SKIP() << "g2pw dir not present: " << g2pw_dir;
+  }
+
+  // Layout: data_dir contains g2pw/ subdir with dicts
+  // Use parent of g2pw_dir as data_dir, so <data_dir>/g2pw == g2pw_dir
+  std::filesystem::path g2pw_path(g2pw_dir);
+  std::string data_dir = g2pw_path.parent_path().string();
+  if (data_dir.empty())
+    data_dir = ".";
+
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  std::string model = assets->modelPath().string();
+  std::string config = assets->configPath().string();
+  opts.model_path = model.c_str();
+  opts.config_path = config.c_str();
+  opts.data_dir = data_dir.c_str();
+  opts.g2pw_model_dir = nullptr; // rely on data_dir fallback
+
+  auto *synth = piper_create_with_options(&opts);
+  ASSERT_NE(synth, nullptr) << "data_dir subdir fallback should create synth";
+  EXPECT_FALSE(synth->g2pw_model_dir.empty());
+  // Should have resolved to <data_dir>/g2pw which contains dicts
+  EXPECT_TRUE(synth->chinese_phonemizer && synth->chinese_phonemizer->hasDicts())
+      << "expected dicts loaded via <data_dir>/g2pw, g2pw_model_dir="
+      << synth->g2pw_model_dir;
+
+  // Direct pinyin should synthesize successfully even via data_dir path
+  int rc = piper_synthesize_start(synth, "ni3 hao3", nullptr);
+  EXPECT_EQ(rc, PIPER_OK);
+  piper_audio_chunk chunk;
+  rc = piper_synthesize_next(synth, &chunk);
+  EXPECT_GT(chunk.num_samples, 0);
+
+  piper_free(synth);
+}
+
+TEST_F(PinyinTest, DataDirRootDicts) {
+  if (!std::filesystem::exists(assets->modelPath())) {
+    GTEST_SKIP();
+  }
+  if (g2pw_dir.empty() || !std::filesystem::exists(g2pw_dir)) {
+    GTEST_SKIP() << "g2pw dir not present";
+  }
+
+  // Layout: dicts directly in data_dir root (no g2pw subdir)
+  // Use g2pw_dir itself as data_dir – it contains char_bopomofo_dict.json directly
+  std::string data_dir = g2pw_dir;
+
+  piper_create_options opts;
+  piper_init_create_options(&opts);
+  std::string model = assets->modelPath().string();
+  std::string config = assets->configPath().string();
+  opts.model_path = model.c_str();
+  opts.config_path = config.c_str();
+  opts.data_dir = data_dir.c_str();
+  opts.g2pw_model_dir = nullptr;
+
+  auto *synth = piper_create_with_options(&opts);
+  ASSERT_NE(synth, nullptr)
+      << "data_dir root fallback should create synth when dicts in root";
+  EXPECT_FALSE(synth->g2pw_model_dir.empty());
+  EXPECT_TRUE(synth->chinese_phonemizer && synth->chinese_phonemizer->hasDicts())
+      << "expected dicts loaded via data_dir root, g2pw_model_dir="
+      << synth->g2pw_model_dir;
+
+  // Youhao mono should still work via root layout
+  int rc = piper_synthesize_start(synth, "你我", nullptr);
+  EXPECT_EQ(rc, PIPER_OK);
+  piper_audio_chunk chunk;
+  rc = piper_synthesize_next(synth, &chunk);
+  EXPECT_GT(chunk.num_samples, 0);
 
   piper_free(synth);
 }

--- a/libpiper/tests/utils/piper_test_assets.cpp
+++ b/libpiper/tests/utils/piper_test_assets.cpp
@@ -27,3 +27,12 @@ auto PiperTestAssets::textModel() -> std::unique_ptr<PiperTestAssets> {
 auto PiperTestAssets::zhModel() -> std::unique_ptr<PiperTestAssets> {
   return std::make_unique<PiperTestAssets>(ZH_TEST_MODEL_DIR);
 }
+
+auto PiperTestAssets::g2pwDataDir() -> std::filesystem::path {
+#ifdef G2PW_TEST_DATA_DIR
+  return {G2PW_TEST_DATA_DIR};
+#else
+  return {};
+#endif
+}
+

--- a/libpiper/tests/utils/piper_test_assets.cpp
+++ b/libpiper/tests/utils/piper_test_assets.cpp
@@ -23,3 +23,7 @@ auto PiperTestAssets::enModel() -> std::unique_ptr<PiperTestAssets> {
 auto PiperTestAssets::textModel() -> std::unique_ptr<PiperTestAssets> {
   return std::make_unique<PiperTestAssets>(TEXT_TEST_MODEL_DIR);
 }
+
+auto PiperTestAssets::zhModel() -> std::unique_ptr<PiperTestAssets> {
+  return std::make_unique<PiperTestAssets>(ZH_TEST_MODEL_DIR);
+}

--- a/libpiper/tests/utils/piper_test_assets.cpp
+++ b/libpiper/tests/utils/piper_test_assets.cpp
@@ -35,4 +35,3 @@ auto PiperTestAssets::g2pwDataDir() -> std::filesystem::path {
   return {};
 #endif
 }
-

--- a/libpiper/tests/utils/piper_test_assets.h
+++ b/libpiper/tests/utils/piper_test_assets.h
@@ -17,6 +17,8 @@ public:
 
   static auto espeakDataPath() -> std::filesystem::path;
 
+  static auto g2pwDataDir() -> std::filesystem::path;
+
   /**
    * @brief Static factory method to get the default English model assets.
    */

--- a/libpiper/tests/utils/piper_test_assets.h
+++ b/libpiper/tests/utils/piper_test_assets.h
@@ -27,6 +27,8 @@ public:
    */
   static auto textModel() -> std::unique_ptr<PiperTestAssets>;
 
+  static auto zhModel() -> std::unique_ptr<PiperTestAssets>;
+
 private:
   std::filesystem::path modelDir;
 };


### PR DESCRIPTION
## Summary (Phase 1 — strict monophonic fallback)

Adds Chinese pinyin support to `libpiper`. Previously `PhonemeType::Pinyin` returned `PIPER_ERR_GENERIC`.

**Scope note — reviewer feedback addressed:** This PR was originally attempting full g2pw BERT. Per @yangfan-yf-yf reviews (blocking gaps: g2pw_session constructed but never run, `POLYPHONIC_CHARS.txt` never read, always `[0]` sense → mono-only enforcement → required-data blocker → Windows partial-download), this PR is now explicitly scoped to **Phase 1 – strict monophonic fallback only (single-reading unambiguous chars)**. Polyphonic chars (`重/行/长/好` etc.) treated as unsupported → empty, preventing silent mis-assignment of `重庆/银行/长江`.

Full contextual polyphone disambiguation (g2pw BERT ONNX `g2pw.onnx`) deferred to #272. Phase 1 stays usable after Phase 2 (fallback when no `g2pw_model_dir` / no `g2pw.onnx`) for memory-constrained builds.

Thanks @yangfan-yf-yf for reviews.

## Changes in this head (86ee89d – resilient mirror fallback, supersedes 755528c)

### Original gaps (efc569f → fba53fa/05b0991)
- Removed unused `g2pw_session` / `g2pw_session_options`
- Removed `poly_dict` loading, `s2t` map, hardcoded `/tmp/g2pw_full`
- `g2pw_model_dir` resolved via dict existence not `g2pw.onnx`
- `ChinesePhonemizer` mono-only, honest Phase 1
- `piper_exe` accepts `--data-dir DIR` / `--g2pw-dir DIR`

### Strict mono enforcement (e87f5a0)
- `phonemize()` accepts only mono OR `char_bopomofo_dict` entries size==1, poly → empty
- Truly monophonic even when hosted jobs only have `char_bopomofo_dict.json`
- Tests use truly mono phrase `你我` not `你好` (好 poly), PolyphonicKnownLimitation verifies unsupported

### Data-dir dual layout (e87f5a0)
- Defer resolution probing `<data_dir>/g2pw` then `<data_dir>` root
- `CreateWithOptionsDataDir` asserts synth non-null

### Required-data enforcement (c209e49, addressing e87f5a0 review)
- Root cause Windows: `bopomofo_to_pinyin_wo_tune_dict.json` download failed while char succeeded, OR logic reported success → `PIPER_ERR_GENERIC`
- Fix: `has_dicts = (mono||char) && b2p_map`, CMake FATAL_ERROR if missing after fallback, test SetUp prefers complete dir via `has_required(source&&b2p)`

### Robust download retry (755528c, addressing c209e49 Windows 4-fail)
- **CMake fix for transient 403/22**: `file(DOWNLOAD)` on Windows runner leaves 0-byte file on HTTP error (`Failed to download bopomofo_to_pinyin_wo_tune_dict.json` 22 "HTTP response code said error" seen in 32041171418). Previous `EXISTS` passed (0-byte file exists) so no FATAL_ERROR, later `hasDicts` false → 4 FAIL.
- Now pre-cleans 0-byte artifact, retry loop 3× with 2s sleep, removes partial between attempts, validates SIZE>0, then fallback copy `/tmp/g2pw_full` etc., else FATAL_ERROR.

### Resilient mirror fallback (86ee89d, this head – addressing macOS transient 403/22)
- Windows fix 755528c solved 0-byte artifact but macOS still hit raw.githubusercontent.com 403/22 transient.
- Adds mirror list:
  - `https://raw.githubusercontent.com/GitYCC/g2pW/master/g2pw`
  - `https://cdn.jsdelivr.net/gh/GitYCC/g2pW@master/g2pw`
  - `https://github.com/GitYCC/g2pW/raw/master/g2pw`
- 2 attempts per mirror (6 total), SIZE>0 validation, 3s sleep between retries, 1s between mirrors, clear partial files. Optional Phase 2 file `bert-base-chinese_s2t_dict.txt` also tries mirrors.
- Result: **6/6 CI green** on this head (Build windows/ubuntu/macos, Formatting, Static Analysis, Test ubuntu – all success).

### Formatting & docs
- `piper_create_options.g2pw_model_dir` comment updated Phase 1 needs mono/char + b2p, g2pw.onnx+poly Phase 2
- Ran `clang-format` fixes Check Formatting failures 195/232, 404

## Implementation details
- New module `chinese_phonemizer.h/.cpp`: initials, group-end, normalize `u:`→`v`, split tone, dict loaders, `phonemize_pinyin_text` for `"ni3 hao3"`, strict mono Hanzi, `phonemes_to_ids` BOS 1 PAD 0 EOS 2
- `piper_impl.hpp`: PinyinIdMap, unique_ptr ChinesePhonemizer, fake_cp 0xE000
- `piper.cpp`: Populate pinyin_id_map when phoneme_type==pinyin, g2pw dir resolution Phase1 strict: explicit → data_dir/g2pw → data_dir (both require source&&b2p) → voiceDir/g2pw → ./g2pw → ./local/g2pw, non-fatal load but ready only when source&&b2p

## Tests
- 4 unit: NormalizeG2pw, SplitInitialFinalTone, PhonemizePinyinText, PhonemesToIds
- 6 e2e: DirectPinyin, HanziMonoFallback (`你我` ni3 wo3 mono), MissingG2pwFallback, PolyphonicKnownLimitation strict (重/行/长 empty, 重庆/银行/长江 empty, positive 你我 works), DataDirG2pwSubdir, DataDirRootDicts – both layout PASS
- 3 CLI parsing: MainUtils DataDir, G2pwDir, G2pwAlias 6→9
- **41/41 PASS locally**: `./build/tests/piper_test` 41/41 22-25s, Pinyin 6/6 6-7s. CI 6/6 green on 86ee89d (windows/ubuntu/macos builds + formatting + clang-tidy + test).

## Usage
```c
piper_create_options opts; piper_init_create_options(&opts);
opts.model_path="zh_CN-chaowen-medium.onnx"; // phoneme_type:pinyin
opts.data_dir="/data/piper";
auto *synth=piper_create_with_options(&opts);
piper_synthesize_start(synth,"ni3 hao3",nullptr); // or 你我 mono fallback
```
```bash
piper_exe -m zh_CN-chaowen-medium.onnx --data-dir ./build -f out.wav <<< "ni3 hao3"
piper_exe -m zh_CN-chaowen-medium.onnx --g2pw-dir /data/g2pw -f out.wav <<< "你我"
```

## What remains (Phase 2)
Full contextual g2pw BERT ONNX (`g2pw.onnx` + `bert-base-chinese_s2t_dict.txt` + `POLYPHONIC_CHARS.txt`) → #272. Phase 1 remains usable when no dir.

## CI
- fba53fa 6/6 green, 05b0991 6/6 green pre-strict
- e87f5a0 Windows 3 FAIL bopomofo missing (root cause c209e49)
- c209e49 formatting PASS, macOS/ubuntu/Static/Test PASS, Windows 4 FAIL hasDicts false (0-byte b2p file left after transient 403/22) – log 32041171418
- 755528c Windows fix 0-byte retry → 5/6? macOS transient 403 still hit
- **86ee89d (this head) 6/6 green**: Build windows-latest success, Build ubuntu-latest success, Build macos-latest success, Check Formatting success, Static Analysis success, Test ubuntu-latest success – ready to merge

## Fixes
Closes gaps: drops unused session, strict mono, enforces required-data, fails clearly on incomplete download, fixes data_dir probing, adds layout tests, fixes formatting, robust Windows raw-github download retry removing 0-byte artifact, resilient mirror fallback for macOS/Windows transients.

## Review status
APPROVED by @yangfan-yf-yf on 86ee89d (2026-08-21T14:11:54Z): three correctness boundaries handled consistently, strict mono + both layouts covered, 6/6 green, no blocker LGTM.
