### PR TITLE
Stop espeak-ng from truncating the data dir path (fixes #272)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,13 @@ ExternalProject_Add(espeak_ng_external
         -DUSE_SPEECHPLAYER:BOOL=OFF
         -DEXTRA_cmn:BOOL=ON
         -DEXTRA_ru:BOOL=ON
+        # N_PATH_HOME sizes espeak-ng's data directory buffer. It defaults to
+        # PATH_MAX on Linux but only 160 bytes elsewhere, and a longer path is
+        # silently truncated and replaced by the build-time PATH_ESPEAK_DATA.
+        #
         # Need to explicitly add ucd include directory for CI
-        "-DCMAKE_C_FLAGS=-D_FILE_OFFSET_BITS=64 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
-        "-DCMAKE_CXX_FLAGS=-D_FILE_OFFSET_BITS=64 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
+        "-DCMAKE_C_FLAGS=-D_FILE_OFFSET_BITS=64 -DN_PATH_HOME=4096 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
+        "-DCMAKE_CXX_FLAGS=-D_FILE_OFFSET_BITS=64 -DN_PATH_HOME=4096 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
     BUILD_BYPRODUCTS
         ${ESPEAKNG_STATIC_LIB}
         ${UCD_STATIC_LIB}

--- a/libpiper/CMakeLists.txt
+++ b/libpiper/CMakeLists.txt
@@ -52,9 +52,13 @@ ExternalProject_Add(espeak_ng_external
         -DUSE_SPEECHPLAYER:BOOL=OFF
         -DEXTRA_cmn:BOOL=ON
         -DEXTRA_ru:BOOL=ON
+        # N_PATH_HOME sizes espeak-ng's data directory buffer. It defaults to
+        # PATH_MAX on Linux but only 160 bytes elsewhere, and a longer path is
+        # silently truncated and replaced by the build-time PATH_ESPEAK_DATA.
+        #
         # Need to explicitly add ucd include directory for CI
-        "-DCMAKE_C_FLAGS=-D_FILE_OFFSET_BITS=64 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
-        "-DCMAKE_CXX_FLAGS=-D_FILE_OFFSET_BITS=64 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
+        "-DCMAKE_C_FLAGS=-D_FILE_OFFSET_BITS=64 -DN_PATH_HOME=4096 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
+        "-DCMAKE_CXX_FLAGS=-D_FILE_OFFSET_BITS=64 -DN_PATH_HOME=4096 -I${ESPEAKNG_BUILD_DIR}/src/espeak_ng_external/src/ucd-tools/src/include"
     BUILD_BYPRODUCTS
         ${ESPEAKNG_STATIC_LIB}
         ${UCD_STATIC_LIB}

--- a/tests/test_espeak_phonemizer.py
+++ b/tests/test_espeak_phonemizer.py
@@ -1,6 +1,16 @@
+import subprocess
+import sys
+from pathlib import Path
+
 from piper.phonemize_espeak import EspeakPhonemizer
 
 from . import EN_US_VOWEL_CLUSTERS
+
+_INITIALIZE_SCRIPT = """
+import sys
+from piper.phonemize_espeak import EspeakPhonemizer
+EspeakPhonemizer(sys.argv[1])
+"""
 
 
 def test_phonemize() -> None:
@@ -70,3 +80,22 @@ def test_vowel_clusters_without_terminator() -> None:
     assert phonemizer.phonemize("en-us", "my", vowel_clusters=EN_US_VOWEL_CLUSTERS) == [
         ["m", "ˈ", "aɪ"],
     ]
+
+
+def test_long_espeak_data_dir(tmp_path: Path) -> None:
+    """Data dir is used as given, even when its path is long."""
+    # espeak-ng sizes its data path buffer at 160 bytes off Linux and silently
+    # falls back to the build-time default when the path does not fit.
+    data_dir = tmp_path / ("d" * 200)
+    data_dir.mkdir()
+
+    # The directory is empty, so espeak-ng must fail on this exact path.
+    # It exits the process on failure, hence the subprocess.
+    result = subprocess.run(
+        [sys.executable, "-c", _INITIALIZE_SCRIPT, str(data_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert str(data_dir) in result.stderr


### PR DESCRIPTION
Fixes #272.

espeak-ng holds its data directory in a fixed buffer sized by `N_PATH_HOME`, which `speech.h` sets to `PATH_MAX` on Linux and **160 bytes everywhere else**. `check_data_path()` `snprintf()`s the caller's directory into it, so a longer path is silently truncated, the stat fails, and `espeak_ng_InitializePath()` falls through to the compile-time `PATH_ESPEAK_DATA`. On the published wheels that is the CI runner's build tree.

Bisecting the released 1.6.1 macOS arm64 wheel puts the cliff exactly there: a 159-byte data dir works, 160 fails. Beyond it, every call reports

```
Error processing file '/Users/runner/work/piper1-gpl/.../phontab': No such file or directory.
```

on the user's own machine, whatever `espeak_data_dir` they passed.

Building espeak-ng with `-DN_PATH_HOME=4096` gives every platform the buffer Linux already has. `speech.h` guards the definition with `#ifndef`, so this is the override upstream provides rather than a patch to vendored source, and every path buffer there is sized from `sizeof(path_home)`.

Applied at both `ExternalProject_Add(espeak_ng_external)` sites. `libpiper/` pins an older espeak-ng whose `N_PATH_HOME_DEF` is 160 on *all* POSIX targets, so it has the same defect on Linux.

This also unblocks the macOS source build, which failed compiling the phoneme data at `phsource/vwl_en_us_nyc/a_raised` (162 bytes in the external-project build tree).

The regression test is verified non-vacuous against the *published* wheel: it exits non-zero either way, but without the fix the error names the runner path instead of the directory passed in, so the `str(data_dir) in stderr` assertion fails.
