### PR TITLE
Release 1.7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Piper
         run: |
-          script/setup --dev --train --zh --torch-cpu
+          script/setup --dev --train --zh --ja --torch-cpu
           script/dev_build
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.7.0
+
+- Add Japanese phonemizer using OpenJTalk (`pyopenjtalk-plus`) in the new `ja` extra
+    - `--data.phoneme_type japanese` for training; `"phoneme_type": "japanese"` in a voice config for synthesis
+    - espeak-ng has no kanji coverage (it reads out Unicode character names) and no pitch accent
+    - Full-context labels are parsed for pitch accent and mapped to IPA, so Japanese voices stay compatible with the IPA-based (espeak) warmstart
+- Add `script/setup --ja`, and install the `ja` extra in CI so the Japanese tests run
+- `libpiper`: add `piper_create_options` and `piper_create_with_options()`, with `piper_create()` kept as a wrapper for ABI compatibility
+
 ## 1.6.1
 
 - Run the g2pW model through `piper.g2pw_onnx` instead of `g2pw.api`, dropping `torch` (~750 MB installed) and `requests` from the `zh` extra

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,12 @@
 [mypy]
+# Keeps the vendored VITS code out of directory crawling. Not enough on its own:
+# piper.train.__main__ and friends import piper.train.vits.*, and mypy follows
+# imports into excluded files, so the errors come back anyway. The ignore_errors
+# section below is what actually silences them.
 exclude = src/piper/train/vits
+
+[mypy-piper.train.vits.*]
+ignore_errors = True
 
 [mypy-onnxruntime.*]
 ignore_missing_imports = True

--- a/script/setup
+++ b/script/setup
@@ -14,6 +14,7 @@ parser.add_argument(
     "--train", action="store_true", help="Install training requirements"
 )
 parser.add_argument("--zh", action="store_true", help="Install Chinese requirements")
+parser.add_argument("--ja", action="store_true", help="Install Japanese requirements")
 parser.add_argument(
     "--torch-cpu", action="store_true", help="Install CPU-only version of PyTorch"
 )
@@ -51,6 +52,9 @@ if args.train:
 
 if args.zh:
     extras.append("zh")
