### PR TITLE
Use full sha hash for espeak ng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 ExternalProject_Add(espeak_ng_external
     GIT_REPOSITORY https://github.com/espeak-ng/espeak-ng.git
-    GIT_TAG 724808c  # 2026-Apr-06
+    GIT_TAG 724808c5a83f9ef95fdd0db886ba7ba537ff224a  # 2026-Apr-06
     PREFIX ${ESPEAKNG_BUILD_DIR}
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${ESPEAKNG_INSTALL_DIR}


### PR DESCRIPTION
Tools like lucky-commit can easily produce a 7 character prefix and provoke a hash collision. Since GitHub shares commit hashes with all forks, I could just fork the repo, brute force a hash with the same prefix and then GitHub would serve a 404 for this shortened hash.

See one of my favorite blog posts https://blog.teddykatz.com/2019/11/12/github-actions-dos.html