### PR TITLE
Add Japanese phonemizer (OpenJTalk + pitch accent -> IPA)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,9 @@ setup(
             "torch>=2,<3",
             "requests>=2,<3",
         ],
+        "ja": [
+            "pyopenjtalk-plus>=0.4,<1",
+        ],
     },
     packages=[
         "piper",

--- a/src/piper/config.py
+++ b/src/piper/config.py
@@ -16,6 +16,7 @@ class PhonemeType(str, Enum):
     TEXT = "text"
     PINYIN = "pinyin"  # zh-CN
     HEBREW = "hebrew"  # he-IL: Nakdimon niqqud + IPA G2P
+    JAPANESE = "japanese"  # ja-JP: OpenJTalk + pitch accent -> IPA
 
 
 @dataclass

--- a/src/piper/phonemize_japanese.py
+++ b/src/piper/phonemize_japanese.py
@@ -1,0 +1,343 @@
+"""Japanese phonemization: OpenJTalk full-context labels -> IPA + prosody symbols.
+
+espeak-ng's Japanese voice has no kanji coverage at all: it falls back to reading
+Unicode character names, so 今日 becomes the phonemes for "Chinese letter"
+(twice). It also mis-reads the topic particles は/へ as "ha"/"he" even for
+kana-only input, and it carries no pitch accent. Instead we use OpenJTalk
+(pyopenjtalk), which does full morphological analysis and gives correct readings
+plus accent information.
+
+Pitch accent is the dominant naturalness lever in Japanese TTS, so we don't stop
+at segmental phonemes. OpenJTalk's full-context labels are parsed into the
+accent-annotated form used by ESPnet's `pyopenjtalk_prosody` G2P, then mapped to
+IPA so the output uses Piper's default phoneme id map. That keeps Japanese voices
+compatible with the IPA-based (espeak) warmstart, the same trick
+:mod:`piper.phonemize_hebrew` uses.
+
+Prosody symbols (all present in the default id map):
+
+- ``↑``  accent rise (low -> high, within an accent phrase)
+- ``↓``  accent fall (the accent nucleus)
+- ``#``  accent phrase boundary
+- ``,``  pause (OpenJTalk ``pau``, e.g. from 、)
+- ``.``  end of a declarative sentence
+- ``?``  end of an interrogative sentence
+
+ESPnet spells the last three ``_``, ``$`` and ``?``. We avoid ``_`` and ``$``
+because Piper reserves them for padding and end-of-sentence
+(see :mod:`piper.const`).
+"""
+
+import logging
+import re
+from typing import Dict, List, Optional, Sequence
+
+_LOGGER = logging.getLogger(__name__)
+
+# Prosody symbols. Chosen so they already have ids in DEFAULT_PHONEME_ID_MAP.
+ACCENT_RISE = "↑"
+ACCENT_FALL = "↓"
+ACCENT_PHRASE_BOUNDARY = "#"
+PAUSE = ","
+DECLARATIVE_END = "."
+INTERROGATIVE_END = "?"
+
+PROSODY_SYMBOLS = frozenset(
+    {
+        ACCENT_RISE,
+        ACCENT_FALL,
+        ACCENT_PHRASE_BOUNDARY,
+        PAUSE,
+        DECLARATIVE_END,
+        INTERROGATIVE_END,
+    }
+)
+
+# OpenJTalk phone -> IPA. Palatalized consonants uniformly use ʲ rather than
+# their closest single-symbol equivalents (ny -> nʲ, not ɲ) to keep the series
+# consistent. Long vowels stay as two identical vowels because Japanese counts
+# them as two morae, and mora timing is what the duration predictor should see.
+OPENJTALK_TO_IPA: Dict[str, str] = {
+    # Vowels
+    "a": "a",
+    "i": "i",
+    "u": "ɯ",  # compressed close back unrounded, not [u]
+    "e": "e",
+    "o": "o",
+    # Consonants
+    "k": "k",
+    "ky": "kʲ",  # キャ
+    "kw": "kʷ",  # クヮ
+    "g": "ɡ",
+    "gy": "ɡʲ",  # ギャ
+    "gw": "ɡʷ",  # グヮ
+    "s": "s",
+    "sh": "ɕ",  # シ
+    "z": "z",
+    "j": "dʑ",  # ジャ
+    "t": "t",
+    "ts": "ts",  # ツ
+    "ty": "tʲ",  # テャ
+    "ch": "tɕ",  # チ
+    "d": "d",
+    "dy": "dʲ",  # デャ
+    "n": "n",
+    "ny": "nʲ",  # ニャ
+    "h": "h",
+    "hy": "hʲ",  # ヒャ
+    "f": "ɸ",  # フ
+    "b": "b",
+    "by": "bʲ",  # ビャ
+    "p": "p",
+    "py": "pʲ",  # ピャ
+    "m": "m",
+    "my": "mʲ",  # ミャ
+    "y": "j",  # ヤ
+    "r": "ɾ",
+    "ry": "ɾʲ",  # リャ
+    "w": "w",
+    "v": "v",  # ヴ
+    # Specials
+    "N": "ɴ",  # ん (moraic nasal)
+    "cl": "ʔ",  # っ (geminate closure)
+}
+
+# OpenJTalk marks devoiced vowels with an uppercase letter (desU = です).
+DEVOICED_VOWELS = frozenset({"A", "I", "U", "E", "O"})
+
+# Vowels and moraic phones that can carry an accent phrase boundary.
+_MORA_FINAL_PHONES = frozenset(
+    {"a", "i", "u", "e", "o", "A", "I", "U", "E", "O", "N", "cl"}
+)
+
+# Sentence-final punctuation, taking any trailing closing brackets/quotes and
+# whitespace with it. OpenJTalk itself only turns these into a `pau`, so we split
+# first to get one audio chunk per sentence.
+_SENTENCE_END_PATTERN = re.compile(r"[。．！？!?]+[」』）】〉》”’\"')\]\s]*")
+
+_CURRENT_PHONE_PATTERN = re.compile(r"\-(.*?)\+")
+
+# "no match" sentinel for the numeric label fields, matching ESPnet's choice.
+_NO_FEATURE = -50
+
+
+class JapanesePhonemizer:
+    """Phonemize Japanese text with OpenJTalk, including pitch accent."""
+
+    def __init__(
+        self,
+        drop_devoiced_vowels: bool = True,
+        use_marine: bool = False,
+    ) -> None:
+        """Initialize phonemizer.
+
+        :param drop_devoiced_vowels: Fold OpenJTalk's devoiced vowels (A I U E O)
+            into their voiced counterparts. Devoicing is largely predictable from
+            context, so keeping it mainly enlarges the phoneme inventory.
+        :param use_marine: Use the neural `marine` model to estimate accent
+            instead of OpenJTalk's rules. More accurate on compound words, but
+            requires ``pip install marine``.
+        """
+        import pyopenjtalk
+
+        self.pyopenjtalk = pyopenjtalk
+        self.drop_devoiced_vowels = drop_devoiced_vowels
+        self.use_marine = use_marine
+
+        if use_marine:
+            try:
+                pyopenjtalk.load_marine_model()
+            except Exception as exc:  # pragma: no cover
+                raise RuntimeError(
+                    "Failed to load the marine accent model. "
+                    "Install it with 'pip install marine'."
+                ) from exc
+
+    def phonemize(self, text: str) -> List[List[str]]:
+        """Return IPA phonemes with prosody symbols, grouped by sentence.
+
+        Each phoneme is a single codepoint, matching how espeak phonemes are
+        keyed in :data:`piper.phoneme_ids.DEFAULT_PHONEME_ID_MAP`.
+        """
+        all_phonemes: List[List[str]] = []
+
+        for sentence_phones in self.phonemize_openjtalk(text):
+            ipa_phonemes: List[str] = []
+
+            for phone in sentence_phones:
+                if phone in PROSODY_SYMBOLS:
+                    ipa_phonemes.append(phone)
+                    continue
+
+                ipa = OPENJTALK_TO_IPA.get(phone)
+                if ipa is None:
+                    _LOGGER.warning("No IPA mapping for OpenJTalk phone: %s", phone)
+                    continue
+
+                # Multi-symbol IPA (kʲ, tɕ, dʑ, ...) becomes separate phonemes.
+                ipa_phonemes.extend(ipa)
+
+            if ipa_phonemes:
+                all_phonemes.append(ipa_phonemes)
+
+        return all_phonemes
+
+    def phonemize_openjtalk(self, text: str) -> List[List[str]]:
+        """Return OpenJTalk phones with prosody symbols, grouped by sentence.
+
+        This is the intermediate representation, before the IPA mapping. It is
+        the readable form ("ky o o ↑ w a ..."), useful for inspecting accent
+        placement.
+        """
+        return [
+            phones
+            for sentence in _split_sentences(text)
+            if (phones := self._phonemize_sentence(sentence))
+        ]
+
+    def _phonemize_sentence(self, sentence: str) -> List[str]:
+        """Parse one sentence's full-context labels into phones + prosody."""
+        try:
+            if self.use_marine:
+                njd_features = self.pyopenjtalk.run_frontend(sentence, run_marine=True)
+            else:
+                njd_features = self.pyopenjtalk.run_frontend(sentence)
+
+            labels = self.pyopenjtalk.make_label(njd_features)
+        except Exception:
+            _LOGGER.exception("Failed to phonemize sentence: %s", sentence)
+            return []
+
+        num_labels = len(labels)
+        phones: List[str] = []
+
+        for label_idx, label in enumerate(labels):
+            match = _CURRENT_PHONE_PATTERN.search(label)
+            if match is None:
+                continue
+
+            phone = match.group(1)
+            if self.drop_devoiced_vowels and (phone in DEVOICED_VOWELS):
+                phone = phone.lower()
+
+            if phone == "sil":
+                # Utterance boundary. The leading one needs no symbol (Piper
+                # prepends BOS itself); the trailing one carries the intonation.
+                if label_idx == (num_labels - 1):
+                    # E:<f1>_<f2>!<e3>_... where e3 == 1 marks a question.
+                    is_question = _numeric_feature(r"!(\d+)_", label) == 1
+                    phones.append(INTERROGATIVE_END if is_question else DECLARATIVE_END)
+
+                continue
+
+            if phone == "pau":
+                phones.append(PAUSE)
+                continue
+
+            phones.append(phone)
+
+            if label_idx >= (num_labels - 1):
+                # No following label to compare accent position against.
+                continue
+
+            # A: mora position within the accent phrase, relative to the accent
+            # nucleus. a1 == 0 means this mora *is* the nucleus.
+            a1 = _numeric_feature(r"/A:([0-9\-]+)\+", label)
+            a2 = _numeric_feature(r"\+(\d+)\+", label)
+            a3 = _numeric_feature(r"\+(\d+)/", label)
+
+            # F: number of morae in the current accent phrase.
+            f1 = _numeric_feature(r"/F:(\d+)_", label)
+
+            a2_next = _numeric_feature(r"\+(\d+)\+", labels[label_idx + 1])
+
+            if (a3 == 1) and (a2_next == 1) and (phone in _MORA_FINAL_PHONES):
+                # Last mora of this accent phrase, first mora of the next.
+                phones.append(ACCENT_PHRASE_BOUNDARY)
+            elif (a1 == 0) and (a2_next == (a2 + 1)) and (a2 != f1):
+                # Accent nucleus, and the phrase continues: pitch falls after.
+                phones.append(ACCENT_FALL)
+            elif (a2 == 1) and (a2_next == 2):
+                # Mora 1 -> 2 of an accent phrase: pitch rises.
+                phones.append(ACCENT_RISE)
+
+        return phones
+
+
+def _numeric_feature(pattern: str, label: str) -> int:
+    """Extract an integer field from a full-context label."""
+    match = re.search(pattern, label)
+    if match is None:
+        return _NO_FEATURE
+
+    try:
+        return int(match.group(1))
+    except ValueError:
+        # Unset fields are written "xx"
+        return _NO_FEATURE
+
+
+def _split_sentences(text: str) -> List[str]:
+    """Split text into sentences, keeping the final punctuation."""
+    sentences: List[str] = []
+    start = 0
+
+    for match in _SENTENCE_END_PATTERN.finditer(text):
+        if _is_decimal_point(text, match):
+            continue
+
+        sentence = text[start : match.end()].strip()
+        if sentence:
+            sentences.append(sentence)
+
+        start = match.end()
+
+    tail = text[start:].strip()
+    if tail:
+        sentences.append(tail)
+
+    return sentences
+
+
+def _is_decimal_point(text: str, match: "re.Match[str]") -> bool:
+    """True for the '.' in "1.5", which is not a sentence boundary."""
+    if match.group(0) != ".":
+        # Anything longer includes 。/！/？ or trailing space: a real boundary.
+        return False
+
+    before = text[match.start() - 1] if match.start() > 0 else ""
+    after = text[match.end()] if match.end() < len(text) else ""
+
+    return before.isdigit() and after.isdigit()
+
+
+def phonemize(
+    text: str,
+    drop_devoiced_vowels: bool = True,
+    use_marine: bool = False,
+) -> List[List[str]]:
+    """Phonemize Japanese text without holding onto a phonemizer instance."""
+    return JapanesePhonemizer(
+        drop_devoiced_vowels=drop_devoiced_vowels, use_marine=use_marine
+    ).phonemize(text)
+
+
+def missing_phonemes(
+    id_map: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Return any phoneme this module can emit that is not in the id map.
+
+    Useful as a sanity check before training: the output should be empty for
+    :data:`piper.phoneme_ids.DEFAULT_PHONEME_ID_MAP`.
+    """
+    if id_map is None:
+        from .phoneme_ids import DEFAULT_PHONEME_ID_MAP
+
+        id_map = list(DEFAULT_PHONEME_ID_MAP)
+
+    known = set(id_map)
+    emitted = set(PROSODY_SYMBOLS)
+    for ipa in OPENJTALK_TO_IPA.values():
+        emitted.update(ipa)
+
+    return sorted(emitted - known)

--- a/src/piper/train/infer_torch.py
+++ b/src/piper/train/infer_torch.py
@@ -49,6 +49,7 @@ def main() -> None:
     # Phonemizer is created lazily depending on phoneme type
     espeak_phonemizer = None
     chinese_phonemizer = None
+    japanese_phonemizer = None
 
     model = VitsModel.load_from_checkpoint(args.checkpoint, map_location="cpu")
 
@@ -82,6 +83,13 @@ def main() -> None:
                 chinese_phonemizer = ChinesePhonemizer(Path.cwd() / "g2pW")
 
             sentence_phonemes = chinese_phonemizer.phonemize(text)
+        elif config.phoneme_type == PhonemeType.JAPANESE:
+            from ..phonemize_japanese import JapanesePhonemizer
+
+            if japanese_phonemizer is None:
+                japanese_phonemizer = JapanesePhonemizer()
+
+            sentence_phonemes = japanese_phonemizer.phonemize(text)
         else:
             if espeak_phonemizer is None:
                 espeak_phonemizer = EspeakPhonemizer()

--- a/src/piper/train/vits/dataset.py
+++ b/src/piper/train/vits/dataset.py
@@ -237,6 +237,15 @@ class VitsDataModule(L.LightningDataModule):
             def phonemize(text: str) -> list[list[str]]:
                 return hebrew_phonemizer.phonemize(text)
 
+        elif self.phoneme_type == PhonemeType.JAPANESE:
+            from piper.phonemize_japanese import JapanesePhonemizer
+
+            # OpenJTalk -> IPA + pitch accent (default IPA id map)
+            japanese_phonemizer = JapanesePhonemizer()
+
+            def phonemize(text: str) -> list[list[str]]:
+                return japanese_phonemizer.phonemize(text)
+
         elif self.phoneme_type == PhonemeType.TEXT:
             # text = phonemes
 

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -234,6 +234,17 @@ class PiperVoice:
 
             return phonemizer.phonemize(text)
 
+        if self.config.phoneme_type == PhonemeType.JAPANESE:
+            from .phonemize_japanese import JapanesePhonemizer
+
+            # OpenJTalk -> IPA + pitch accent (default IPA id map)
+            phonemizer = getattr(self, "_japanese_phonemizer", None)
+            if phonemizer is None:
+                phonemizer = JapanesePhonemizer()
+                setattr(self, "_japanese_phonemizer", phonemizer)
+
+            return phonemizer.phonemize(text)
+
         if self.config.phoneme_type != PhonemeType.ESPEAK:
             raise ValueError(f"Unexpected phoneme type: {self.config.phoneme_type}")
 

--- a/tests/test_japanese_phonemizer.py
+++ b/tests/test_japanese_phonemizer.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tests for Japanese phonemization: OpenJTalk + pitch accent -> IPA."""
+
+import pytest
+
+from piper.config import PhonemeType, PiperConfig
+from piper.phoneme_ids import DEFAULT_PHONEME_ID_MAP
+from piper.phonemize_japanese import (
+    ACCENT_FALL,
+    ACCENT_PHRASE_BOUNDARY,
+    ACCENT_RISE,
+    PROSODY_SYMBOLS,
+    JapanesePhonemizer,
+    missing_phonemes,
+)
+from piper.voice import PiperVoice
+
+pytest.importorskip("pyopenjtalk", reason="pyopenjtalk-plus is not installed")
+
+
+@pytest.fixture(scope="module")
+def phonemizer() -> JapanesePhonemizer:
+    return JapanesePhonemizer()
+
+
+def _openjtalk(phonemizer: JapanesePhonemizer, text: str) -> str:
+    """Readable single-sentence OpenJTalk form, e.g. "a ↓ m e"."""
+    sentences = phonemizer.phonemize_openjtalk(text)
+    assert len(sentences) == 1, sentences
+    return " ".join(sentences[0])
+
+
+def _segmental(phonemizer: JapanesePhonemizer, text: str) -> str:
+    """OpenJTalk phones only, with every prosody symbol stripped."""
+    return "".join(
+        phone
+        for phone in phonemizer.phonemize_openjtalk(text)[0]
+        if phone not in PROSODY_SYMBOLS
+    )
+
+
+def test_every_emitted_phoneme_is_in_default_map() -> None:
+    """Warmstart compat: nothing this module emits may be outside the IPA map."""
+    assert missing_phonemes() == []
+
+
+def test_phonemes_are_in_default_map(phonemizer: JapanesePhonemizer) -> None:
+    text = "今日はいい天気ですね。音楽を聞きたいです。何時に出発しますか？"
+    for sentence in phonemizer.phonemize(text):
+        for phoneme in sentence:
+            assert phoneme in DEFAULT_PHONEME_ID_MAP, repr(phoneme)
+
+
+def test_kanji_is_read_not_spelled(phonemizer: JapanesePhonemizer) -> None:
+    """The reason espeak-ng is unusable: it spells kanji out as letter names."""
+    # 東京 -> to-o-kyo-o, identical to the kana spelling.
+    assert _segmental(phonemizer, "東京") == "tookyoo"
+    assert _segmental(phonemizer, "東京") == _segmental(phonemizer, "とうきょう")
+    # 東 alone is "higashi", not "to" — this needs real morphological analysis.
+    assert _segmental(phonemizer, "東") == "higashi"
+
+
+def test_topic_particles(phonemizer: JapanesePhonemizer) -> None:
+    """は/へ as particles are wa/e, not ha/he (espeak-ng gets this wrong)."""
+    phones = _openjtalk(phonemizer, "私は学校へ行きます").split()
+    assert "w" in phones and "a" in phones
+    # は read as "ha" would put an 'h' immediately after "watashi"
+    assert _openjtalk(phonemizer, "私は").split()[:4] == ["w", "a", ACCENT_RISE, "t"]
+
+
+def test_accent_minimal_pair(phonemizer: JapanesePhonemizer) -> None:
+    """雨 (HL, accented on mora 1) vs 飴 (LH, unaccented)."""
+    assert _openjtalk(phonemizer, "雨が降る").startswith(f"a {ACCENT_FALL} m e")
+    assert _openjtalk(phonemizer, "飴が好き").startswith(f"a {ACCENT_RISE} m e")
+
+
+def test_accent_shows_on_following_particle(phonemizer: JapanesePhonemizer) -> None:
+    """橋 (LHL) and 端 (LHH) differ only once a particle follows."""
+    assert _openjtalk(phonemizer, "橋") == _openjtalk(phonemizer, "端")
+    assert ACCENT_FALL in _openjtalk(phonemizer, "橋の")
+    assert ACCENT_FALL not in _openjtalk(phonemizer, "端の")
+
+
+def test_accent_phrase_boundary(phonemizer: JapanesePhonemizer) -> None:
+    phones = _openjtalk(phonemizer, "今日はいい天気ですね。")
+    assert ACCENT_PHRASE_BOUNDARY in phones
+
+
+def test_question_vs_statement(phonemizer: JapanesePhonemizer) -> None:
+    assert _openjtalk(phonemizer, "そうですか？").endswith("?")
+    assert _openjtalk(phonemizer, "そうです。").endswith(".")
+    # No punctuation at all still gets a declarative marker.
+    assert _openjtalk(phonemizer, "そうです").endswith(".")
+
+
+def test_numbers_are_expanded(phonemizer: JapanesePhonemizer) -> None:
+    """OpenJTalk reads digits natively: 123円 -> hyaku nijuu san en."""
+    assert _segmental(phonemizer, "123円") == "hyakunijuusaNeN"
+
+
+def test_sentence_splitting(phonemizer: JapanesePhonemizer) -> None:
+    assert len(phonemizer.phonemize("今日はいい天気ですね。明日は雨です。")) == 2
+    assert len(phonemizer.phonemize("えっ、そうですか？やった！")) == 2
+    # 、 is a pause inside one sentence, not a split.
+    assert len(phonemizer.phonemize("えっ、そうですか？")) == 1
+
+
+def test_decimal_point_is_not_a_sentence_break(phonemizer: JapanesePhonemizer) -> None:
+    assert len(phonemizer.phonemize("1.5リットルの水。")) == 1
+
+
+def test_devoiced_vowels_folded(phonemizer: JapanesePhonemizer) -> None:
+    """です ends in a devoiced u, which folds to plain u by default."""
+    assert _openjtalk(phonemizer, "そうです").endswith("d e s u .")
+
+    keep = JapanesePhonemizer(drop_devoiced_vowels=False)
+    assert "U" in " ".join(keep.phonemize_openjtalk("そうです")[0])
+
+
+def test_long_vowels_stay_two_morae(phonemizer: JapanesePhonemizer) -> None:
+    """とう is two morae; collapsing it to a length mark loses mora timing."""
+    # とうきょう -> t o o ky o o: four 'o', no ː length marks.
+    ipa = "".join(phonemizer.phonemize("東京")[0])
+    assert ipa.count("o") == 4
+    assert "ː" not in ipa
+
+
+def test_empty_and_punctuation_only(phonemizer: JapanesePhonemizer) -> None:
+    assert not phonemizer.phonemize("")
+    assert not phonemizer.phonemize("   ")
+
+
+def test_end_to_end_phonemize_ids() -> None:
+    config = PiperConfig(
+        num_symbols=256,
+        num_speakers=1,
+        sample_rate=22050,
+        espeak_voice="ja",
+        phoneme_id_map=DEFAULT_PHONEME_ID_MAP,
+        phoneme_type=PhonemeType.JAPANESE,
+    )
+    voice = PiperVoice(session=None, config=config)  # type: ignore[arg-type]
+    phonemes = voice.phonemize("今日はいい天気ですね。")
+    assert phonemes and phonemes[0]
+    ids = voice.phonemes_to_ids(phonemes[0])
+    assert ids and all(isinstance(i, int) for i in ids)


### PR DESCRIPTION
espeak-ng's Japanese voice has no kanji coverage: it falls back to reading Unicode character names, so 今日 becomes the phonemes for "Chinese letter". It also mis-reads the topic particles は/へ as "ha"/"he" on kana-only input and carries no pitch accent at all.

Use OpenJTalk (pyopenjtalk) instead, parsing its full-context labels into the accent-annotated form used by ESPnet's pyopenjtalk_prosody G2P, then mapping to IPA. Accent rise/fall/phrase-boundary become ↑/↓/#, which already have ids in the default phoneme map, so Japanese voices need no custom phoneme table and stay warmstart-compatible with the IPA (espeak) voices.

New phoneme_type=japanese, wired into inference, training and infer_torch. pyopenjtalk-plus is a new optional dependency under the 'ja' extra.