### PR TITLE
feat(voice): auto-preload CUDA/cuDNN shared libraries when use_cuda=True

### DIFF
--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -150,6 +150,12 @@ class PiperVoice:
 
         providers: list[Union[str, tuple[str, dict[str, Any]]]]
         if use_cuda:
+            if hasattr(onnxruntime, "preload_dlls"):
+                try:
+                    onnxruntime.preload_dlls()
+                except Exception as error:
+                    _LOGGER.debug("Failed to preload CUDA DLLs: %s", error)
+
             providers = [
                 (
                     "CUDAExecutionProvider",

--- a/tests/test_piper.py
+++ b/tests/test_piper.py
@@ -6,7 +6,8 @@ import struct
 import sys
 import wave
 from pathlib import Path
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,6 +31,95 @@ def test_load_voice() -> None:
     assert voice.config.num_speakers == 1
     assert voice.config.phoneme_type == "espeak"
     assert voice.config.espeak_voice == "en-us"
+
+
+def test_load_voice_cuda_preloads_dlls() -> None:
+    """Test that use_cuda=True calls preload_dlls before creating InferenceSession."""
+    call_order: list[str] = []
+
+    def fake_preload() -> None:
+        call_order.append("preload")
+
+    def fake_session(*args: Any, **kwargs: Any) -> MagicMock:
+        call_order.append("session")
+        return MagicMock()
+
+    with (
+        patch(
+            "piper.voice.onnxruntime.preload_dlls",
+            side_effect=fake_preload,
+            create=True,
+        ) as mock_preload,
+        patch(
+            "piper.voice.onnxruntime.InferenceSession",
+            side_effect=fake_session,
+        ) as mock_session,
+    ):
+        PiperVoice.load(_TEST_VOICE, use_cuda=True)
+        assert mock_preload.call_count == 1
+        assert mock_session.call_count == 1
+        assert call_order == ["preload", "session"]
+        _args, kwargs = mock_session.call_args
+        assert kwargs["providers"] == [
+            (
+                "CUDAExecutionProvider",
+                {"cudnn_conv_algo_search": "HEURISTIC"},
+            )
+        ]
+
+
+def test_load_voice_cuda_without_preload_dlls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that older ONNX Runtime without preload_dlls retains the CUDA session path."""
+    import onnxruntime
+
+    monkeypatch.delattr(onnxruntime, "preload_dlls", raising=False)
+
+    with patch("piper.voice.onnxruntime.InferenceSession") as mock_session:
+        PiperVoice.load(_TEST_VOICE, use_cuda=True)
+        assert mock_session.call_count == 1
+        _args, kwargs = mock_session.call_args
+        assert kwargs["providers"] == [
+            (
+                "CUDAExecutionProvider",
+                {"cudnn_conv_algo_search": "HEURISTIC"},
+            )
+        ]
+
+
+def test_load_voice_cuda_preload_exception_resilient() -> None:
+    """Test that an exception during preload_dlls does not prevent session construction."""
+    with (
+        patch(
+            "piper.voice.onnxruntime.preload_dlls",
+            side_effect=RuntimeError("Preload failed"),
+            create=True,
+        ) as mock_preload,
+        patch("piper.voice.onnxruntime.InferenceSession") as mock_session,
+    ):
+        voice = PiperVoice.load(_TEST_VOICE, use_cuda=True)
+        assert mock_preload.call_count == 1
+        assert mock_session.call_count == 1
+        assert voice.session is mock_session.return_value
+        _args, kwargs = mock_session.call_args
+        assert kwargs["providers"] == [
+            (
+                "CUDAExecutionProvider",
+                {"cudnn_conv_algo_search": "HEURISTIC"},
+            )
+        ]
+
+
+def test_load_voice_cuda_disabled_no_preload() -> None:
+    """Test that use_cuda=False does not call preload_dlls."""
+    with (
+        patch("piper.voice.onnxruntime.preload_dlls", create=True) as mock_preload,
+        patch("piper.voice.onnxruntime.InferenceSession") as mock_session,
+    ):
+        PiperVoice.load(_TEST_VOICE, use_cuda=False)
+        mock_preload.assert_not_called()
+        assert mock_session.call_count == 1
+        _args, kwargs = mock_session.call_args
+        assert kwargs["providers"] == ["CPUExecutionProvider"]
 
 
 def test_phonemize_synthesize() -> None:


### PR DESCRIPTION
## Summary
Auto-discovers and preloads CUDA/cuDNN dynamic shared libraries via `onnxruntime.preload_dlls()` when `use_cuda=True` is enabled in `PiperVoice.load`.

## Problem
When users install CUDA support via standard Python wheels in their virtualenv (e.g. `pip install onnxruntime-gpu nvidia-cublas-cu12 nvidia-cudnn-cu12 nvidia-cuda-runtime-cu12 ...`), `onnxruntime`'s `CUDAExecutionProvider` fails to locate the shared libraries (`libcublasLt.so`, `libcufft.so`, etc.) on Linux because they are installed inside `site-packages/nvidia/*/lib/`. This causes ORT to fail creating `CUDAExecutionProvider` with missing shared object errors unless the user manually identifies every NVIDIA package directory and exports `LD_LIBRARY_PATH`.

This is especially common in isolated virtual environments, containerized deployments, and immutable Linux distributions (Fedora Atomic / Bazzite / Silverblue, NixOS, etc.) where system-wide CUDA toolkit installations are unavailable or discouraged.

## Solution
Since ONNX Runtime 1.21.0, `onnxruntime.preload_dlls()` is provided specifically to discover and preload NVIDIA runtime dynamic libraries from Python site-packages across platforms.

This PR calls `onnxruntime.preload_dlls()` when `use_cuda=True`:
- **Backwards-compatible**: Guarded with `hasattr(onnxruntime, "preload_dlls")` so older ONNX Runtime versions are unaffected.
- **Graceful fallback**: Wrapped in a `try...except` block so environments with standard system-wide CUDA toolkits or custom paths continue to function normally.

## Testing
- Verified on Linux (Bazzite, Python 3.12, NVIDIA RTX 4070) with `onnxruntime-gpu` + `nvidia-*-cu12` wheels.
- Confirmed `CUDAExecutionProvider` successfully initializes and synthesizes speech on the GPU without requiring manual `LD_LIBRARY_PATH` configuration.
- Formatted and verified with `black`, `isort`, and `flake8`.