### PR TITLE
http server: streaming (threading-chunking-splitting)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ src/piper/train/vits/monotonic_align/core.c
 *.so
 
 lightning_logs/
+
+# Symlink/copy of the built espeak-ng data when working from src/
+src/piper/espeak-ng-data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+
+- Add `piper.chunking`: configurable text chunking on word/punctuation/sentence boundaries
 
 ## 1.8.0
 
@@ -24,7 +27,6 @@
     - `g2pw.api` imports torch only to build padded tensors and iterate batches; the model itself already ran under onnxruntime
     - Also 1.5-2x faster, since it no longer forks DataLoader worker processes on every call
     - `g2pW` is still required, for its pinyin/bopomofo lookup tables
-
 ## 1.6.0
 
 - Add Hebrew phonemizer using Nakdimon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## Unreleased
 
+- HTTP server: stream audio while synthesizing (`/synthesize`, `/stream`) instead of waiting for the whole text
+- HTTP server: add `/stop` plus channel/group preemption and client-disconnect detection so speech can be interrupted immediately
+- HTTP server: split text into small chunks before synthesis (`--chunk-*`) and warm the model up at startup
 - Add `piper.chunking`: configurable text chunking on word/punctuation/sentence boundaries
 
 ## 1.8.0

--- a/docs/API_HTTP.md
+++ b/docs/API_HTTP.md
@@ -21,6 +21,14 @@ python3 -m piper.http_server -m en_US-lessac-medium
 This will start an HTTP server on port 5000 (use `--host` and `--port` to override).
 If you have voices in a different directory, use `--data-dir <DIR>`
 