+
+if args.ja:
+    extras.append("ja")
 
 extras_str = ""
 if extras:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ HTTP_DATA_FILES = [
 
 setup(
     name="piper-tts",
-    version="1.6.1",
+    version="1.7.0",
     description="Fast and local neural text-to-speech engine",
     url="http://github.com/OHF-voice/piper1-gpl",
     license="GPL-3.0-or-later",

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         "dev": [
             "black==24.8.0",
             "flake8==7.1.1",
+            "isort==5.13.2",  # used by script/lint and script/format
             "mypy==1.14.0",
             "pylint==3.2.7",
             "pytest==8.3.4",

--- a/src/piper/hebrew/hebrew_ipa.py
+++ b/src/piper/hebrew/hebrew_ipa.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-import unicodedata as _ud
+
 import re as _re
+import unicodedata as _ud
 from dataclasses import dataclass
 from typing import List, Tuple
 

--- a/src/piper/hebrew/hebrew_ipa.py
+++ b/src/piper/hebrew/hebrew_ipa.py
@@ -160,7 +160,7 @@ def _map_consonant(
     b = FINAL_FORM_BASE.get(base, base)
 
     # Silent letters and special cases
-    if b == ALEF or b == AYIN:
+    if b in (ALEF, AYIN):
         # Realize glottal stop only when it separates vowels or hosts its own vowel
         # Actual decision is postponed to vowel handling; here return placeholder
         return "<GLT>"  # may collapse later

--- a/src/piper/train/vits/dataset.py
+++ b/src/piper/train/vits/dataset.py
@@ -490,7 +490,7 @@ class VitsDataModule(L.LightningDataModule):
                 )
 
         full_dataset = VitsDataset(all_utts)
-        
+
         n = len(full_dataset)
         valid_set_size = int(n * self.validation_split)
         num_test = min(self.num_test_examples, max(0, n - valid_set_size - 1))
@@ -528,7 +528,9 @@ class VitsDataModule(L.LightningDataModule):
                 len(self.train_dataset),
                 self.batch_size,
             )
-        return self._make_dataloader(self.train_dataset, shuffle=True, drop_last=drop_last)
+        return self._make_dataloader(
+            self.train_dataset, shuffle=True, drop_last=drop_last
+        )
 
     def test_dataloader(self):
         return self._make_dataloader(self.test_dataset)

--- a/tests/test_chinese_phonemizer.py
+++ b/tests/test_chinese_phonemizer.py
@@ -3,14 +3,19 @@
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
-# Chinese phonemization requires the optional [zh] dependencies (g2pW, ...).
-# Skip the whole module if they are not installed.
-phonemize_chinese = pytest.importorskip("piper.phonemize_chinese")
-ChinesePhonemizer = phonemize_chinese.ChinesePhonemizer
-phonemes_to_ids = phonemize_chinese.phonemes_to_ids
+if TYPE_CHECKING:
+    # Real names for type checking, which doesn't need the deps installed.
+    from piper.phonemize_chinese import ChinesePhonemizer, phonemes_to_ids
+else:
+    # Chinese phonemization requires the optional [zh] dependencies (g2pW, ...).
+    # Skip the whole module if they are not installed.
+    phonemize_chinese = pytest.importorskip("piper.phonemize_chinese")
+    ChinesePhonemizer = phonemize_chinese.ChinesePhonemizer
+    phonemes_to_ids = phonemize_chinese.phonemes_to_ids
 
 PAD_ID = 0
 BOS_ID = 1

--- a/tests/test_hebrew_phonemizer.py
+++ b/tests/test_hebrew_phonemizer.py
@@ -19,13 +19,13 @@ _ORACLE = (
 )
 
 
-@pytest.fixture(scope="module")
-def diacritizer() -> NakdimonDiacritizer:
+@pytest.fixture(name="diacritizer", scope="module")
+def diacritizer_fixture() -> NakdimonDiacritizer:
     return NakdimonDiacritizer()
 
 
-@pytest.fixture(scope="module")
-def phonemizer() -> HebrewPhonemizer:
+@pytest.fixture(name="phonemizer", scope="module")
+def phonemizer_fixture() -> HebrewPhonemizer:
     return HebrewPhonemizer()
 
 

--- a/tests/test_japanese_phonemizer.py
+++ b/tests/test_japanese_phonemizer.py
@@ -18,8 +18,8 @@ from piper.voice import PiperVoice
 pytest.importorskip("pyopenjtalk", reason="pyopenjtalk-plus is not installed")
 
 
-@pytest.fixture(scope="module")
-def phonemizer() -> JapanesePhonemizer:
+@pytest.fixture(name="phonemizer", scope="module")
+def phonemizer_fixture() -> JapanesePhonemizer:
     return JapanesePhonemizer()
 
 


### PR DESCRIPTION
Prepares the 1.7.0 release.

## Changes

- **`script/setup --ja`** — installs the `ja` extra (`pyopenjtalk-plus`), matching the existing `--zh` flag.
- **CI** — `.github/workflows/test.yml` now runs `script/setup --dev --train --zh --ja --torch-cpu`. Without the extra installed, `tests/test_japanese_phonemizer.py` was being skipped wholesale by its `pytest.importorskip("pyopenjtalk")`; the 15 Japanese tests now actually run.
- **Version** bumped to 1.7.0 in `setup.py` (the only place it lives — `libpiper/CMakeLists.txt` parses it from there).
- **Changelog** entry for 1.7.0 covering the Japanese phonemizer (#274) and the `piper_create_options` refactor (#270), the two changes since 1.6.1.

## Lint fixes found while checking the release over

`script/lint` was failing on `main`. It now passes end to end:

- **`mypy.ini` exclude didn't work.** `exclude = src/piper/train/vits` only skips directory crawling, but `piper.train.__main__` and the export/infer modules import `piper.train.vits.*`, and mypy follows imports into excluded files — so all 92 errors came back anyway. Added `[mypy-piper.train.vits.*] ignore_errors = True`, which is what actually silences them, and commented the exclude.
- **`tests/test_chinese_phonemizer.py`** — the `importorskip` binding made `ChinesePhonemizer` a variable, which isn't valid as a type annotation (5 errors). The real names now come from a `TYPE_CHECKING` branch; runtime skip behavior is unchanged.
- **`isort` was missing from the `dev` extra**, though both `script/lint` and `script/format` invoke it — neither could run in a fresh `--dev` venv.
- **Pylint `W0621 redefined-outer-name`** — 19 instances in the Japanese and Hebrew tests, which declared fixtures under the same name their test parameters use. Both now follow the convention `test_chinese_phonemizer.py` already used: a `*_fixture` function plus `@pytest.fixture(name=...)`. Test signatures are unchanged. Also fixed the one remaining `R1714` in `hebrew_ipa.py`.
- **Formatting** — black on `src/piper/train/vits/dataset.py`, isort on `src/piper/hebrew/hebrew_ipa.py`. Whitespace and import order only.

## Verification

- `python3 -m pytest tests` — 46 passed, including all 15 Japanese tests.
- black, isort, flake8, mypy clean over `src/piper` and `tests`; pylint 10.00/10.
  - Pylint needs the espeakbridge extension built first (`script/dev_build`), otherwise it reports `E0611` against `src/piper/phonemize_espeak.py`.
- `pyopenjtalk-plus` has manylinux wheels for cp39–cp313, so `pip install piper-tts[ja]` resolves without a source build across the full `python_requires=">=3.9"` range (3.9 pins to `0.4.1.post8`, the last release with cp39 wheels; `0.4.1.post9` is `>=3.10`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
