### PR TITLE
Make libpiper compilable alone on Debian 13

### DIFF
--- a/libpiper/README.md
+++ b/libpiper/README.md
@@ -56,10 +56,12 @@ int main() {
                            &options /* NULL for defaults */);
 
     piper_audio_chunk chunk;
-    while (piper_synthesize_next(synth, &chunk) != PIPER_DONE) {
+    auto status = PIPER_OK;
+    do {
+        status = piper_synthesize_next(synth, &chunk);
         audio_stream.write(reinterpret_cast<const char *>(chunk.samples),
                            chunk.num_samples * sizeof(float));
-    }
+    } while (PIPER_OK == status);
 
     piper_free(synth);
 

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -678,7 +678,8 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
     output_names_strs.reserve(count);
     Ort::AllocatorWithDefaultOptions allocator;
     for (size_t i = 0; i < count; ++i) {
-      output_names_strs.emplace_back(synth->session->GetOutputNameAllocated(i, allocator).get());
+      output_names_strs.emplace_back(
+          synth->session->GetOutputNameAllocated(i, allocator).get());
     }
   }
   std::vector<const char *> output_names;

--- a/libpiper/src/piper.cpp
+++ b/libpiper/src/piper.cpp
@@ -422,7 +422,16 @@ auto piper_synthesize_next(struct piper_synthesizer *synth,
                                              "sid"};
 
   // Get all output names
-  std::vector<std::string> output_names_strs = synth->session->GetOutputNames();
+  std::vector<std::string> output_names_strs;
+  {
+    const auto count = synth->session->GetOutputCount();
+    output_names_strs.reserve(count);
+    Ort::AllocatorWithDefaultOptions allocator;
+    for (size_t i = 0; i < count; ++i) {
+      output_names_strs.emplace_back(synth->session->GetOutputNameAllocated(i, allocator).get());
+    }
+  }
+
   std::vector<const char *> output_names;
   output_names.reserve(output_names_strs.size());
   for (const auto &name : output_names_strs) {


### PR DESCRIPTION
Packages libespeak-ng-dev, libonnxruntime-dev and nlohmann-json3-dev are enough to compile libpiper on Debian 13, with this first commit.

The second commit is more general, it fixes the libpiper example code.