+The voice model is loaded once and stays in memory, and a warmup utterance is
+synthesized at startup (disable with `--no-warmup`) so the first request is not
+slower than the others.
+
+Audio is **streamed while it is being synthesized**, and requests can be
+**interrupted**, which is what makes the server usable as a screen reader
+backend.
+
 ## Web Interface
 
 Open [http://localhost:5000](http://localhost:5000) in your browser to test the voice:
@@ -52,9 +60,131 @@ The JSON data fields are:
 * `length_scale` (optional) - speaking speed; defaults to 1
 * `noise_scale` (optional) - speaking variability
 * `noise_w_scale` (optional) - phoneme width variability
+* `volume` (optional) - audio multiplier; defaults to 1
+* `normalize_audio` (optional) - scale samples to the full range; defaults to
+  **false when the text is chunked** (normalizing each chunk separately makes the
+  loudness jump between chunks) and to true otherwise. Force it with
+  `--normalize` / `--no-normalize` on the server.
+* `sentence_silence` (optional) - seconds of silence after each sentence
+* `chunk_silence` (optional) - seconds of silence between chunks of a sentence
+* `chunk` (optional) - chunking options, see [below](#chunking)
+* `stream` (optional) - set to `false` for a buffered response with a complete
+  WAV header (needed by `<audio>` elements); defaults to `true`
+* `format` (optional) - `wav` (default) or `raw`
+* `stream_id`, `group`, `channel`, `preempt` (optional) - see
+  [interruption](#interruption)
+
+The same fields can be passed as query parameters, and a plain text body is
+accepted as `text`. `POST /` behaves like `POST /synthesize`.
 
 Get the available voices with:
 
 ``` sh
 curl localhost:5000/voices
 ```
+
+## Streaming Audio
+
+`POST /stream` returns raw 16-bit mono PCM as soon as the first piece of audio
+exists, using chunked transfer encoding:
+
+``` sh
+curl -N -H 'Content-Type: application/json' \
+    -d '{ "text": "This is a test." }' \
+    localhost:5000/stream | aplay -r 22050 -f S16_LE -t raw -
+```
+
+The audio format is reported in the response headers:
+
+* `X-Piper-Sample-Rate`, `X-Piper-Sample-Width`, `X-Piper-Channels`
+* `X-Piper-Voice` - voice actually used
+* `X-Piper-Stream-Id` - id needed to stop this stream
+
+`POST /synthesize` streams too; it just prepends a WAV header whose length
+fields are "big enough" so that players stream until end of data.
+
+## Interruption
+
+A screen reader must be able to silence the current utterance instantly when the
+user moves to another area. Three mechanisms are available:
+
+**1. Stop explicitly**
+
+``` sh
+curl -X POST -d '{}' localhost:5000/stop                          # everything
+curl -X POST -d '{"stream_id": "abc"}' localhost:5000/stop        # one stream
+curl -X POST -d '{"group": "utt-1"}' localhost:5000/stop          # one utterance
+curl -X POST -d '{"channel": "screen-reader"}' localhost:5000/stop
+```
+
+Inference stops before the next chunk, the response ends, and the engine is
+immediately free. The model stays loaded, so there is no warm-up afterwards.
+
+**2. Close the connection** - a client that stops reading and closes the socket
+also cancels the synthesis.
+
+**3. Preemption** - a new request cancels the running ones in the same
+`channel` (default: `default`). This is on by default; use `--no-preempt` on the
+server or `"preempt": false` per request to disable it.
+
+Requests that belong to the same utterance (a long text sent as several chunk
+requests) must share a `group` so they do not cancel each other.
+
+`/info` lists the streams currently active.
+
+## Chunking
+
+Piper synthesizes one sentence at a time, so a long sentence delays the first
+sample. The server splits text on word/punctuation/sentence boundaries before
+synthesis, which shortens time-to-first-audio and makes interruption faster.
+
+Server defaults:
+
+``` sh
+python3 -m piper.http_server -m en_US-lessac-medium \
+    --chunk-profile responsive \
+    --chunk-max-words 5 --chunk-first-max-words 3 --chunk-min-words 2
+```
+
+Profiles: `instant`, `responsive` (default), `balanced`, `smooth`, `off`.
+
+Per request:
+
+``` sh
+curl -N -d '{"text": "...", "chunk": {"max_words": 3, "first_max_words": 2}}' \
+    localhost:5000/stream
+curl -N -d '{"text": "...", "chunk": "smooth"}' localhost:5000/stream
+curl -N -d '{"text": "...", "chunk": {"enabled": false}}' localhost:5000/stream
+```
+
+Clients that chunk the text themselves should send
+`"chunk": {"enabled": false}` so the text is not split twice.
+
+All available options are documented in
+[`piper/chunking.py`](../src/piper/chunking.py).
+
+Measured on one machine with `en_US-lessac-low` and a 30-word text, the effect on
+time-to-first-audio is large:
+
+| Chunking | First audio | Audio produced |
+| --- | --- | --- |
+| `off` | 1030 ms | 8.96 s |
+| `smooth` | 135 ms | 8.88 s |
+| `responsive` | 132 ms | 10.60 s |
+| `instant` | 50 ms | 12.32 s |
+
+Note the last column: the smaller the chunks, the more pauses are added and the
+longer the speech becomes. That is the trade-off to tune.
+
+## Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/` | test page |
+| `POST` | `/`, `/synthesize` | synthesize, streaming WAV |
+| `POST` | `/stream` | synthesize, streaming raw PCM |
+| `POST` | `/stop` | stop active streams |
+| `GET` | `/info` | voice, chunking defaults, active streams, last utterance |
+| `GET` | `/voices` | downloaded voices |
+| `GET` | `/all-voices` | all Piper voices (from HuggingFace) |
+| `POST` | `/download` | download a voice |

--- a/src/piper/chunking.py
+++ b/src/piper/chunking.py
@@ -1,0 +1,486 @@
+"""Configurable text chunking for low-latency streaming synthesis.
+
+Screen readers hand over arbitrarily large blocks of text. Synthesis granularity
+in Piper is one sentence, so a long sentence means a long wait before the first
+sample is heard. Splitting text into small pieces *before* synthesis is what
+makes time-to-first-audio short and predictable.
+
+Splitting is always a trade-off: smaller pieces start faster but prosody
+suffers and boundary artifacts become audible. Nothing here is hardcoded --
+every knob is exposed through :class:`ChunkingConfig`, which can be built from
+CLI arguments, environment variables, a speech-dispatcher module config file or
+a JSON request body, and can be tuned per user.
+
+Example::
+
+    >>> config = ChunkingConfig(max_words=4, first_max_words=2)
+    >>> list(chunk_text("Hello there, world. This is a test.", config))
+    ['Hello there,', 'world.', 'This is a test.']
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, fields, replace
+from typing import Any, Iterable, Iterator, List, Mapping, Optional, Set, Tuple
+
+__all__ = [
+    "ChunkingConfig",
+    "PROFILES",
+    "chunk_text",
+    "iter_chunks",
+    "TextChunk",
+]
+
+# Boundary strengths
+_WORD = 1
+_CLAUSE = 2
+_SENTENCE = 3
+
+_WHITESPACE_PATTERN = re.compile(r"\s+")
+
+# Characters that are stripped when deciding what a "word" is
+_TRAILING_PUNCTUATION = "\"'’”)]}»"
+
+DEFAULT_SENTENCE_PUNCTUATION = ".!?…。！？"
+DEFAULT_CLAUSE_PUNCTUATION = ",;:—–)"
+
+# Words that end with a period without ending a sentence.
+DEFAULT_ABBREVIATIONS: Set[str] = {
+    "mr",
+    "mrs",
+    "ms",
+    "dr",
+    "prof",
+    "st",
+    "vs",
+    "etc",
+    "eg",
+    "e.g",
+    "ie",
+    "i.e",
+    "no",
+    "fig",
+    "al",
+    "inc",
+    "ltd",
+    "jr",
+    "sr",
+    "approx",
+    "min",
+    "max",
+    "vol",
+    "cf",
+}
+
+
+@dataclass(frozen=True)
+class TextChunk:
+    """A piece of text to synthesize, with its position in the source text."""
+
+    text: str
+    """Text of the chunk (whitespace normalized)."""
+
+    start: int
+    """Offset of the chunk in the (normalized) source text."""
+
+    end: int
+    """End offset (exclusive) of the chunk in the (normalized) source text."""
+
+    index: int
+    """Zero-based index of the chunk."""
+
+    is_last: bool = False
+    """True if this is the final chunk of the text."""
+
+
+@dataclass
+class ChunkingConfig:
+    """How text is split before being synthesized.
+
+    All defaults aim at screen-reader responsiveness: a very short first chunk
+    so speech starts almost immediately, then slightly larger chunks so that
+    prosody stays acceptable.
+    """
+
+    enabled: bool = True
+    """False disables splitting entirely (one chunk per input text)."""
+
+    max_words: int = 5
+    """Maximum number of words per chunk (0 = unlimited)."""
+
+    first_max_words: int = 3
+    """Maximum number of words in the *first* chunk (0 = same as max_words).
+
+    The first chunk determines time-to-first-audio, so it usually pays to make
+    it smaller than the others.
+    """
+
+    min_words: int = 2
+    """Do not break at a sentence/clause boundary before this many words.
+
+    Prevents pathological one-word chunks such as "Yes." followed by "OK."
+    being synthesized separately.
+    """
+
+    max_chars: int = 0
+    """Hard cap on chunk length in characters (0 = unlimited).
+
+    A single "word" can be arbitrarily long (URLs, base64, code). This is the
+    safety net that keeps inference time bounded.
+    """
+
+    merge_short_tail: bool = True
+    """Merge a trailing chunk shorter than ``min_words`` into the previous one."""
+
+    break_on_sentence: bool = True
+    """Break at sentence punctuation (once ``min_words`` is reached)."""
+
+    break_on_clause: bool = True
+    """Break at clause punctuation such as commas (once ``min_words`` is reached)."""
+
+    sentence_punctuation: str = DEFAULT_SENTENCE_PUNCTUATION
+    """Characters that end a sentence."""
+
+    clause_punctuation: str = DEFAULT_CLAUSE_PUNCTUATION
+    """Characters that end a clause."""
+
+    abbreviations: Set[str] = field(default_factory=lambda: set(DEFAULT_ABBREVIATIONS))
+    """Lowercase words that end with '.' without ending a sentence."""
+
+    strip_urls: bool = False
+    """Replace URLs with their host name (they are painful to listen to)."""
+
+    def __post_init__(self) -> None:
+        # Be forgiving with values coming from config files/environment
+        self.max_words = max(0, int(self.max_words))
+        self.first_max_words = max(0, int(self.first_max_words))
+        self.min_words = max(1, int(self.min_words))
+        self.max_chars = max(0, int(self.max_chars))
+
+        # Be tolerant of a comma-separated string (config files, environment)
+        self.abbreviations = _as_word_set(self.abbreviations)
+
+    # -------------------------------------------------------------------------
+
+    @property
+    def first_limit(self) -> int:
+        """Word limit for the first chunk."""
+        if self.first_max_words:
+            if self.max_words:
+                return min(self.first_max_words, self.max_words)
+
+            return self.first_max_words
+
+        return self.max_words
+
+    def replace(self, **changes: Any) -> "ChunkingConfig":
+        """Return a copy with the given fields changed (ignores None values)."""
+        changes = {key: value for key, value in changes.items() if value is not None}
+        return replace(self, **changes)
+
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def from_mapping(
+        values: Mapping[str, Any],
+        prefix: str = "",
+        base: Optional["ChunkingConfig"] = None,
+    ) -> "ChunkingConfig":
+        """Build a config from a mapping (JSON body, env vars, config file).
+
+        Keys are matched case-insensitively, with ``-``/``_`` treated the same,
+        and may be prefixed (e.g. ``PIPER_CHUNK_MAX_WORDS`` with
+        ``prefix="piper_chunk_"``). Unknown keys are ignored so the same
+        mapping can carry unrelated settings.
+
+        A ``profile`` key selects one of :data:`PROFILES` as the base.
+        """
+        normalized = {
+            _normalize_key(key): value
+            for key, value in values.items()
+            if _normalize_key(key).startswith(_normalize_key(prefix))
+        }
+        prefix_len = len(_normalize_key(prefix))
+        normalized = {key[prefix_len:]: value for key, value in normalized.items()}
+
+        config = base
+        profile = normalized.get("profile")
+        if profile:
+            profile_config = PROFILES.get(str(profile).strip().lower())
+            if profile_config is None:
+                raise ValueError(
+                    f"Unknown chunking profile: {profile} "
+                    f"(expected one of {sorted(PROFILES)})"
+                )
+            config = profile_config
+
+        config = replace(config) if config is not None else ChunkingConfig()
+
+        for config_field in fields(ChunkingConfig):
+            if config_field.name not in normalized:
+                continue
+
+            raw_value = normalized[config_field.name]
+            setattr(
+                config,
+                config_field.name,
+                _coerce(
+                    config_field.name, raw_value, getattr(config, config_field.name)
+                ),
+            )
+
+        config.__post_init__()
+        return config
+
+
+def _as_word_set(value: Any) -> Set[str]:
+    """Convert a comma-separated string or an iterable into a set of words."""
+    if isinstance(value, str):
+        return {word.strip().lower() for word in value.split(",") if word.strip()}
+
+    return {str(word).strip().lower() for word in value}
+
+
+def _normalize_key(key: str) -> str:
+    return key.strip().lower().replace("-", "_")
+
+
+def _coerce(name: str, value: Any, current: Any) -> Any:
+    """Convert a string value to the type of the current field value."""
+    if isinstance(current, bool):
+        if isinstance(value, str):
+            value = value.strip().lower()
+            if value in ("1", "true", "yes", "on"):
+                return True
+            if value in ("0", "false", "no", "off"):
+                return False
+            raise ValueError(f"Invalid boolean for {name}: {value}")
+
+        return bool(value)
+
+    if isinstance(current, int):
+        return int(value)
+
+    if isinstance(current, set):
+        return _as_word_set(value)
+
+    return value
+
+
+#: Named presets. Users (and bug reports) can refer to these by name.
+PROFILES: "dict[str, ChunkingConfig]" = {
+    # Absolute minimum latency: start speaking after two words.
+    "instant": ChunkingConfig(max_words=3, first_max_words=2, min_words=1),
+    # Recommended default for screen reading.
+    "responsive": ChunkingConfig(max_words=5, first_max_words=3, min_words=2),
+    # Compromise: quick start, longer pieces afterwards.
+    "balanced": ChunkingConfig(max_words=10, first_max_words=4, min_words=3),
+    # Prosody first: only break at sentences (still streams per sentence).
+    "smooth": ChunkingConfig(
+        max_words=0, first_max_words=0, min_words=2, break_on_clause=False
+    ),
+    # No client-side splitting at all.
+    "off": ChunkingConfig(enabled=False),
+}
+
+_URL_PATTERN = re.compile(r"\b(?:https?|ftp)://(\S+)")
+
+
+def normalize_text(text: str, config: Optional[ChunkingConfig] = None) -> str:
+    """Collapse whitespace (including newlines) into single spaces."""
+    if (config is not None) and config.strip_urls:
+        text = _URL_PATTERN.sub(lambda m: m.group(1).split("/")[0], text)
+
+    return _WHITESPACE_PATTERN.sub(" ", text).strip()
+
+
+def _boundary_strength(token: str, config: ChunkingConfig) -> int:
+    """Return the boundary strength after ``token``."""
+    stripped = token.rstrip(_TRAILING_PUNCTUATION)
+    if not stripped:
+        return _WORD
+
+    last_char = stripped[-1]
+    if last_char in config.sentence_punctuation:
+        if last_char == ".":
+            word = stripped[:-1].lower()
+            # "Mr." / "e.g." / initials ("J.") do not end a sentence
+            if word in config.abbreviations:
+                return _WORD
+
+            if len(word) == 1 and word.isalpha():
+                return _WORD
+
+            if word.isdigit():
+                # "1. First item" -- list numbering, weak boundary
+                return _CLAUSE
+
+        return _SENTENCE
+
+    if last_char in config.clause_punctuation:
+        return _CLAUSE
+
+    return _WORD
+
+
+def iter_chunks(
+    text: str, config: Optional[ChunkingConfig] = None
+) -> Iterator[TextChunk]:
+    """Split text into :class:`TextChunk` objects.
+
+    Chunks are yielded lazily so that synthesis of the first chunk can start
+    while the rest of the text is still being split.
+    """
+    if config is None:
+        config = ChunkingConfig()
+
+    text = normalize_text(text, config)
+    if not text:
+        return
+
+    if not config.enabled:
+        yield TextChunk(text=text, start=0, end=len(text), index=0, is_last=True)
+        return
+
+    pending: List[TextChunk] = []
+    for chunk in _split(text, config):
+        # Keep one chunk in hand so a short tail can be merged into it
+        pending.append(chunk)
+        if len(pending) > 1:
+            yield pending.pop(0)
+
+    if not pending:
+        return
+
+    last = pending[0]
+    yield TextChunk(
+        text=last.text, start=last.start, end=last.end, index=last.index, is_last=True
+    )
+
+
+def _split(text: str, config: ChunkingConfig) -> Iterator[TextChunk]:
+    """Greedy split at the strongest boundary allowed by the limits."""
+    index = 0
+    start: Optional[int] = None
+    end = 0
+    num_words = 0
+
+    def limit() -> int:
+        return config.first_limit if index == 0 else config.max_words
+
+    prev_chunk: Optional[TextChunk] = None
+
+    for token, token_start, token_end in _iter_tokens(text, config.max_chars):
+        if start is None:
+            start = token_start
+
+        # Hard character cap: emit what we have before adding this token
+        if config.max_chars and num_words and ((token_end - start) > config.max_chars):
+            chunk = TextChunk(text=text[start:end], start=start, end=end, index=index)
+            prev_chunk, emit = _merge_tail(prev_chunk, chunk, config)
+            if emit is not None:
+                yield emit
+
+            index += 1
+            start = token_start
+            num_words = 0
+
+        end = token_end
+        num_words += 1
+
+        strength = _boundary_strength(token, config)
+        should_break = False
+        if (strength == _SENTENCE) and config.break_on_sentence:
+            # Piper synthesizes one sentence at a time anyway: never merge
+            # across a sentence boundary, whatever min_words says.
+            should_break = True
+        elif (
+            (strength == _CLAUSE)
+            and config.break_on_clause
+            and (num_words >= config.min_words)
+        ):
+            should_break = True
+
+        if (not should_break) and limit() and (num_words >= limit()):
+            should_break = True
+
+        if config.max_chars and ((end - start) >= config.max_chars):
+            should_break = True
+
+        if should_break:
+            chunk = TextChunk(text=text[start:end], start=start, end=end, index=index)
+            prev_chunk, emit = _merge_tail(prev_chunk, chunk, config)
+            if emit is not None:
+                yield emit
+
+            index += 1
+            start = None
+            num_words = 0
+
+    if start is not None:
+        chunk = TextChunk(text=text[start:end], start=start, end=end, index=index)
+        prev_chunk, emit = _merge_tail(prev_chunk, chunk, config)
+        if emit is not None:
+            yield emit
+
+    if prev_chunk is not None:
+        yield prev_chunk
+
+
+def _merge_tail(
+    prev_chunk: Optional[TextChunk], chunk: TextChunk, config: ChunkingConfig
+) -> Tuple[Optional[TextChunk], Optional[TextChunk]]:
+    """Hold back one chunk so a too-short chunk can be merged with it.
+
+    Returns (chunk to hold, chunk to emit now).
+    """
+    if prev_chunk is None:
+        return chunk, None
+
+    if not config.merge_short_tail:
+        return chunk, prev_chunk
+
+    too_short = _count_words(chunk.text) < config.min_words
+    if too_short:
+        merged_text = f"{prev_chunk.text} {chunk.text}"
+        if (not config.max_chars) or (len(merged_text) <= config.max_chars):
+            return (
+                TextChunk(
+                    text=merged_text,
+                    start=prev_chunk.start,
+                    end=chunk.end,
+                    index=prev_chunk.index,
+                ),
+                None,
+            )
+
+    return chunk, prev_chunk
+
+
+def _count_words(text: str) -> int:
+    return len(text.split())
+
+
+def _iter_tokens(text: str, max_chars: int = 0) -> Iterator[Tuple[str, int, int]]:
+    """Yield (token, start, end) for whitespace-separated tokens.
+
+    Tokens longer than ``max_chars`` (URLs, base64 blobs, code) are hard-split
+    so that inference time per chunk stays bounded.
+    """
+    for match in re.finditer(r"\S+", text):
+        token, start, end = match.group(0), match.start(), match.end()
+        if max_chars and (len(token) > max_chars):
+            for offset in range(0, len(token), max_chars):
+                piece = token[offset : offset + max_chars]
+                yield piece, start + offset, start + offset + len(piece)
+
+            continue
+
+        yield token, start, end
+
+
+def chunk_text(text: str, config: Optional[ChunkingConfig] = None) -> Iterable[str]:
+    """Split text and yield chunk strings (convenience wrapper)."""
+    for chunk in iter_chunks(text, config):
+        yield chunk.text

--- a/src/piper/http_server.py
+++ b/src/piper/http_server.py
@@ -1,26 +1,360 @@
-"""Flask web server with HTTP API for Piper."""
+"""Flask web server with HTTP API for Piper.
+
+The server keeps voices loaded in memory and streams audio *while* it is being
+synthesized, which is what makes it usable as a screen reader backend:
+
+* ``POST /synthesize`` streams a WAV file (chunked transfer encoding) as soon as
+  the first piece of audio exists.
+* ``POST /stream`` streams raw 16-bit PCM, ready to be piped into a player.
+* ``POST /stop`` immediately aborts synthesis and the output stream of active
+  requests, freeing the engine for the next utterance.
+* Requests can also be interrupted simply by closing the connection, and a new
+  request on the same *channel* preempts the ones that are still running.
+
+Long texts are split into small pieces before synthesis (see
+:mod:`piper.chunking`) so that time-to-first-audio stays short and interruption
+is nearly instantaneous. Every chunking parameter can be set per request or with
+``--chunk-*`` options.
+"""
 
 import argparse
 import io
 import json
 import logging
+import threading
 import time
+import uuid
 import wave
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 from urllib.request import urlopen
 
-from flask import Flask, render_template, request
+from flask import Flask, Response, render_template, request
 
 from . import PiperVoice, SynthesisConfig
+from .chunking import PROFILES, ChunkingConfig, iter_chunks
 from .download_voices import VOICES_JSON, download_voice
 
-_LOGGER = logging.getLogger()
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CHANNEL = "default"
+
+# Audio format of Piper output (all voices)
+SAMPLE_WIDTH = 2
+NUM_CHANNELS = 1
 
 
-def main() -> None:
-    """Run HTTP server."""
-    parser = argparse.ArgumentParser()
+# -----------------------------------------------------------------------------
+# Interruption
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class Stream:
+    """An in-flight synthesis request that can be cancelled."""
+
+    stream_id: str
+    channel: str
+    group: str = ""
+    """Utterance this stream belongs to: streams of the same group never
+    preempt each other (a long text is sent as several requests)."""
+
+    cancelled: threading.Event = field(default_factory=threading.Event)
+    started: float = field(default_factory=time.monotonic)
+
+    def cancel(self) -> None:
+        self.cancelled.set()
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self.cancelled.is_set()
+
+
+class StreamRegistry:
+    """Tracks active streams so they can be stopped or preempted.
+
+    A *channel* groups streams that compete for the same pair of ears: a new
+    request in a channel cancels the ones already running there. Screen readers
+    need exactly this: moving the pointer to another area must silence the
+    previous area immediately.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._streams: Dict[str, Stream] = {}
+
+    def start(
+        self,
+        channel: str = DEFAULT_CHANNEL,
+        stream_id: Optional[str] = None,
+        group: Optional[str] = None,
+        preempt: bool = True,
+    ) -> Stream:
+        """Register a new stream, cancelling the ones it preempts.
+
+        Streams of the same ``group`` (one utterance, possibly split over
+        several requests) never cancel each other, whatever order they arrive
+        in.
+        """
+        stream_id = stream_id or uuid.uuid4().hex
+        stream = Stream(stream_id=stream_id, channel=channel, group=group or stream_id)
+        to_cancel: List[Stream] = []
+        with self._lock:
+            # Same id twice: the newer request wins
+            existing = self._streams.get(stream.stream_id)
+            if existing is not None:
+                to_cancel.append(existing)
+
+            if preempt:
+                to_cancel.extend(
+                    other
+                    for other in self._streams.values()
+                    if (other.channel == channel)
+                    and (other.group != stream.group)
+                    and (other is not existing)
+                )
+
+            self._streams[stream.stream_id] = stream
+
+        for other in to_cancel:
+            _LOGGER.debug("Preempting stream %s", other.stream_id)
+            other.cancel()
+
+        return stream
+
+    def finish(self, stream: Stream) -> None:
+        with self._lock:
+            if self._streams.get(stream.stream_id) is stream:
+                del self._streams[stream.stream_id]
+
+    def cancel(
+        self,
+        stream_id: Optional[str] = None,
+        channel: Optional[str] = None,
+        group: Optional[str] = None,
+    ) -> List[str]:
+        """Cancel streams by id, by group, by channel, or all of them.
+
+        :return: ids of the cancelled streams.
+        """
+        with self._lock:
+            if stream_id is not None:
+                streams = [
+                    s for s in self._streams.values() if s.stream_id == stream_id
+                ]
+            elif group is not None:
+                streams = [s for s in self._streams.values() if s.group == group]
+            elif channel is not None:
+                streams = [s for s in self._streams.values() if s.channel == channel]
+            else:
+                streams = list(self._streams.values())
+
+        for stream in streams:
+            stream.cancel()
+
+        return [stream.stream_id for stream in streams]
+
+    def active(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            streams = list(self._streams.values())
+
+        now = time.monotonic()
+        return [
+            {
+                "stream_id": stream.stream_id,
+                "channel": stream.channel,
+                "group": stream.group,
+                "seconds": round(now - stream.started, 3),
+                "cancelled": stream.is_cancelled,
+            }
+            for stream in streams
+        ]
+
+
+class Cancelled(Exception):
+    """Raised internally when a stream is cancelled."""
+
+
+# -----------------------------------------------------------------------------
+# WAV streaming
+# -----------------------------------------------------------------------------
+
+# Length fields of a WAV file that is still being written. Players that stream
+# from a pipe (aplay, ffplay, browsers) accept a "big enough" length and simply
+# stop at end of stream.
+_STREAMING_WAV_SIZE = 0x7FFFFFFF - 128
+
+
+def wav_header(
+    sample_rate: int,
+    sample_width: int = SAMPLE_WIDTH,
+    num_channels: int = NUM_CHANNELS,
+    num_bytes: Optional[int] = None,
+) -> bytes:
+    """Build a 44-byte WAV header, for an unknown length by default."""
+    data_size = _STREAMING_WAV_SIZE if num_bytes is None else num_bytes
+    with io.BytesIO() as wav_io:
+        wav_file: wave.Wave_write = wave.open(wav_io, "wb")
+        with wav_file:
+            wav_file.setframerate(sample_rate)
+            wav_file.setsampwidth(sample_width)
+            wav_file.setnchannels(num_channels)
+            wav_file.writeframes(b"")
+
+        header = bytearray(wav_io.getvalue()[:44])
+
+    # RIFF size and data size
+    header[4:8] = (data_size + 36).to_bytes(4, "little")
+    header[40:44] = data_size.to_bytes(4, "little")
+    return bytes(header)
+
+
+# -----------------------------------------------------------------------------
+# Voices
+# -----------------------------------------------------------------------------
+
+
+class VoiceManager:
+    """Loads voices once and keeps them in memory."""
+
+    def __init__(
+        self,
+        default_model_path: Path,
+        data_dirs: Iterable[str],
+        use_cuda: bool = False,
+        include_alignments: bool = True,
+    ) -> None:
+        self.data_dirs = [Path(data_dir) for data_dir in data_dirs]
+        self.use_cuda = use_cuda
+        self.default_voice_id = default_model_path.name
+        for suffix in (".onnx", ".onnx.json"):
+            if self.default_voice_id.endswith(suffix):
+                self.default_voice_id = self.default_voice_id[: -len(suffix)]
+                break
+
+        self._lock = threading.Lock()
+        self._voices: Dict[str, PiperVoice] = {
+            self.default_voice_id: PiperVoice.load(
+                default_model_path,
+                use_cuda=use_cuda,
+                include_alignments=include_alignments,
+            )
+        }
+
+        # One inference at a time per process: parallel ONNX runs on a CPU only
+        # make every request slower, which is the opposite of what we want.
+        self.inference_lock = threading.Lock()
+
+    @property
+    def default_voice(self) -> PiperVoice:
+        return self._voices[self.default_voice_id]
+
+    def get(self, voice_id: Optional[str]) -> Tuple[str, PiperVoice]:
+        """Get a loaded voice by name, loading it on first use."""
+        if (not voice_id) or (voice_id in ("no_voice", "NULL", "default")):
+            # "no_voice" is what speech-dispatcher generic modules pass when the
+            # client did not request a specific voice.
+            return self.default_voice_id, self.default_voice
+
+        with self._lock:
+            voice = self._voices.get(voice_id)
+
+        if voice is not None:
+            return voice_id, voice
+
+        for data_dir in self.data_dirs:
+            model_path = data_dir / f"{voice_id}.onnx"
+            if not model_path.exists():
+                continue
+
+            _LOGGER.debug("Loading voice %s", model_path)
+            voice = PiperVoice.load(model_path, use_cuda=self.use_cuda)
+            with self._lock:
+                self._voices[voice_id] = voice
+
+            return voice_id, voice
+
+        _LOGGER.warning("Voice not found: %s. Using default voice.", voice_id)
+        return self.default_voice_id, self.default_voice
+
+    def loaded(self) -> List[str]:
+        with self._lock:
+            return sorted(self._voices)
+
+
+# -----------------------------------------------------------------------------
+# Request parsing
+# -----------------------------------------------------------------------------
+
+
+def _request_data() -> Dict[str, Any]:
+    """Get parameters from a JSON body, a form, or the query string."""
+    data: Dict[str, Any] = {}
+    if request.args:
+        data.update(request.args.to_dict())
+
+    raw = b""
+    if request.form:
+        form = request.form.to_dict()
+        only_key = next(iter(form)) if len(form) == 1 else None
+        if (only_key is not None) and (form[only_key] == ""):
+            # `curl -d '{"text": "..."}'` sends a body with a form content type
+            # (that is curl's default), so werkzeug parses the whole body as a
+            # single valueless key. Treat it as the raw body instead, otherwise
+            # every parameter is silently dropped: `/stop` with a "stream_id"
+            # would stop *every* stream.
+            raw = only_key.encode("utf-8")
+        else:
+            data.update(form)
+
+    if not raw:
+        raw = request.get_data(cache=False)
+
+    if raw:
+        try:
+            body = json.loads(raw)
+            if isinstance(body, dict):
+                data.update(body)
+            elif isinstance(body, str):
+                data["text"] = body
+        except (ValueError, UnicodeDecodeError):
+            # Plain text body
+            data["text"] = raw.decode("utf-8", errors="replace")
+
+    return data
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+
+    if isinstance(value, bool):
+        return value
+
+    text = str(value).strip().lower()
+    if text in ("1", "true", "yes", "on"):
+        return True
+
+    if text in ("0", "false", "no", "off"):
+        return False
+
+    return default
+
+
+def _as_float(value: Any, default: Optional[float]) -> Optional[float]:
+    if value is None:
+        return default
+
+    return float(value)
+
+
+# -----------------------------------------------------------------------------
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Build the command line parser."""
+    parser = argparse.ArgumentParser(prog="piper.http_server")
     parser.add_argument("--host", default="0.0.0.0", help="HTTP server host")
     parser.add_argument("--port", type=int, default=5000, help="HTTP server port")
     #
@@ -41,6 +375,23 @@ def main() -> None:
         type=float,
         help="Phoneme width noise",
     )
+    parser.add_argument(
+        "--volume", type=float, default=1.0, help="Volume multiplier (default: 1.0)"
+    )
+    parser.add_argument(
+        "--normalize",
+        dest="normalize_audio",
+        action="store_true",
+        default=None,
+        help="Always scale audio samples to the full range",
+    )
+    parser.add_argument(
+        "--no-normalize",
+        dest="normalize_audio",
+        action="store_false",
+        default=None,
+        help="Never normalize audio",
+    )
     #
     parser.add_argument("--cuda", action="store_true", help="Use GPU")
     #
@@ -50,6 +401,63 @@ def main() -> None:
         type=float,
         default=0.0,
         help="Seconds of silence after each sentence",
+    )
+    parser.add_argument(
+        "--chunk-silence",
+        "--chunk_silence",
+        type=float,
+        default=0.0,
+        help="Seconds of silence between chunks of the same sentence (default: 0)",
+    )
+    #
+    # Chunking (see piper.chunking). Defaults are tuned for responsiveness.
+    parser.add_argument(
+        "--chunk-profile",
+        "--chunk_profile",
+        default="responsive",
+        choices=sorted(PROFILES),
+        help="Text chunking preset (default: responsive, use 'off' to disable)",
+    )
+    parser.add_argument(
+        "--chunk-max-words",
+        "--chunk_max_words",
+        type=int,
+        help="Maximum words per synthesized chunk (0 = unlimited)",
+    )
+    parser.add_argument(
+        "--chunk-first-max-words",
+        "--chunk_first_max_words",
+        type=int,
+        help="Maximum words in the first chunk (lower = faster first audio)",
+    )
+    parser.add_argument(
+        "--chunk-min-words",
+        "--chunk_min_words",
+        type=int,
+        help="Minimum words before breaking at a clause boundary",
+    )
+    parser.add_argument(
+        "--chunk-max-chars",
+        "--chunk_max_chars",
+        type=int,
+        help="Hard limit on chunk length in characters (0 = unlimited)",
+    )
+    #
+    parser.add_argument(
+        "--no-preempt",
+        action="store_true",
+        help="Don't cancel running requests when a new one arrives on the same channel",
+    )
+    parser.add_argument(
+        "--no-warmup",
+        action="store_true",
+        help="Don't synthesize a warmup utterance at startup",
+    )
+    parser.add_argument(
+        "--warmup-text",
+        "--warmup_text",
+        default="Piper is ready.",
+        help="Text used for the (silent) warmup synthesis at startup",
     )
     #
     parser.add_argument(
@@ -68,8 +476,11 @@ def main() -> None:
     parser.add_argument(
         "--debug", action="store_true", help="Print DEBUG messages to console"
     )
-    args = parser.parse_args()
-    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+    return parser
+
+
+def create_app(args: argparse.Namespace) -> Flask:
+    """Load the voice(s) and build the Flask application."""
     _LOGGER.debug(args)
 
     if not args.download_dir:
@@ -92,16 +503,36 @@ def main() -> None:
 
     if not model_path.exists():
         raise ValueError(
-            f"Unable to find voice: {model_path} (use piper.download_voices)"
+            f"Unable to find voice: {model_path} in {maybe_model_path} (use piper.download_voices)"
         )
 
-    default_model_id = model_path.name.rstrip(".onnx")
-
-    # Load voice
-    default_voice = PiperVoice.load(
-        model_path, use_cuda=args.cuda, include_alignments=True
+    # Default chunking for every request (may be overridden per request)
+    default_chunking = ChunkingConfig.from_mapping(
+        {
+            "profile": args.chunk_profile,
+            **{
+                key: value
+                for key, value in (
+                    ("max_words", args.chunk_max_words),
+                    ("first_max_words", args.chunk_first_max_words),
+                    ("min_words", args.chunk_min_words),
+                    ("max_chars", args.chunk_max_chars),
+                )
+                if value is not None
+            },
+        }
     )
-    loaded_voices: Dict[str, PiperVoice] = {default_model_id: default_voice}
+    _LOGGER.debug("Chunking: %s", default_chunking)
+
+    voices = VoiceManager(
+        model_path,
+        data_dirs=args.data_dir,
+        use_cuda=args.cuda,
+        include_alignments=True,
+    )
+    default_model_id = voices.default_voice_id
+    default_voice = voices.default_voice
+    streams = StreamRegistry()
 
     # Create web server.
     # Images live in the "img" directory and are served under "/img".
@@ -109,6 +540,305 @@ def main() -> None:
 
     # Info about the most recently synthesized utterance (for the web page).
     last_synthesis: Dict[str, Any] = {}
+
+    # -------------------------------------------------------------------------
+
+    def get_syn_config(
+        data: Dict[str, Any], voice: PiperVoice, chunking: ChunkingConfig
+    ) -> SynthesisConfig:
+        """Build a synthesis config from request data, CLI args, voice config."""
+        speaker_id: Optional[int] = data.get("speaker_id")
+        if speaker_id is not None:
+            speaker_id = int(speaker_id)
+
+        if (voice.config.num_speakers > 1) and (speaker_id is None):
+            speaker = data.get("speaker")
+            if speaker:
+                speaker_id = voice.config.speaker_id_map.get(speaker)
+
+            if speaker_id is None:
+                if speaker:
+                    _LOGGER.warning(
+                        "Speaker not found: '%s' in %s",
+                        speaker,
+                        voice.config.speaker_id_map.keys(),
+                    )
+
+                speaker_id = args.speaker or voice.config.default_speaker_id
+
+        if (speaker_id is not None) and (speaker_id > voice.config.num_speakers):
+            speaker_id = 0
+
+        def scale(name: str, cli_value: Optional[float], voice_value: float) -> float:
+            value = data.get(name)
+            if value is None:
+                value = cli_value if cli_value is not None else voice_value
+
+            return float(value)
+
+        # Normalization scales each synthesized piece to the full range, which
+        # makes the loudness jump from chunk to chunk. It is therefore off by
+        # default as soon as the text is chunked, unless asked for explicitly.
+        normalize_audio = data.get("normalize_audio")
+        if normalize_audio is None:
+            normalize_audio = (
+                args.normalize_audio
+                if args.normalize_audio is not None
+                else (not chunking.enabled)
+            )
+
+        return SynthesisConfig(
+            speaker_id=speaker_id,
+            length_scale=scale(
+                "length_scale", args.length_scale, voice.config.length_scale
+            ),
+            noise_scale=scale(
+                "noise_scale", args.noise_scale, voice.config.noise_scale
+            ),
+            noise_w_scale=scale(
+                "noise_w_scale", args.noise_w_scale, voice.config.noise_w_scale
+            ),
+            normalize_audio=_as_bool(normalize_audio, True),
+            volume=float(_as_float(data.get("volume"), args.volume) or 1.0),
+        )
+
+    def get_chunking(data: Dict[str, Any]) -> ChunkingConfig:
+        """Per-request chunking config, falling back to the server defaults."""
+        overrides: Dict[str, Any] = {}
+        chunk_data = data.get("chunk")
+        if isinstance(chunk_data, dict):
+            overrides.update(chunk_data)
+        elif isinstance(chunk_data, str):
+            overrides["profile"] = chunk_data
+
+        # Flat keys: chunk_max_words=3, ...
+        for key, value in data.items():
+            if key.startswith("chunk_") and (key != "chunk_silence"):
+                overrides[key[len("chunk_") :]] = value
+
+        if not overrides:
+            return default_chunking
+
+        return ChunkingConfig.from_mapping(overrides, base=default_chunking)
+
+    def synthesize_stream(
+        voice: PiperVoice,
+        text: str,
+        syn_config: SynthesisConfig,
+        chunking: ChunkingConfig,
+        stream: Stream,
+        sentence_silence: float,
+        chunk_silence: float,
+    ) -> Iterator[bytes]:
+        """Yield 16-bit PCM as it is synthesized, checking for cancellation.
+
+        Cancellation is checked before every inference call and before every
+        write, so a stop request takes effect within one chunk of audio (a few
+        tens of milliseconds with the default chunking).
+        """
+        sample_rate = voice.config.sample_rate
+        sentence_silence_bytes = bytes(int(sample_rate * sentence_silence) * 2)
+        chunk_silence_bytes = bytes(int(sample_rate * chunk_silence) * 2)
+
+        num_samples = 0
+        completed = False
+        start_time = time.monotonic()
+        first_audio_seconds: Optional[float] = None
+        phonemes: List[str] = []
+        alignments: List[Dict[str, Any]] = []
+
+        try:
+            for chunk in iter_chunks(text, chunking):
+                if stream.is_cancelled:
+                    raise Cancelled
+
+                if chunk.index > 0:
+                    yield chunk_silence_bytes
+
+                audio_chunks = _synthesize_chunk(voice, chunk.text, syn_config, stream)
+                for sentence_idx, audio_chunk in enumerate(audio_chunks):
+                    if stream.is_cancelled:
+                        raise Cancelled
+
+                    if sentence_idx > 0:
+                        yield sentence_silence_bytes
+
+                    if first_audio_seconds is None:
+                        first_audio_seconds = time.monotonic() - start_time
+
+                    num_samples += len(audio_chunk.audio_float_array)
+                    phonemes.extend(audio_chunk.phonemes)
+                    for alignment in audio_chunk.phoneme_alignments or []:
+                        alignments.append(
+                            {
+                                "phoneme": alignment.phoneme,
+                                "seconds": alignment.num_samples / sample_rate,
+                            }
+                        )
+
+                    if chunk.is_last and (sentence_idx == (len(audio_chunks) - 1)):
+                        # Everything has been synthesized. The generator is
+                        # still suspended on this last yield, so the flag has to
+                        # be set before it: a client that stops reading here has
+                        # not interrupted anything.
+                        completed = True
+
+                    yield audio_chunk.audio_int16_bytes
+
+            completed = True
+        except Cancelled:
+            _LOGGER.debug("Stream cancelled: %s", stream.stream_id)
+        except GeneratorExit:
+            if not completed:
+                # Client disconnected early: interrupting by closing the
+                # connection is a legitimate way to stop speech.
+                stream.cancel()
+                _LOGGER.debug("Stream closed by client: %s", stream.stream_id)
+
+            raise
+        finally:
+            streams.finish(stream)
+            total_seconds = time.monotonic() - start_time
+            audio_seconds = num_samples / voice.config.sample_rate
+            _LOGGER.debug(
+                "Stream %s: first audio in %.3fs, %.3fs audio in %.3fs (%s)",
+                stream.stream_id,
+                first_audio_seconds if first_audio_seconds is not None else -1,
+                audio_seconds,
+                total_seconds,
+                "complete" if completed else "cancelled",
+            )
+            last_synthesis.clear()
+            last_synthesis.update(
+                text=text,
+                synthesize_seconds=total_seconds,
+                first_audio_seconds=first_audio_seconds,
+                audio_seconds=audio_seconds,
+                cancelled=(not completed) and stream.is_cancelled,
+                phonemes=phonemes,
+                alignments=alignments,
+            )
+
+    def _synthesize_chunk(
+        voice: PiperVoice,
+        text: str,
+        syn_config: SynthesisConfig,
+        stream: Stream,
+    ) -> List[Any]:
+        """Synthesize one chunk of text while holding the inference lock.
+
+        The lock is taken per chunk (not per request) so a preempted request
+        releases the engine after at most one inference call, and it is never
+        held while writing to the network: a slow or stalled client must not be
+        able to block the engine.
+        """
+        with voices.inference_lock:
+            if stream.is_cancelled:
+                raise Cancelled
+
+            audio_chunks: List[Any] = []
+            for audio_chunk in voice.synthesize(
+                text, syn_config, include_alignments=True
+            ):
+                audio_chunks.append(audio_chunk)
+                if stream.is_cancelled:
+                    break
+
+            return audio_chunks
+
+    def audio_response(data: Dict[str, Any], output_format: str) -> Response:
+        """Build a streaming audio response from request data."""
+        text = str(data.get("text") or "").strip()
+        if not text:
+            raise ValueError("No text provided")
+
+        voice_id, voice = voices.get(data.get("voice"))
+        chunking = get_chunking(data)
+        syn_config = get_syn_config(data, voice, chunking)
+        sample_rate = voice.config.sample_rate
+
+        stream = streams.start(
+            channel=str(data.get("channel") or DEFAULT_CHANNEL),
+            stream_id=data.get("stream_id"),
+            group=data.get("group"),
+            preempt=_as_bool(data.get("preempt"), not args.no_preempt),
+        )
+
+        _LOGGER.debug(
+            "Synthesizing (stream=%s, voice=%s, format=%s): '%s'",
+            stream.stream_id,
+            voice_id,
+            output_format,
+            text,
+        )
+
+        audio_stream = synthesize_stream(
+            voice,
+            text,
+            syn_config,
+            chunking,
+            stream,
+            sentence_silence=float(
+                _as_float(data.get("sentence_silence"), args.sentence_silence) or 0.0
+            ),
+            chunk_silence=float(
+                _as_float(data.get("chunk_silence"), args.chunk_silence) or 0.0
+            ),
+        )
+
+        is_wav = output_format == "wav"
+        mimetype = (
+            "audio/wav"
+            if is_wav
+            else f"audio/L16; rate={sample_rate}; channels={NUM_CHANNELS}"
+        )
+
+        if not _as_bool(data.get("stream"), True):
+            # Buffered response with a complete WAV header, for clients that
+            # cannot consume a stream (e.g. <audio src> from a blob).
+            audio_bytes = b"".join(audio_stream)
+            body: Iterable[bytes] = [
+                (
+                    wav_header(sample_rate, num_bytes=len(audio_bytes)) + audio_bytes
+                    if is_wav
+                    else audio_bytes
+                )
+            ]
+            response = Response(body, mimetype=mimetype)
+        else:
+            if is_wav:
+
+                def with_header() -> Iterator[bytes]:
+                    yield wav_header(sample_rate)
+                    yield from audio_stream
+
+                body = with_header()
+            else:
+                body = audio_stream
+
+            response = Response(body, mimetype=mimetype, direct_passthrough=True)
+
+        response.headers["X-Piper-Stream-Id"] = stream.stream_id
+        response.headers["X-Piper-Voice"] = voice_id
+        response.headers["X-Piper-Sample-Rate"] = str(sample_rate)
+        response.headers["X-Piper-Sample-Width"] = str(SAMPLE_WIDTH)
+        response.headers["X-Piper-Channels"] = str(NUM_CHANNELS)
+        response.headers["Cache-Control"] = "no-store"
+        # Don't let proxies buffer the stream
+        response.headers["X-Accel-Buffering"] = "no"
+        return response
+
+    # -------------------------------------------------------------------------
+
+    @app.errorhandler(ValueError)
+    def app_bad_request(error: ValueError) -> Tuple[Dict[str, Any], int]:
+        """Report bad requests as JSON, never as an HTML error page.
+
+        Clients (screen readers) must be able to tell a bad request from a
+        server failure without parsing HTML.
+        """
+        _LOGGER.debug("Bad request: %s", error)
+        return {"error": str(error)}, 400
 
     @app.route("/", methods=["GET"])
     def app_index() -> str:
@@ -124,11 +854,18 @@ def main() -> None:
           "voice": {
             "name": "<voice name>",
             "language": "<espeak voice/alphabet>",
-            "num_speakers": <number of speakers>
+            "num_speakers": <number of speakers>,
+            "sample_rate": <hertz>
           },
+          "loaded_voices": ["<voice name>", ...],
+          "chunking": { <default chunking config> },
+          "streams": [ { "stream_id": ..., "channel": ... }, ... ],
           "last": {                            (null until something is synthesized)
             "text": "<synthesized text>",
             "synthesize_seconds": <wall-clock synthesis time>,
+            "first_audio_seconds": <time to first audio chunk>,
+            "audio_seconds": <duration of audio produced>,
+            "cancelled": <true if interrupted>,
             "phonemes": ["<phoneme>", ...],
             "alignments": [
               { "phoneme": "<phoneme>", "seconds": <duration> },
@@ -142,7 +879,20 @@ def main() -> None:
                 "name": default_model_id,
                 "language": default_voice.config.espeak_voice,
                 "num_speakers": default_voice.config.num_speakers,
+                "sample_rate": default_voice.config.sample_rate,
+                "sample_width": SAMPLE_WIDTH,
+                "num_channels": NUM_CHANNELS,
             },
+            "loaded_voices": voices.loaded(),
+            "chunking": {
+                "profile": args.chunk_profile,
+                "max_words": default_chunking.max_words,
+                "first_max_words": default_chunking.first_max_words,
+                "min_words": default_chunking.min_words,
+                "max_chars": default_chunking.max_chars,
+                "enabled": default_chunking.enabled,
+            },
+            "streams": streams.active(),
             "last": last_synthesis or None,
         }
 
@@ -168,7 +918,12 @@ def main() -> None:
                     config_paths.append(config_path)
 
         for config_path in config_paths:
-            model_id = config_path.name.rstrip(".onnx.json")
+            model_id = config_path.name
+            for suffix in (".onnx.json", ".json"):
+                if model_id.endswith(suffix):
+                    model_id = model_id[: -len(suffix)]
+                    break
+
             if model_id in voices_dict:
                 continue
 
@@ -213,9 +968,13 @@ def main() -> None:
 
         return model_id
 
-    @app.route("/synthesize", methods=["POST"])
-    def app_synthesize() -> bytes:
-        """Synthesize audio from text.
+    @app.route("/synthesize", methods=["POST", "GET"])
+    @app.route("/", methods=["POST"])
+    def app_synthesize() -> Response:
+        """Synthesize audio from text and stream it as a WAV file.
+
+        Audio starts flowing as soon as the first chunk of text has been
+        synthesized; the response uses chunked transfer encoding.
 
         Expects a JSON object with the format:
         {
@@ -225,133 +984,106 @@ def main() -> None:
           "speaker_id": "<speaker id>",  (optional, overrides speaker)
           "length_scale": 1.0,           (optional)
           "noise_scale": 0.667,          (optional)
-          "length_w_scale": 0.8          (optional)
+          "noise_w_scale": 0.8,          (optional)
+          "volume": 1.0,                 (optional)
+          "normalize_audio": false,      (optional, default: false when chunked)
+          "sentence_silence": 0.0,       (optional)
+          "chunk_silence": 0.0,          (optional)
+          "chunk": { ... },              (optional, see /stream)
+          "stream_id": "<id>",           (optional, for /stop)
+          "group": "<id>",               (optional, utterance id: streams of the
+                                          same group never preempt each other)
+          "channel": "<name>",           (optional, preemption group)
+          "preempt": true,               (optional)
+          "format": "wav" | "raw"        (optional)
         }
+
+        The same fields may be passed as query parameters, and a plain text body
+        is accepted as "text".
         """
-        data = json.loads(request.data)
-        text = data.get("text", "").strip()
-        if not text:
-            raise ValueError("No text provided")
+        data = _request_data()
+        output_format = str(data.get("format") or "wav").lower()
+        if output_format in ("pcm", "raw", "l16"):
+            output_format = "raw"
+        elif request.accept_mimetypes.best in ("audio/pcm", "audio/l16", "audio/basic"):
+            output_format = "raw"
+        else:
+            output_format = "wav"
 
-        _LOGGER.debug(data)
+        return audio_response(data, output_format)
 
-        model_id = data.get("voice", default_model_id)
-        voice = loaded_voices.get(model_id)
-        if voice is None:
-            for data_dir in args.data_dir:
-                maybe_model_path = Path(data_dir) / f"{model_id}.onnx"
-                if maybe_model_path.exists():
-                    _LOGGER.debug("Loading voice %s", model_id)
-                    voice = PiperVoice.load(maybe_model_path, use_cuda=args.cuda)
-                    loaded_voices[model_id] = voice
-                    break
+    @app.route("/stream", methods=["POST", "GET"])
+    def app_stream() -> Response:
+        """Synthesize audio from text and stream raw 16-bit PCM.
 
-        if voice is None:
-            _LOGGER.warning("Voice not found: %s. Using default voice.", model_id)
-            voice = default_voice
+        Same fields as /synthesize. The audio format is reported in the
+        X-Piper-Sample-Rate, X-Piper-Sample-Width and X-Piper-Channels headers,
+        and the id needed to stop this stream in X-Piper-Stream-Id.
 
-        speaker_id: Optional[int] = data.get("speaker_id")
-        if (voice.config.num_speakers > 1) and (speaker_id is None):
-            speaker = data.get("speaker")
-            if speaker:
-                speaker_id = voice.config.speaker_id_map.get(speaker)
+        Example:
+          curl -N -d '{"text": "Hello world."}' localhost:5000/stream \\
+            | aplay -r 22050 -f S16_LE -t raw -
+        """
+        data = _request_data()
+        return audio_response(data, "raw")
 
-            if speaker_id is None:
-                _LOGGER.warning(
-                    "Speaker not found: '%s' in %s",
-                    speaker,
-                    voice.config.speaker_id_map.keys(),
-                )
-                speaker_id = args.speaker or voice.config.default_speaker_id
+    @app.route("/stop", methods=["POST", "GET"])
+    def app_stop() -> Dict[str, Any]:
+        """Immediately stop synthesis and output of active streams.
 
-        if (speaker_id is not None) and (speaker_id > voice.config.num_speakers):
-            speaker_id = 0
+        Expects (all optional) a JSON object with the format:
+        {
+          "stream_id": "<id>",   (stop only this stream)
+          "group": "<id>",       (stop every stream of this utterance)
+          "channel": "<name>"    (stop every stream of this channel)
+        }
 
-        syn_config = SynthesisConfig(
-            speaker_id=speaker_id,
-            length_scale=float(
-                data.get(
-                    "length_scale",
-                    (
-                        args.length_scale
-                        if args.length_scale is not None
-                        else voice.config.length_scale
-                    ),
-                )
-            ),
-            noise_scale=float(
-                data.get(
-                    "noise_scale",
-                    (
-                        args.noise_scale
-                        if args.noise_scale is not None
-                        else voice.config.noise_scale
-                    ),
-                )
-            ),
-            noise_w_scale=float(
-                data.get(
-                    "noise_w_scale",
-                    (
-                        args.noise_w_scale
-                        if args.noise_w_scale is not None
-                        else voice.config.noise_w_scale
-                    ),
-                )
-            ),
+        With no parameters, every active stream is stopped.
+
+        Inference stops before the next chunk, the HTTP response ends, and the
+        engine is immediately available for the next request. The model stays
+        loaded, so there is no warm-up cost afterwards.
+        """
+        data = _request_data()
+        stopped = streams.cancel(
+            stream_id=data.get("stream_id"),
+            channel=data.get("channel"),
+            group=data.get("group"),
+        )
+        _LOGGER.debug("Stopped streams: %s", stopped)
+        return {"stopped": stopped, "num_stopped": len(stopped)}
+
+    # -------------------------------------------------------------------------
+
+    if not args.no_warmup:
+        # Pay the first-inference cost (ONNX/CUDA lazy init) before any client
+        # is waiting for audio.
+        warmup_start = time.monotonic()
+        num_warmup_samples = 0
+        for audio_chunk in default_voice.synthesize(args.warmup_text):
+            num_warmup_samples += len(audio_chunk.audio_float_array)
+
+        _LOGGER.info(
+            "Warmed up voice %s in %.3fs (%d samples discarded)",
+            default_model_id,
+            time.monotonic() - warmup_start,
+            num_warmup_samples,
         )
 
-        _LOGGER.debug("Synthesizing text: '%s' with config=%s", text, syn_config)
-        phonemes: List[str] = []
-        alignments: List[Dict[str, Any]] = []
-        start_time = time.monotonic()
-        with io.BytesIO() as wav_io:
-            wav_file: wave.Wave_write = wave.open(wav_io, "wb")
-            with wav_file:
-                wav_params_set = False
-                for i, audio_chunk in enumerate(
-                    voice.synthesize(text, syn_config, include_alignments=True)
-                ):
-                    if not wav_params_set:
-                        wav_file.setframerate(audio_chunk.sample_rate)
-                        wav_file.setsampwidth(audio_chunk.sample_width)
-                        wav_file.setnchannels(audio_chunk.sample_channels)
-                        wav_params_set = True
+    return app
 
-                    if i > 0:
-                        wav_file.writeframes(
-                            bytes(
-                                int(
-                                    voice.config.sample_rate * args.sentence_silence * 2
-                                )
-                            )
-                        )
 
-                    wav_file.writeframes(audio_chunk.audio_int16_bytes)
+def main() -> None:
+    """Run HTTP server."""
+    args = get_parser().parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
-                    # Collect phonemes/alignments for the web page
-                    phonemes.extend(audio_chunk.phonemes)
-                    for alignment in audio_chunk.phoneme_alignments or []:
-                        alignments.append(
-                            {
-                                "phoneme": alignment.phoneme,
-                                "seconds": alignment.num_samples
-                                / audio_chunk.sample_rate,
-                            }
-                        )
+    app = create_app(args)
+    _LOGGER.info("Listening on http://%s:%s", args.host, args.port)
 
-            synthesize_seconds = time.monotonic() - start_time
-            last_synthesis.clear()
-            last_synthesis.update(
-                text=text,
-                synthesize_seconds=synthesize_seconds,
-                phonemes=phonemes,
-                alignments=alignments,
-            )
-
-            return wav_io.getvalue()
-
-    app.run(host=args.host, port=args.port)
+    # threaded=True is required: /stop must be handled while /synthesize is
+    # still streaming.
+    app.run(host=args.host, port=args.port, threaded=True)
 
 
 if __name__ == "__main__":

--- a/src/piper/templates/index.html
+++ b/src/piper/templates/index.html
@@ -518,7 +518,9 @@
               const response = await fetch("synthesize", {
                   method: "POST",
                   headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({ text: text }),
+                  // stream: false -> buffered WAV with a complete header, which
+                  // is what <audio> needs. Command-line clients stream instead.
+                  body: JSON.stringify({ text: text, stream: false }),
               });
 
               if (!response.ok) {

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,126 @@
+"""Tests for text chunking."""
+
+import pytest
+
+from piper.chunking import (
+    PROFILES,
+    ChunkingConfig,
+    chunk_text,
+    iter_chunks,
+    normalize_text,
+)
+
+
+def test_disabled_chunking() -> None:
+    """Text is passed through unchanged (but normalized) when disabled."""
+    chunks = list(chunk_text("Hello\nworld.  Again.", PROFILES["off"]))
+    assert chunks == ["Hello world. Again."]
+
+
+def test_empty_text() -> None:
+    assert not list(chunk_text("   \n\t "))
+
+
+def test_normalize_text() -> None:
+    assert normalize_text(" a \n b\tc  ") == "a b c"
+
+
+def test_first_chunk_is_shorter() -> None:
+    """Time-to-first-audio is what matters: the first chunk is smaller."""
+    config = ChunkingConfig(max_words=5, first_max_words=2, min_words=1)
+    chunks = list(chunk_text("one two three four five six seven eight", config))
+    assert chunks[0] == "one two"
+    assert all(len(chunk.split()) <= 5 for chunk in chunks)
+
+
+def test_break_on_sentence() -> None:
+    """A sentence boundary always ends a chunk."""
+    chunks = list(chunk_text("Alpha beta. Gamma delta epsilon zeta.", ChunkingConfig()))
+    assert chunks[0] == "Alpha beta."
+
+
+def test_break_on_clause() -> None:
+    config = ChunkingConfig(max_words=10, first_max_words=0, min_words=2)
+    chunks = list(chunk_text("Hello there, my dear friend, how are you?", config))
+    assert chunks[0] == "Hello there,"
+    assert chunks[1] == "my dear friend,"
+
+
+def test_clause_break_respects_min_words() -> None:
+    config = ChunkingConfig(max_words=10, first_max_words=0, min_words=3)
+    chunks = list(chunk_text("Yes, indeed my friend, this is fine.", config))
+    assert chunks[0] == "Yes, indeed my friend,"
+
+
+def test_abbreviations_are_not_sentence_ends() -> None:
+    config = ChunkingConfig(max_words=10, first_max_words=0, min_words=1)
+    chunks = list(chunk_text("Mr. Smith and Dr. Jones arrived.", config))
+    assert chunks == ["Mr. Smith and Dr. Jones arrived."]
+
+
+def test_initials_are_not_sentence_ends() -> None:
+    config = ChunkingConfig(max_words=10, first_max_words=0, min_words=1)
+    chunks = list(chunk_text("Written by J. R. Tolkien here.", config))
+    assert chunks == ["Written by J. R. Tolkien here."]
+
+
+def test_short_tail_is_merged() -> None:
+    """A dangling one-word chunk is merged into the previous one."""
+    config = ChunkingConfig(max_words=3, first_max_words=3, min_words=2)
+    chunks = list(chunk_text("one two three four", config))
+    assert chunks == ["one two three four"]
+
+    config.merge_short_tail = False
+    assert list(chunk_text("one two three four", config)) == ["one two three", "four"]
+
+
+def test_max_chars_splits_long_words() -> None:
+    """Inference time must stay bounded even without whitespace."""
+    text = "x" * 100
+    chunks = list(chunk_text(text, ChunkingConfig(max_chars=30)))
+    assert all(len(chunk) <= 30 for chunk in chunks)
+    assert "".join(chunks) == text
+
+
+def test_chunk_offsets() -> None:
+    """Offsets allow the caller to map audio back to the source text."""
+    text = "Alpha beta. Gamma delta."
+    chunks = list(iter_chunks(text, ChunkingConfig()))
+    for chunk in chunks:
+        assert text[chunk.start : chunk.end] == chunk.text
+
+    assert chunks[-1].is_last
+    assert not chunks[0].is_last
+    assert [chunk.index for chunk in chunks] == list(range(len(chunks)))
+
+
+def test_profiles_are_ordered_by_latency() -> None:
+    assert PROFILES["instant"].first_limit <= PROFILES["responsive"].first_limit
+    assert PROFILES["responsive"].first_limit <= PROFILES["balanced"].first_limit
+    assert not PROFILES["off"].enabled
+    assert not PROFILES["smooth"].break_on_clause
+
+
+def test_from_mapping_with_prefix_and_profile() -> None:
+    config = ChunkingConfig.from_mapping(
+        {
+            "PIPER_CHUNK_PROFILE": "instant",
+            "PIPER_CHUNK_MAX_WORDS": "7",
+            "PIPER_CHUNK_MERGE_SHORT_TAIL": "false",
+            "UNRELATED": "x",
+        },
+        prefix="piper_chunk_",
+    )
+    assert config.max_words == 7
+    assert config.first_max_words == PROFILES["instant"].first_max_words
+    assert config.merge_short_tail is False
+
+
+def test_from_mapping_rejects_unknown_profile() -> None:
+    with pytest.raises(ValueError):
+        ChunkingConfig.from_mapping({"profile": "nope"})
+
+
+def test_from_mapping_abbreviations_from_string() -> None:
+    config = ChunkingConfig.from_mapping({"abbreviations": "abc,Def"})
+    assert config.abbreviations == {"abc", "def"}

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1,0 +1,338 @@
+"""Tests for the streaming HTTP server."""
+
+import io
+import json
+import threading
+import time
+import wave
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+flask = pytest.importorskip("flask")
+
+# pylint: disable=wrong-import-position
+from piper.http_server import (  # noqa: E402  (after importorskip)
+    StreamRegistry,
+    create_app,
+    get_parser,
+    wav_header,
+)
+
+_TESTS_DIR = Path(__file__).parent
+_TEST_VOICE = _TESTS_DIR / "test_voice.onnx"
+
+# The test voice always produces one second of silence per sentence
+SAMPLE_RATE = 22050
+BYTES_PER_SENTENCE = SAMPLE_RATE * 2
+
+
+@pytest.fixture(name="app")
+def app_fixture() -> Any:
+    args = get_parser().parse_args(
+        [
+            "-m",
+            str(_TEST_VOICE),
+            "--data-dir",
+            str(_TESTS_DIR),
+            "--no-warmup",
+        ]
+    )
+    return create_app(args)
+
+
+@pytest.fixture(name="client")
+def client_fixture(app: Any) -> Any:
+    return app.test_client()
+
+
+# -----------------------------------------------------------------------------
+# WAV header
+# -----------------------------------------------------------------------------
+
+
+def test_wav_header_streaming() -> None:
+    """A streaming header must be readable before the audio exists."""
+    header = wav_header(SAMPLE_RATE)
+    assert len(header) == 44
+    assert header[:4] == b"RIFF"
+    assert header[8:12] == b"WAVE"
+    # Length fields are "big enough" so players stream until end of data
+    assert int.from_bytes(header[40:44], "little") > 1_000_000
+
+
+def test_wav_header_known_length() -> None:
+    header = wav_header(SAMPLE_RATE, num_bytes=100)
+    assert int.from_bytes(header[40:44], "little") == 100
+    assert int.from_bytes(header[4:8], "little") == 136
+
+    with io.BytesIO(header + bytes(100)) as wav_io:
+        with wave.open(wav_io, "rb") as wav_file:
+            assert wav_file.getframerate() == SAMPLE_RATE
+            assert wav_file.getsampwidth() == 2
+            assert wav_file.getnchannels() == 1
+            assert wav_file.getnframes() == 50
+
+
+# -----------------------------------------------------------------------------
+# Synthesis
+# -----------------------------------------------------------------------------
+
+
+def test_synthesize_buffered_wav(client: Any) -> None:
+    """stream=false returns a complete WAV file (what browsers need)."""
+    response = client.post("/synthesize", json={"text": "Test one.", "stream": False})
+    assert response.status_code == 200
+    assert response.mimetype == "audio/wav"
+
+    with io.BytesIO(response.data) as wav_io:
+        with wave.open(wav_io, "rb") as wav_file:
+            assert wav_file.getframerate() == SAMPLE_RATE
+            assert wav_file.getnframes() == SAMPLE_RATE
+
+
+def test_synthesize_streams_wav_header_first(client: Any) -> None:
+    """Audio must start flowing before synthesis is finished."""
+    response = client.post("/synthesize", json={"text": "Test one. Test two."})
+    assert response.status_code == 200
+    assert response.headers["X-Piper-Sample-Rate"] == str(SAMPLE_RATE)
+
+    stream: Iterator[bytes] = response.iter_encoded()
+    first = next(stream)
+    assert first.startswith(b"RIFF")
+
+
+def test_stream_raw_pcm(client: Any) -> None:
+    response = client.post("/stream", json={"text": "Test one. Test two."})
+    assert response.status_code == 200
+    assert response.mimetype == "audio/L16"
+    assert response.headers["X-Piper-Channels"] == "1"
+    assert len(response.data) == 2 * BYTES_PER_SENTENCE
+
+
+def test_stream_is_chunked_by_default(client: Any) -> None:
+    """Chunking splits one long sentence into several inference calls."""
+    text = "one two three four five six seven eight nine ten eleven twelve"
+    response = client.post("/stream", json={"text": text})
+    # Each chunk of the sentence produces its own "sentence" of audio
+    assert len(response.data) > BYTES_PER_SENTENCE
+
+    no_chunking = client.post(
+        "/stream", json={"text": text, "chunk": {"enabled": False}}
+    )
+    assert len(no_chunking.data) == BYTES_PER_SENTENCE
+
+
+def test_stream_accepts_query_parameters(client: Any) -> None:
+    response = client.get("/stream?text=Test+one.")
+    assert response.status_code == 200
+    assert len(response.data) == BYTES_PER_SENTENCE
+
+
+def test_stream_accepts_plain_text_body(client: Any) -> None:
+    response = client.post("/stream", data="Test one.".encode("utf-8"))
+    assert response.status_code == 200
+    assert len(response.data) == BYTES_PER_SENTENCE
+
+
+def test_json_body_with_a_form_content_type(client: Any) -> None:
+    """`curl -d '{...}'` sends JSON with a form content type by default."""
+    response = client.post(
+        "/stream",
+        data=json.dumps({"text": "Test one.", "chunk": {"enabled": False}}),
+        content_type="application/x-www-form-urlencoded",
+    )
+    assert response.status_code == 200
+    assert len(response.data) == BYTES_PER_SENTENCE
+
+
+def test_form_parameters_are_still_read(client: Any) -> None:
+    response = client.post("/stream", data={"text": "Test one.", "chunk_max_words": 0})
+    assert response.status_code == 200
+    assert len(response.data) == BYTES_PER_SENTENCE
+
+
+def test_legacy_post_to_root(client: Any) -> None:
+    """The old `curl -d '{"text": ...}' host:5000 | aplay -` still works."""
+    response = client.post("/", json={"text": "Test one."})
+    assert response.status_code == 200
+    assert response.data.startswith(b"RIFF")
+
+
+def test_silence_between_sentences_and_chunks(client: Any) -> None:
+    response = client.post(
+        "/stream",
+        json={
+            "text": "Test one. Test two.",
+            "chunk": {"enabled": False},
+            "sentence_silence": 0.5,
+        },
+    )
+    assert len(response.data) == (2 * BYTES_PER_SENTENCE) + int(SAMPLE_RATE * 0.5) * 2
+
+
+def test_info_reports_chunking_and_last_utterance(client: Any) -> None:
+    client.post("/stream", json={"text": "Test one."})
+    info = json.loads(client.get("/info").data)
+    assert info["voice"]["sample_rate"] == SAMPLE_RATE
+    assert info["chunking"]["profile"] == "responsive"
+    assert info["last"]["audio_seconds"] == pytest.approx(1.0)
+    assert info["last"]["cancelled"] is False
+    assert info["last"]["first_audio_seconds"] is not None
+
+
+def test_no_text_is_an_error(client: Any) -> None:
+    """Bad requests are reported as JSON, not as an HTML error page."""
+    response = client.post("/stream", json={"text": "  "})
+    assert response.status_code == 400
+    assert "error" in json.loads(response.data)
+
+
+def test_unknown_voice_falls_back_to_default(client: Any) -> None:
+    response = client.post("/stream", json={"text": "Test one.", "voice": "nope"})
+    assert response.status_code == 200
+    assert response.headers["X-Piper-Voice"] == "test_voice"
+
+
+def test_no_voice_uses_default(client: Any) -> None:
+    """speech-dispatcher generic modules pass "no_voice" when unset."""
+    response = client.post("/stream", json={"text": "Test one.", "voice": "no_voice"})
+    assert response.headers["X-Piper-Voice"] == "test_voice"
+
+
+def test_stop_endpoint_reports_stopped_streams(client: Any) -> None:
+    response = json.loads(client.post("/stop", json={}).data)
+    assert response == {"stopped": [], "num_stopped": 0}
+
+
+def test_stop_cancels_a_stream_in_progress(app: Any) -> None:
+    """A stop request ends the response instead of playing the whole text."""
+    client = app.test_client()
+    long_text = "Test sentence. " * 50
+    response = client.post(
+        "/stream",
+        json={"text": long_text, "stream_id": "s1", "chunk": {"enabled": False}},
+    )
+    stream = response.iter_encoded()
+
+    # First piece of audio proves synthesis started
+    assert len(next(stream)) > 0
+
+    stopped = json.loads(app.test_client().post("/stop", json={"stream_id": "s1"}).data)
+    assert stopped["stopped"] == ["s1"]
+
+    num_bytes = sum(len(data) for data in stream)
+    # 50 sentences would be 50 seconds of audio; we stop long before that
+    assert num_bytes < 50 * BYTES_PER_SENTENCE
+    response.close()
+
+
+# -----------------------------------------------------------------------------
+# Stream registry (interruption logic)
+# -----------------------------------------------------------------------------
+
+
+def test_registry_preempts_same_channel() -> None:
+    registry = StreamRegistry()
+    first = registry.start(channel="screen-reader")
+    second = registry.start(channel="screen-reader")
+    assert first.is_cancelled
+    assert not second.is_cancelled
+
+
+def test_registry_does_not_preempt_other_channels() -> None:
+    registry = StreamRegistry()
+    first = registry.start(channel="a")
+    second = registry.start(channel="b")
+    assert not first.is_cancelled
+    assert not second.is_cancelled
+
+
+def test_registry_does_not_preempt_same_group() -> None:
+    """Chunks of one utterance may arrive out of order: they must not fight."""
+    registry = StreamRegistry()
+    first = registry.start(stream_id="u1-0", group="u1")
+    second = registry.start(stream_id="u1-1", group="u1")
+    assert not first.is_cancelled
+    assert not second.is_cancelled
+
+    third = registry.start(stream_id="u2-0", group="u2")
+    assert first.is_cancelled
+    assert second.is_cancelled
+    assert not third.is_cancelled
+
+
+def test_registry_no_preempt_option() -> None:
+    registry = StreamRegistry()
+    first = registry.start(channel="c")
+    second = registry.start(channel="c", preempt=False)
+    assert not first.is_cancelled
+    assert not second.is_cancelled
+
+
+def test_registry_cancel_by_group_and_channel() -> None:
+    registry = StreamRegistry()
+    first = registry.start(stream_id="a", group="g1", channel="c")
+    second = registry.start(stream_id="b", group="g1", channel="c")
+    assert registry.cancel(group="g1") == ["a", "b"]
+    assert first.is_cancelled and second.is_cancelled
+
+    third = registry.start(stream_id="c", channel="other")
+    assert registry.cancel(channel="other") == ["c"]
+    assert third.is_cancelled
+
+
+def test_registry_finish_removes_stream() -> None:
+    registry = StreamRegistry()
+    stream = registry.start()
+    assert len(registry.active()) == 1
+    registry.finish(stream)
+    assert not registry.active()
+
+
+def test_registry_is_thread_safe() -> None:
+    registry = StreamRegistry()
+    errors = []
+
+    def worker(index: int) -> None:
+        try:
+            for _ in range(50):
+                stream = registry.start(channel=f"c{index % 3}")
+                registry.cancel(stream_id=stream.stream_id)
+                registry.finish(stream)
+        except Exception as error:  # pylint: disable=broad-except
+            errors.append(error)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors
+    assert not registry.active()
+
+
+def test_first_audio_is_faster_with_chunking(app: Any) -> None:
+    """Chunking exists to shorten time-to-first-audio; check it holds."""
+    client = app.test_client()
+    text = " ".join(["word"] * 40) + "."
+
+    def time_to_first_audio(chunk_enabled: bool) -> float:
+        start = time.monotonic()
+        response = client.post(
+            "/stream", json={"text": text, "chunk": {"enabled": chunk_enabled}}
+        )
+        stream = response.iter_encoded()
+        next(stream)
+        elapsed = time.monotonic() - start
+        response.close()
+        return elapsed
+
+    # The test voice is instant, so only check that both paths work and that
+    # chunking produces the first audio at least as fast.
+    chunked = time_to_first_audio(True)
+    whole = time_to_first_audio(False)
+    assert chunked <= (whole + 0.5)


### PR DESCRIPTION
I had a need for real-time tts (for use with `speech-dispatcher` & `orca` ; see next PR #286). Without having a clear generic component/layer providing text-chunking/preprocessing (and its tight integration with server threading and http semantics), I ended up delegating that to a LLM (Opus 5)

Commit messages say it all.

End-result (in combination with the subsequent PR taking care of the client-side and speech-dispatcher integration):


[![Watch the video](https://github.com/user-attachments/assets/36f75c74-647c-4cc1-90e9-4a046efa05f9)](https://github.com/user-attachments/assets/36f75c74-647c-4cc1-90e9-4a046efa05f9)


- Not as clean as #84 (but more complete regarding actual real-time usages)
- Fixes https://github.com/rhasspy/piper/issues/376, #48 and #185
- `/stop` fixes https://github.com/rhasspy/piper/issues/437