### PR TITLE
speech-dispatcher module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `piper.chunking`: configurable text chunking on word/punctuation/sentence boundaries
+- Add `piper.client` and the `piper-client` command: streaming HTTP client with chunking, prefetching, instant interruption and audio playback
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Add `piper.chunking`: configurable text chunking on word/punctuation/sentence boundaries
 - Add `piper.client` and the `piper-client` command: streaming HTTP client with chunking, prefetching, instant interruption and audio playback
+- Add `piper.speechd_module` and the `sd_piper` command: Speech Dispatcher output module for screen readers
+- Speech Dispatcher module: start the server on demand (systemd user unit, transient unit or detached process) without delaying module load, and `sd_piper --print-service` to install it as a user service
+- Client and Speech Dispatcher module: play audio at the sample rate of the requested voice instead of the server's default voice (voices mixing 22.05 kHz and 44.1 kHz were slowed down or sped up)
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `piper.chunking`: configurable text chunking on word/punctuation/sentence boundaries
+
 ## 1.8.0
 
 - Add Thai phonemizer using TLTK in the new `th` extra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `piper.speechd_module` and the `sd_piper` command: Speech Dispatcher output module for screen readers
 - Speech Dispatcher module: start the server on demand (systemd user unit, transient unit or detached process) without delaying module load, and `sd_piper --print-service` to install it as a user service
 - Client and Speech Dispatcher module: play audio at the sample rate of the requested voice instead of the server's default voice (voices mixing 22.05 kHz and 44.1 kHz were slowed down or sped up)
+- Add example Speech Dispatcher configurations in `etc/speech-dispatcher/` and `docs/SPEECHD.md`
 
 ## 1.8.0
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ pip install piper-tts
 * 🗣️ [Voices][voices]
 * 🖥️ [Command-line interface][cli]
 * 🌐 [Web server][api-http]
+* 🗣️ [Screen readers (Speech Dispatcher)][speechd]
 * 🐍 [Python API][api-python]
 * 🔧 [C/C++ API][libpiper]
 * 🏋️ [Training new voices][training]
@@ -53,6 +54,7 @@ Bindings to use Piper in programming languages other than Python and C/C++:
 [espeak-ng]: https://github.com/espeak-ng/espeak-ng
 [cli]: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/CLI.md
 [api-http]: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/API_HTTP.md
+[speechd]: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/SPEECHD.md
 [api-python]: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/API_PYTHON.md
 [training]: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/TRAINING.md
 [building]: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/BUILDING.md

--- a/docs/SPEECHD.md
+++ b/docs/SPEECHD.md
@@ -1,0 +1,346 @@
+# 🗣️ Screen readers (Speech Dispatcher)
+
+Piper can be used as a [Speech Dispatcher][speechd] output module, which makes it
+available to screen readers (Orca, NVDA over a bridge, `spd-say`, Firefox reader
+mode, Okular, ...).
+
+Screen reading has requirements that a "synthesize a WAV file" pipeline cannot
+meet:
+
+| Requirement | How it is solved |
+| --- | --- |
+| No warm-up per utterance | [`piper.http_server`](API_HTTP.md) keeps the voice model in memory |
+| Speech must start immediately | The server streams audio while synthesizing, and text is split into small chunks ([chunking](#chunking)) |
+| Speech must stop immediately | `POST /stop`, connection close, or a new request on the same channel aborts inference *and* playback |
+| Voice/rate from the screen reader | The output module maps Speech Dispatcher parameters to Piper's |
+
+Two integrations are provided:
+
+* **[Native output module](#native-module-recommended)** (`sd_piper`): speaks the
+  Speech Dispatcher module protocol, so `STOP`, `CANCEL` and `PAUSE` really
+  interrupt speech, and index marks are reported. **Recommended.**
+* **[Generic module](#generic-module)** (`piper-client` + `sd_generic`): a single
+  shell command per utterance. Simpler, less responsive.
+
+---
+
+## 1. Start the server
+
+Install the HTTP extra and download a voice:
+
+``` sh
+python3 -m pip install 'piper-tts[http]'
+python3 -m piper.download_voices en_US-kristin-medium
+```
+
+Run the server (it warms the model up at startup, so the first utterance is not
+slower than the others):
+
+``` sh
+python3 -m piper.http_server -m en_US-kristin-medium --chunk-profile responsive
+```
+
+Check it:
+
+``` sh
+curl -s localhost:5000/info | python3 -m json.tool
+piper-client "Piper is running."
+```
+
+### Run it as a user service
+
+`sd_piper` writes a unit for the voice in your module configuration:
+
+``` sh
+sd_piper --print-service > ~/.config/systemd/user/piper-server.service
+systemctl --user daemon-reload
+systemctl --user enable --now piper-server
+```
+
+This is the recommended setup: the server is up before the first utterance,
+systemd restarts it if it dies, and it stops at logout.
+
+The generated unit backs off between restarts (2 s, 5 s, 11 s, 26 s, 60 s) and
+gives up after five failures, so a mistake that cannot be fixed by restarting —
+a voice that is not downloaded, typically — is reported once instead of looping:
+
+``` sh
+systemctl --user status piper-server     # "failed" instead of restarting forever
+journalctl --user -u piper-server -n 30  # why it failed
+systemctl --user reset-failed piper-server && systemctl --user start piper-server
+```
+
+If you write the unit yourself, remember that systemd expands neither `~` nor
+`$PATH`: `ExecStart` needs absolute paths (`sd_piper --print-service` does this
+for you).
+
+You do not have to run a service at all, though — see [starting the server on
+demand](#starting-the-server-on-demand).
+
+---
+
+## 2. Native module (recommended)
+
+Install the module binary and its configuration (no root needed):
+
+``` sh
+mkdir -p ~/.local/libexec/speech-dispatcher-modules ~/.config/speech-dispatcher/modules
+ln -sf "$(command -v sd_piper)" ~/.local/libexec/speech-dispatcher-modules/sd_piper
+sd_piper --print-config > ~/.config/speech-dispatcher/modules/piper.conf
+```
+
+Speech Dispatcher discovers every `sd_<name>` binary in that directory, so the
+module is registered as `piper` with `piper.conf` as its configuration. No
+`speechd.conf` change is required. If you prefer to be explicit, add:
+
+```
+AddModule "piper" "sd_piper" "piper.conf"
+DefaultModule piper
+```
+
+Restart the daemon and test:
+
+``` sh
+systemctl --user restart speech-dispatcher   # or: pkill speech-dispatcher
+spd-say -O                                   # list output modules: "piper"
+spd-say -o piper "Hello from Piper."
+spd-say -o piper -r 50 "Now a little faster."
+```
+
+Set Piper as the default voice in your screen reader (Orca: *Preferences →
+Voice → Speech system/synthesizer*) or make it the default module with
+`DefaultModule piper` in `~/.config/speech-dispatcher/speechd.conf`.
+
+### What the module supports
+
+| Speech Dispatcher | Piper |
+| --- | --- |
+| `SET RATE` (-100..100) | `length_scale`, scaled by `PiperRateFactor` (rate 100 = 3x faster by default) |
+| `SET VOLUME` (-100..100) | audio multiplier (100 = unchanged) |
+| `SET VOICE` (`FEMALE1`, ...) + `SET LANGUAGE` | voice chosen from the `AddVoice` table |
+| `SET SYNTHESIS_VOICE` | Piper voice name, used as-is |
+| `LIST VOICES` | `AddVoice` entries plus every voice the server reports |
+| `STOP` / `CANCEL` | playback killed, inference abandoned, `703 STOP` |
+| `PAUSE` | treated as a stop (`704 PAUSE`); Piper has no resume position |
+| `CHAR`, `KEY` | spoken as a single chunk |
+| index marks | reported as each chunk of text is played |
+| `SET PITCH` | not supported by Piper voices (ignored) |
+| `SOUND_ICON` | not supported (Speech Dispatcher falls back) |
+
+Audio can be played by the module (default) or handed back to Speech Dispatcher:
+
+```
+PiperAudio player   # this module plays: interruption drops buffered audio at once
+PiperAudio server   # speech-dispatcher plays, using AudioOutputMethod
+```
+
+`player` is the default because it gives the crispest interruption: the player
+process is killed, so nothing that was already buffered is heard.
+
+Logs go to `~/.cache/speech-dispatcher/log/piper.log`.
+
+### Starting the server on demand
+
+If nothing answers at `PiperURL`, the module starts a server itself, so
+`spd-say -o piper "hello"` works with no server running and no user service.
+Only the first utterance waits (the time it takes to load the model).
+
+```
+PiperAutostart auto              # auto (default) | yes | no
+PiperServerManager auto          # auto | systemd | process | none
+PiperServerService "piper-server.service"
+#PiperServerCommand "python3 -m piper.http_server -m /path/voice.onnx"
+PiperServerTimeout 20
+```
+
+How it works, in order:
+
+1. **`INIT` never waits.** Speech Dispatcher blocks while a module loads, so the
+   server is started in the background; an utterance that arrives too early
+   waits in the module's worker thread instead, and `STOP` still interrupts it.
+2. **A server that already answers is reused** — nothing is started, and two
+   module instances never start two servers: whoever starts one holds an
+   advisory lock in `$XDG_RUNTIME_DIR` until it answers, and the others wait
+   for it instead of starting their own.
+3. **systemd first.** If the user unit named by `PiperServerService` exists, it
+   is started (`systemctl --user start piper-server.service`). Otherwise the
+   server is started as a transient unit (`systemd-run --user --collect
+   --unit=piper-server-<port>`), so it is supervised by systemd, survives the
+   module, and is cleaned up at logout. Without systemd, it is started as a
+   detached process logging to `~/.local/state/piper/http_server.log`.
+4. **The command** is `PiperServerCommand` (`~` is expanded), or, by default,
+   derived from the configuration:
+   `python3 -m piper.http_server --host 127.0.0.1 --port <PiperURL port> --model <DefaultVoice>`.
+5. **Only local servers.** A remote `PiperURL` is never started, and a failed
+   start is not retried for 30 s, so every utterance does not pay the timeout.
+
+The started server keeps running after Speech Dispatcher exits: the next
+session finds a warm model. Stop it with `systemctl --user stop
+piper-server-5000` (transient unit), or set `PiperAutostart no` and manage it
+yourself.
+
+---
+
+## 3. Generic module
+
+If you would rather use the stock `sd_generic`:
+
+``` sh
+cp etc/speech-dispatcher/modules/piper-generic.conf ~/.config/speech-dispatcher/modules/
+systemctl --user restart speech-dispatcher
+spd-say -o piper-generic "Hello from the generic module."
+```
+
+It runs, for each utterance:
+
+``` sh
+echo "$DATA" | piper-client --voice "$VOICE" --rate $RATE --sd-volume $VOLUME
+```
+
+`piper-client` chunks the text, streams the audio from the server and plays it,
+and stops playback immediately when Speech Dispatcher terminates it (SIGTERM).
+Compared to the native module you lose index marks, `PAUSE`, and you pay one
+process start (~50 ms) per utterance.
+
+This replaces the older recipe of calling the `piper` CLI directly, which
+reloaded the model for every utterance.
+
+---
+
+## 4. The command-line client
+
+`piper-client` is also useful on its own:
+
+``` sh
+piper-client "Hello world."                       # play
+echo "long text..." | piper-client                # from stdin
+piper-client --output raw "Hi" | aplay -r 22050 -f S16_LE -t raw -
+piper-client --stop                               # interrupt whatever is speaking
+piper-client --info                               # server info
+piper-client --list-voices
+```
+
+Useful options (all of them also read an environment variable, which is handy
+inside a `GenericExecuteSynth` command):
+
+| Option | Environment | Meaning |
+| --- | --- | --- |
+| `--url` | `PIPER_URL` | server URL (default `http://localhost:5000`) |
+| `--voice` | `PIPER_VOICE`, `VOICE` | voice name (`no_voice` and `*.onnx` are handled) |
+| `--rate` | `PIPER_RATE`, `RATE` | speech rate in [-100, 100] |
+| `--rate-factor` | `PIPER_RATE_FACTOR` | how much `rate=100` speeds speech up (default 3) |
+| `--length-scale` | `PIPER_LENGTH_SCALE` | phoneme length, overrides `--rate` |
+| `--sd-volume` | `PIPER_VOLUME`, `VOLUME` | volume in [-100, 100] (100 = unchanged) |
+| `--chunk-profile` | `PIPER_CHUNK_PROFILE` | `instant`, `responsive`, `balanced`, `smooth`, `off` |
+| `--chunk-max-words` etc. | `PIPER_CHUNK_MAX_WORDS`, ... | individual chunking knobs |
+| `--chunk-mode` | `PIPER_CHUNK_MODE` | `client` (default) or `server` |
+| `--prefetch` | `PIPER_PREFETCH` | chunks synthesized ahead of playback |
+| `--player` | `PIPER_PLAYER` | player command template, or `auto` |
+| `--player-latency-ms` | `PIPER_PLAYER_LATENCY_MS` | playback buffer (default 40 ms) |
+| `--channel` | `PIPER_CHANNEL` | preemption group on the server |
+
+Example of a custom player (PipeWire, specific sink):
+
+``` sh
+piper-client --player "pw-play --raw --format=s16 --rate={rate} --channels=1 --latency={latency_ms}ms --target=my-sink -" "Hello."
+```
+
+A "read the selection aloud" hotkey becomes:
+
+``` sh
+xclip -o -selection primary | piper-client --channel hotkey
+```
+
+Press it again and the previous reading is interrupted automatically (same
+channel).
+
+---
+
+## Chunking
+
+Piper synthesizes one sentence at a time, so a long sentence means a long wait
+before the first sound. The client (or the server) therefore splits text on
+word, punctuation and sentence boundaries before synthesis.
+
+Splitting is a trade-off: short chunks start faster, but prosody suffers and
+boundary artifacts can appear. Nothing is hardcoded — pick a profile and adjust:
+
+| Profile | First chunk | Chunks | First audio | Speech length | Use for |
+| --- | --- | --- | --- | --- | --- |
+| `instant` | 2 words | 3 words | 50 ms | +37% | slow machines, "what is under the cursor" |
+| `responsive` | 3 words | 5 words | 132 ms | +18% | **default**, screen reading |
+| `balanced` | 4 words | 10 words | ~150 ms | +10% | mixed reading |
+| `smooth` | sentence | sentence | 135 ms | +0% | reading documents |
+| `off` | — | — | 1030 ms | +0% | one request, one utterance |
+
+(measured with `en_US-lessac-low` on a laptop CPU and a 30-word text; the
+"speech length" column is the price of chunking: each chunk gets its own
+sentence-like prosody, so more pauses are inserted.)
+
+Individual knobs (`--chunk-max-words`, `PiperChunkMinWords`, `max_chars`,
+`break_on_clause`, `abbreviations`, ...) are documented in
+[`piper/chunking.py`](../src/piper/chunking.py) and accepted by the CLI, the
+module config, and the HTTP API.
+
+If you hear clicks at chunk boundaries, add a few milliseconds of silence
+between chunks (`--chunk-silence 0.02` / `PiperChunkSilence 0.02`) or use a
+larger profile.
+
+Audio normalization is switched off automatically as soon as text is chunked:
+normalizing each chunk to full scale makes the volume jump from chunk to chunk.
+Use `--sd-volume` / `SET VOLUME` (or `PiperNormalize 1`, at the cost of that
+pumping) if the result is too quiet.
+
+---
+
+## Latency checklist
+
+1. **Server running before the screen reader** — otherwise the first utterance
+   pays the model load (~1 s).
+2. **Warm-up enabled** (default) — the first inference is the expensive one.
+3. **Voice quality** — `low` and `medium` voices are much faster than `high`;
+   for screen reading `medium` is usually the sweet spot.
+4. **Chunk profile** — the single most effective knob for time-to-first-audio.
+5. **Player latency** — 40 ms is a good default; increase it if audio breaks up.
+6. **Rate** — a high rate shortens the audio, which also shortens synthesis.
+7. Measure: `curl -s localhost:5000/info` reports `first_audio_seconds` for the
+   last utterance.
+
+---
+
+## Troubleshooting
+
+**"dummy" module speaks an error message**
+Speech Dispatcher could not talk to the module. Check
+`~/.cache/speech-dispatcher/log/piper.log` and that `sd_piper` is executable and
+reachable through the symlink.
+
+**No sound, no error**
+Test the player alone:
+`piper-client --output raw "test" | aplay -r 22050 -f S16_LE -t raw -`.
+`pw-play` needs the trailing `-` to read stdin. In `player` mode the module
+inherits the environment of `speech-dispatcher`, so `PULSE_SERVER`/`PULSE_SINK`
+must be visible there.
+
+**Speech does not stop**
+With the native module, `STOP` kills the player process. If you configured
+`PiperAudio server`, stopping is handled by Speech Dispatcher's audio layer
+instead; try `PiperAudio player`.
+
+**Speech is slow and low-pitched (or fast and high-pitched)**
+That is an audio sample rate mismatch. Voices do not share one rate
+(`fr_FR-tom-medium` is 44.1 kHz, `en_US-kristin-medium` 22.05 kHz); the module
+and `piper-client` use the rate of the voice being spoken, so this should not
+happen — check `curl -s localhost:5000/voices | grep -A2 sample_rate` and the
+`X-Piper-Sample-Rate` header if it does.
+
+**Speech is choppy**
+Increase `PiperPlayerLatencyMs`, increase `PiperPrefetch`, use a smaller voice,
+or a larger chunk profile.
+
+**The module works but the screen reader still uses espeak**
+The screen reader picks the module itself: set it in its preferences, or set
+`DefaultModule piper` in `~/.config/speech-dispatcher/speechd.conf`.
+
+<!-- Links -->
+[speechd]: https://freebsoft.org/speechd

--- a/etc/speech-dispatcher/modules/piper-generic.conf
+++ b/etc/speech-dispatcher/modules/piper-generic.conf
@@ -1,0 +1,35 @@
+# Piper through Speech Dispatcher's generic module, using piper-client.
+#
+# This is the fallback for setups that prefer the stock sd_generic module. It
+# still gets streaming, chunking and a persistent model (all of that lives in
+# piper-client and piper.http_server), but interruption relies on
+# speech-dispatcher killing the client process, and rate/voice changes cost one
+# process start per utterance. The native module (piper.conf) is better.
+#
+# Install:
+#   cp etc/speech-dispatcher/modules/piper-generic.conf \
+#      ~/.config/speech-dispatcher/modules/
+#
+# Speech Dispatcher registers every *-generic.conf in that directory
+# automatically (module name: piper-generic).
+#
+# Start the server first:
+#   python3 -m piper.http_server -m ~/.piper-voices/en_US-kristin-medium.onnx
+
+# piper-client reads the text on stdin, chunks it, streams it from the server
+# and plays it. Newlines do not need to be stripped (it normalizes whitespace),
+# and it stops playback immediately when speech-dispatcher terminates it.
+GenericExecuteSynth "echo \'$DATA\' | piper-client --voice \"$VOICE\" --rate $RATE --sd-volume $VOLUME --chunk-profile responsive"
+
+# Hide this module if piper-client is not installed.
+GenericCmdDependency "piper-client"
+
+GenericRateAdd 0
+GenericRateMultiply 1
+GenericVolumeAdd 0
+GenericVolumeMultiply 1
+
+AddVoice "en-US" "FEMALE1" "en_US-kristin-medium"
+#AddVoice "en-US" "MALE1"   "en_US-ryan-medium"
+
+DefaultVoice "en_US-kristin-medium"

--- a/etc/speech-dispatcher/modules/piper.conf
+++ b/etc/speech-dispatcher/modules/piper.conf
@@ -1,0 +1,101 @@
+# Piper output module for Speech Dispatcher (native module, sd_piper)
+#
+# Install:
+#   mkdir -p ~/.config/speech-dispatcher/modules
+#   sd_piper --print-config > ~/.config/speech-dispatcher/modules/piper.conf
+#   mkdir -p ~/.local/libexec/speech-dispatcher-modules
+#   ln -sf "$(command -v sd_piper)" ~/.local/libexec/speech-dispatcher-modules/sd_piper
+#
+# Speech Dispatcher then discovers the module automatically as "piper".
+# See docs/SPEECHD.md.
+
+# Where piper.http_server is listening.
+PiperURL "http://localhost:5000"
+
+# Audio output:
+#   player - this module plays audio itself (default). Interruption drops
+#            buffered audio immediately, which is what a screen reader needs.
+#   server - hand PCM back to Speech Dispatcher and let it play (uses the
+#            AudioOutputMethod from speechd.conf).
+PiperAudio player
+
+# Player command used in "player" mode. "auto" picks the first available of
+# pw-play, paplay, aplay, ffplay. {rate}, {channels} and {latency_ms} are
+# substituted; the command must read raw PCM on stdin.
+PiperPlayer "auto"
+
+# Playback buffer. Lower = speech stops sooner after STOP, but drop-outs become
+# more likely on a loaded machine.
+PiperPlayerLatencyMs 40
+
+# Chunking: how text is split before synthesis. This is the main
+# latency/quality trade-off, tune it to taste.
+#   instant    - start after 2 words, chunks of 3 (fastest, most artifacts)
+#   responsive - start after 3 words, chunks of 5 (default)
+#   balanced   - start after 4 words, chunks of 10
+#   smooth     - only split at sentences (best prosody, slowest start)
+#   off        - no splitting at all
+PiperChunkProfile responsive
+
+# Individual chunking knobs (override the profile).
+#PiperChunkMaxWords 5
+#PiperChunkFirstMaxWords 3
+#PiperChunkMinWords 2
+#PiperChunkMaxChars 0
+#PiperChunkAbbreviations "mr,mrs,dr,prof,etc"
+
+# Number of chunks synthesized ahead of playback.
+PiperPrefetch 1
+
+# Insert a little silence between chunks if you hear clicks at chunk
+# boundaries (seconds).
+#PiperChunkSilence 0.02
+#PiperSentenceSilence 0.0
+
+# Speech rate mapping: rate=+100 is this many times faster than rate=0,
+# rate=-100 this many times slower. Screen reader users often want 3 or more.
+PiperRateFactor 3.0
+
+# Length scale used at rate=0 (< 1 is faster).
+#PiperLengthScale 1.0
+
+# Starting the server
+# -------------------
+# The server is started on demand when it is not already running (the first
+# utterance then waits for the model to load). The best setup is still to run
+# it as a user service, so it is ready before the screen reader speaks:
+#
+#   sd_piper --print-service > ~/.config/systemd/user/piper-server.service
+#   systemctl --user daemon-reload && systemctl --user enable --now piper-server
+#
+#   auto - start it if PiperURL is local and it does not answer (default)
+#   yes  - same, and complain in the log when it is not possible
+#   no   - never start anything; only use a server that is already running
+PiperAutostart auto
+
+# How to start it:
+#   auto    - systemd user service if available, otherwise a plain process
+#   systemd - only systemd (the unit below, or a transient one)
+#   process - only a detached child process
+PiperServerManager auto
+
+# systemd user unit started when it exists. Use "none" to always start a
+# transient unit / plain process instead.
+PiperServerService "piper-server.service"
+
+# Command used to start the server ("~" is expanded). The default is derived
+# from DefaultVoice:
+#   python3 -m piper.http_server --host 127.0.0.1 --port 5000 --model <voice>
+#PiperServerCommand "python3 -m piper.http_server -m /home/user/.piper-voices/en_US-kristin-medium.onnx"
+
+# How long the first utterance waits for the server (seconds).
+PiperServerTimeout 20
+
+# Voices: AddVoice <language> <symbolic voice> <Piper voice name>
+# The Piper voice name is what the server knows (see: curl localhost:5000/voices).
+AddVoice "en-US" "FEMALE1" "en_US-kristin-medium"
+#AddVoice "en-US" "MALE1"   "en_US-ryan-medium"
+#AddVoice "fr-FR" "FEMALE1" "fr_FR-siwis-medium"
+
+# Voice used when the client does not ask for anything specific.
+DefaultVoice "en_US-kristin-medium"

--- a/setup.py
+++ b/setup.py
@@ -152,6 +152,9 @@ setup(
             # Streaming HTTP client, also usable from a speech-dispatcher
             # generic module
             "piper-client = piper.client:main",
+            # Speech Dispatcher output module (symlink into
+            # ~/.local/libexec/speech-dispatcher-modules/sd_piper)
+            "sd_piper = piper.speechd_module:main",
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,9 @@ setup(
     entry_points={
         "console_scripts": [
             "piper = piper.__main__:main",
+            # Streaming HTTP client, also usable from a speech-dispatcher
+            # generic module
+            "piper-client = piper.client:main",
         ]
     },
 )

--- a/src/piper/chunking.py
+++ b/src/piper/chunking.py
@@ -1,0 +1,486 @@
+"""Configurable text chunking for low-latency streaming synthesis.
+
+Screen readers hand over arbitrarily large blocks of text. Synthesis granularity
+in Piper is one sentence, so a long sentence means a long wait before the first
+sample is heard. Splitting text into small pieces *before* synthesis is what
+makes time-to-first-audio short and predictable.
+
+Splitting is always a trade-off: smaller pieces start faster but prosody
+suffers and boundary artifacts become audible. Nothing here is hardcoded --
+every knob is exposed through :class:`ChunkingConfig`, which can be built from
+CLI arguments, environment variables, a speech-dispatcher module config file or
+a JSON request body, and can be tuned per user.
+
+Example::
+
+    >>> config = ChunkingConfig(max_words=4, first_max_words=2)
+    >>> list(chunk_text("Hello there, world. This is a test.", config))
+    ['Hello there,', 'world.', 'This is a test.']
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, fields, replace
+from typing import Any, Iterable, Iterator, List, Mapping, Optional, Set, Tuple
+
+__all__ = [
+    "ChunkingConfig",
+    "PROFILES",
+    "chunk_text",
+    "iter_chunks",
+    "TextChunk",
+]
+
+# Boundary strengths
+_WORD = 1
+_CLAUSE = 2
+_SENTENCE = 3
+
+_WHITESPACE_PATTERN = re.compile(r"\s+")
+
+# Characters that are stripped when deciding what a "word" is
+_TRAILING_PUNCTUATION = "\"'’”)]}»"
+
+DEFAULT_SENTENCE_PUNCTUATION = ".!?…。！？"
+DEFAULT_CLAUSE_PUNCTUATION = ",;:—–)"
+
+# Words that end with a period without ending a sentence.
+DEFAULT_ABBREVIATIONS: Set[str] = {
+    "mr",
+    "mrs",
+    "ms",
+    "dr",
+    "prof",
+    "st",
+    "vs",
+    "etc",
+    "eg",
+    "e.g",
+    "ie",
+    "i.e",
+    "no",
+    "fig",
+    "al",
+    "inc",
+    "ltd",
+    "jr",
+    "sr",
+    "approx",
+    "min",
+    "max",
+    "vol",
+    "cf",
+}
+
+
+@dataclass(frozen=True)
+class TextChunk:
+    """A piece of text to synthesize, with its position in the source text."""
+
+    text: str
+    """Text of the chunk (whitespace normalized)."""
+
+    start: int
+    """Offset of the chunk in the (normalized) source text."""
+
+    end: int
+    """End offset (exclusive) of the chunk in the (normalized) source text."""
+
+    index: int
+    """Zero-based index of the chunk."""
+
+    is_last: bool = False
+    """True if this is the final chunk of the text."""
+
+
+@dataclass
+class ChunkingConfig:
+    """How text is split before being synthesized.
+
+    All defaults aim at screen-reader responsiveness: a very short first chunk
+    so speech starts almost immediately, then slightly larger chunks so that
+    prosody stays acceptable.
+    """
+
+    enabled: bool = True
+    """False disables splitting entirely (one chunk per input text)."""
+
+    max_words: int = 5
+    """Maximum number of words per chunk (0 = unlimited)."""
+
+    first_max_words: int = 3
+    """Maximum number of words in the *first* chunk (0 = same as max_words).
+
+    The first chunk determines time-to-first-audio, so it usually pays to make
+    it smaller than the others.
+    """
+
+    min_words: int = 2
+    """Do not break at a sentence/clause boundary before this many words.
+
+    Prevents pathological one-word chunks such as "Yes." followed by "OK."
+    being synthesized separately.
+    """
+
+    max_chars: int = 0
+    """Hard cap on chunk length in characters (0 = unlimited).
+
+    A single "word" can be arbitrarily long (URLs, base64, code). This is the
+    safety net that keeps inference time bounded.
+    """
+
+    merge_short_tail: bool = True
+    """Merge a trailing chunk shorter than ``min_words`` into the previous one."""
+
+    break_on_sentence: bool = True
+    """Break at sentence punctuation (once ``min_words`` is reached)."""
+
+    break_on_clause: bool = True
+    """Break at clause punctuation such as commas (once ``min_words`` is reached)."""
+
+    sentence_punctuation: str = DEFAULT_SENTENCE_PUNCTUATION
+    """Characters that end a sentence."""
+
+    clause_punctuation: str = DEFAULT_CLAUSE_PUNCTUATION
+    """Characters that end a clause."""
+
+    abbreviations: Set[str] = field(default_factory=lambda: set(DEFAULT_ABBREVIATIONS))
+    """Lowercase words that end with '.' without ending a sentence."""
+
+    strip_urls: bool = False
+    """Replace URLs with their host name (they are painful to listen to)."""
+
+    def __post_init__(self) -> None:
+        # Be forgiving with values coming from config files/environment
+        self.max_words = max(0, int(self.max_words))
+        self.first_max_words = max(0, int(self.first_max_words))
+        self.min_words = max(1, int(self.min_words))
+        self.max_chars = max(0, int(self.max_chars))
+
+        # Be tolerant of a comma-separated string (config files, environment)
+        self.abbreviations = _as_word_set(self.abbreviations)
+
+    # -------------------------------------------------------------------------
+
+    @property
+    def first_limit(self) -> int:
+        """Word limit for the first chunk."""
+        if self.first_max_words:
+            if self.max_words:
+                return min(self.first_max_words, self.max_words)
+
+            return self.first_max_words
+
+        return self.max_words
+
+    def replace(self, **changes: Any) -> "ChunkingConfig":
+        """Return a copy with the given fields changed (ignores None values)."""
+        changes = {key: value for key, value in changes.items() if value is not None}
+        return replace(self, **changes)
+
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def from_mapping(
+        values: Mapping[str, Any],
+        prefix: str = "",
+        base: Optional["ChunkingConfig"] = None,
+    ) -> "ChunkingConfig":
+        """Build a config from a mapping (JSON body, env vars, config file).
+
+        Keys are matched case-insensitively, with ``-``/``_`` treated the same,
+        and may be prefixed (e.g. ``PIPER_CHUNK_MAX_WORDS`` with
+        ``prefix="piper_chunk_"``). Unknown keys are ignored so the same
+        mapping can carry unrelated settings.
+
+        A ``profile`` key selects one of :data:`PROFILES` as the base.
+        """
+        normalized = {
+            _normalize_key(key): value
+            for key, value in values.items()
+            if _normalize_key(key).startswith(_normalize_key(prefix))
+        }
+        prefix_len = len(_normalize_key(prefix))
+        normalized = {key[prefix_len:]: value for key, value in normalized.items()}
+
+        config = base
+        profile = normalized.get("profile")
+        if profile:
+            profile_config = PROFILES.get(str(profile).strip().lower())
+            if profile_config is None:
+                raise ValueError(
+                    f"Unknown chunking profile: {profile} "
+                    f"(expected one of {sorted(PROFILES)})"
+                )
+            config = profile_config
+
+        config = replace(config) if config is not None else ChunkingConfig()
+
+        for config_field in fields(ChunkingConfig):
+            if config_field.name not in normalized:
+                continue
+
+            raw_value = normalized[config_field.name]
+            setattr(
+                config,
+                config_field.name,
+                _coerce(
+                    config_field.name, raw_value, getattr(config, config_field.name)
+                ),
+            )
+
+        config.__post_init__()
+        return config
+
+
+def _as_word_set(value: Any) -> Set[str]:
+    """Convert a comma-separated string or an iterable into a set of words."""
+    if isinstance(value, str):
+        return {word.strip().lower() for word in value.split(",") if word.strip()}
+
+    return {str(word).strip().lower() for word in value}
+
+
+def _normalize_key(key: str) -> str:
+    return key.strip().lower().replace("-", "_")
+
+
+def _coerce(name: str, value: Any, current: Any) -> Any:
+    """Convert a string value to the type of the current field value."""
+    if isinstance(current, bool):
+        if isinstance(value, str):
+            value = value.strip().lower()
+            if value in ("1", "true", "yes", "on"):
+                return True
+            if value in ("0", "false", "no", "off"):
+                return False
+            raise ValueError(f"Invalid boolean for {name}: {value}")
+
+        return bool(value)
+
+    if isinstance(current, int):
+        return int(value)
+
+    if isinstance(current, set):
+        return _as_word_set(value)
+
+    return value
+
+
+#: Named presets. Users (and bug reports) can refer to these by name.
+PROFILES: "dict[str, ChunkingConfig]" = {
+    # Absolute minimum latency: start speaking after two words.
+    "instant": ChunkingConfig(max_words=3, first_max_words=2, min_words=1),
+    # Recommended default for screen reading.
+    "responsive": ChunkingConfig(max_words=5, first_max_words=3, min_words=2),
+    # Compromise: quick start, longer pieces afterwards.
+    "balanced": ChunkingConfig(max_words=10, first_max_words=4, min_words=3),
+    # Prosody first: only break at sentences (still streams per sentence).
+    "smooth": ChunkingConfig(
+        max_words=0, first_max_words=0, min_words=2, break_on_clause=False
+    ),
+    # No client-side splitting at all.
+    "off": ChunkingConfig(enabled=False),
+}
+
+_URL_PATTERN = re.compile(r"\b(?:https?|ftp)://(\S+)")
+
+
+def normalize_text(text: str, config: Optional[ChunkingConfig] = None) -> str:
+    """Collapse whitespace (including newlines) into single spaces."""
+    if (config is not None) and config.strip_urls:
+        text = _URL_PATTERN.sub(lambda m: m.group(1).split("/")[0], text)
+
+    return _WHITESPACE_PATTERN.sub(" ", text).strip()
+
+
+def _boundary_strength(token: str, config: ChunkingConfig) -> int:
+    """Return the boundary strength after ``token``."""
+    stripped = token.rstrip(_TRAILING_PUNCTUATION)
+    if not stripped:
+        return _WORD
+
+    last_char = stripped[-1]
+    if last_char in config.sentence_punctuation:
+        if last_char == ".":
+            word = stripped[:-1].lower()
+            # "Mr." / "e.g." / initials ("J.") do not end a sentence
+            if word in config.abbreviations:
+                return _WORD
+
+            if len(word) == 1 and word.isalpha():
+                return _WORD
+
+            if word.isdigit():
+                # "1. First item" -- list numbering, weak boundary
+                return _CLAUSE
+
+        return _SENTENCE
+
+    if last_char in config.clause_punctuation:
+        return _CLAUSE
+
+    return _WORD
+
+
+def iter_chunks(
+    text: str, config: Optional[ChunkingConfig] = None
+) -> Iterator[TextChunk]:
+    """Split text into :class:`TextChunk` objects.
+
+    Chunks are yielded lazily so that synthesis of the first chunk can start
+    while the rest of the text is still being split.
+    """
+    if config is None:
+        config = ChunkingConfig()
+
+    text = normalize_text(text, config)
+    if not text:
+        return
+
+    if not config.enabled:
+        yield TextChunk(text=text, start=0, end=len(text), index=0, is_last=True)
+        return
+
+    pending: List[TextChunk] = []
+    for chunk in _split(text, config):
+        # Keep one chunk in hand so a short tail can be merged into it
+        pending.append(chunk)
+        if len(pending) > 1:
+            yield pending.pop(0)
+
+    if not pending:
+        return
+
+    last = pending[0]
+    yield TextChunk(
+        text=last.text, start=last.start, end=last.end, index=last.index, is_last=True
+    )
+
+
+def _split(text: str, config: ChunkingConfig) -> Iterator[TextChunk]:
+    """Greedy split at the strongest boundary allowed by the limits."""
+    index = 0
+    start: Optional[int] = None
+    end = 0
+    num_words = 0
+
+    def limit() -> int:
+        return config.first_limit if index == 0 else config.max_words
+
+    prev_chunk: Optional[TextChunk] = None
+
+    for token, token_start, token_end in _iter_tokens(text, config.max_chars):
+        if start is None:
+            start = token_start
+
+        # Hard character cap: emit what we have before adding this token
+        if config.max_chars and num_words and ((token_end - start) > config.max_chars):
+            chunk = TextChunk(text=text[start:end], start=start, end=end, index=index)
+            prev_chunk, emit = _merge_tail(prev_chunk, chunk, config)
+            if emit is not None:
+                yield emit
+
+            index += 1
+            start = token_start
+            num_words = 0
+
+        end = token_end
+        num_words += 1
+
+        strength = _boundary_strength(token, config)
+        should_break = False
+        if (strength == _SENTENCE) and config.break_on_sentence:
+            # Piper synthesizes one sentence at a time anyway: never merge
+            # across a sentence boundary, whatever min_words says.
+            should_break = True
+        elif (
+            (strength == _CLAUSE)
+            and config.break_on_clause
+            and (num_words >= config.min_words)
+        ):
+            should_break = True
+
+        if (not should_break) and limit() and (num_words >= limit()):
+            should_break = True
+
+        if config.max_chars and ((end - start) >= config.max_chars):
+            should_break = True
+
+        if should_break:
+            chunk = TextChunk(text=text[start:end], start=start, end=end, index=index)
+            prev_chunk, emit = _merge_tail(prev_chunk, chunk, config)
+            if emit is not None:
+                yield emit
+
+            index += 1
+            start = None
+            num_words = 0
+
+    if start is not None:
+        chunk = TextChunk(text=text[start:end], start=start, end=end, index=index)
+        prev_chunk, emit = _merge_tail(prev_chunk, chunk, config)
+        if emit is not None:
+            yield emit
+
+    if prev_chunk is not None:
+        yield prev_chunk
+
+
+def _merge_tail(
+    prev_chunk: Optional[TextChunk], chunk: TextChunk, config: ChunkingConfig
+) -> Tuple[Optional[TextChunk], Optional[TextChunk]]:
+    """Hold back one chunk so a too-short chunk can be merged with it.
+
+    Returns (chunk to hold, chunk to emit now).
+    """
+    if prev_chunk is None:
+        return chunk, None
+
+    if not config.merge_short_tail:
+        return chunk, prev_chunk
+
+    too_short = _count_words(chunk.text) < config.min_words
+    if too_short:
+        merged_text = f"{prev_chunk.text} {chunk.text}"
+        if (not config.max_chars) or (len(merged_text) <= config.max_chars):
+            return (
+                TextChunk(
+                    text=merged_text,
+                    start=prev_chunk.start,
+                    end=chunk.end,
+                    index=prev_chunk.index,
+                ),
+                None,
+            )
+
+    return chunk, prev_chunk
+
+
+def _count_words(text: str) -> int:
+    return len(text.split())
+
+
+def _iter_tokens(text: str, max_chars: int = 0) -> Iterator[Tuple[str, int, int]]:
+    """Yield (token, start, end) for whitespace-separated tokens.
+
+    Tokens longer than ``max_chars`` (URLs, base64 blobs, code) are hard-split
+    so that inference time per chunk stays bounded.
+    """
+    for match in re.finditer(r"\S+", text):
+        token, start, end = match.group(0), match.start(), match.end()
+        if max_chars and (len(token) > max_chars):
+            for offset in range(0, len(token), max_chars):
+                piece = token[offset : offset + max_chars]
+                yield piece, start + offset, start + offset + len(piece)
+
+            continue
+
+        yield token, start, end
+
+
+def chunk_text(text: str, config: Optional[ChunkingConfig] = None) -> Iterable[str]:
+    """Split text and yield chunk strings (convenience wrapper)."""
+    for chunk in iter_chunks(text, config):
+        yield chunk.text

--- a/src/piper/client.py
+++ b/src/piper/client.py
@@ -1,0 +1,1165 @@
+"""Streaming HTTP client for the Piper web server.
+
+This is the piece that makes ``piper.http_server`` usable as a screen reader
+backend. It is intentionally dependency-free (standard library only) so that it
+starts fast, and every behaviour is configurable:
+
+* **Chunking**: long texts are split into small pieces on word/punctuation/
+  sentence boundaries before being sent (see :mod:`piper.chunking`), so audio
+  starts playing after the first few words instead of after the whole text.
+* **Pipelining**: while a chunk is playing, the next one is already being
+  synthesized.
+* **Interruption**: :meth:`PiperClient.stop` kills playback, aborts the HTTP
+  streams and tells the server to abandon the inference in progress. It is safe
+  to call from a signal handler or another thread.
+* **Playback**: raw PCM is piped into a player process (pw-play, paplay, aplay,
+  ffplay, or any command you configure), or written to a file/stdout for use in
+  a shell pipeline.
+
+Command line usage (reads text from stdin or from the arguments)::
+
+    piper-client "Hello world."
+    echo "Hello world." | piper-client --voice en_US-kristin-medium
+    piper-client --output raw "Hello world." | aplay -r 22050 -f S16_LE -t raw -
+
+See docs/SPEECHD.md for the speech-dispatcher configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import io
+import json
+import logging
+import os
+import queue
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+import uuid
+import wave
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
+from urllib.parse import urlsplit
+
+from .chunking import ChunkingConfig, TextChunk, iter_chunks
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_URL = "http://localhost:5000"
+
+# speech-dispatcher sends rate/pitch/volume in [-100, 100]
+SD_MIN = -100
+SD_MAX = 100
+
+#: rate=+100 makes speech RATE_FACTOR times faster, rate=-100 that much slower
+DEFAULT_RATE_FACTOR = 3.0
+
+__all__ = [
+    "AudioSink",
+    "ClientConfig",
+    "PiperClient",
+    "PlayerConfig",
+    "rate_to_length_scale",
+    "sd_volume_to_multiplier",
+    "wav_header",
+    "main",
+]
+
+# Length fields of a WAV file that is still being written. Players that stream
+# from a pipe accept a "big enough" length and stop at end of stream.
+_STREAMING_WAV_SIZE = 0x7FFFFFFF - 128
+
+
+def wav_header(sample_rate: int, sample_width: int = 2, num_channels: int = 1) -> bytes:
+    """Build a 44-byte WAV header for a stream of unknown length.
+
+    ``piper.http_server`` has the same helper for its streaming responses, but
+    it is not imported here on purpose: this module stays standard-library only
+    (importing the server would pull in flask) and usable against a remote
+    server.
+    """
+    with io.BytesIO() as wav_io:
+        wav_file: wave.Wave_write = wave.open(wav_io, "wb")
+        with wav_file:
+            wav_file.setframerate(sample_rate)
+            wav_file.setsampwidth(sample_width)
+            wav_file.setnchannels(num_channels)
+            wav_file.writeframes(b"")
+
+        header = bytearray(wav_io.getvalue()[:44])
+
+    # RIFF size and data size
+    header[4:8] = (_STREAMING_WAV_SIZE + 36).to_bytes(4, "little")
+    header[40:44] = _STREAMING_WAV_SIZE.to_bytes(4, "little")
+    return bytes(header)
+
+
+# -----------------------------------------------------------------------------
+# Parameter mapping (speech-dispatcher units -> Piper synthesis parameters)
+# -----------------------------------------------------------------------------
+
+
+def rate_to_length_scale(
+    rate: float,
+    base_length_scale: float = 1.0,
+    rate_factor: float = DEFAULT_RATE_FACTOR,
+) -> float:
+    """Convert a speech-dispatcher rate in [-100, 100] to a length scale.
+
+    ``rate=0`` keeps ``base_length_scale``, ``rate=100`` divides it by
+    ``rate_factor`` (faster), ``rate=-100`` multiplies it (slower).
+    """
+    rate = max(SD_MIN, min(SD_MAX, rate))
+    return base_length_scale * (rate_factor ** (-rate / 100.0))
+
+
+def sd_volume_to_multiplier(volume: float) -> float:
+    """Convert a speech-dispatcher volume in [-100, 100] to an audio multiplier.
+
+    speech-dispatcher's nominal volume is 100 (full), so 100 maps to 1.0 and
+    every 100 points below that halves the amplitude.
+    """
+    volume = max(SD_MIN, min(SD_MAX, volume))
+    return 2.0 ** ((volume - 100.0) / 100.0)
+
+
+# -----------------------------------------------------------------------------
+# Playback
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class PlayerConfig:
+    """How raw PCM is played.
+
+    ``command`` is a shell-style command template. ``{rate}``, ``{channels}``,
+    ``{width}`` and ``{latency_ms}`` are substituted. The player must read raw
+    PCM from stdin. ``auto`` picks the first available player.
+    """
+
+    command: str = "auto"
+    latency_ms: int = 40
+    """Target playback buffer. Lower = interruption is heard sooner, but risk of
+    underruns (drop-outs) increases."""
+
+    #: Player templates, in order of preference.
+    templates: Sequence[Tuple[str, str]] = (
+        (
+            "pw-play",
+            "pw-play --raw --format=s16 --rate={rate} --channels={channels}"
+            " --latency={latency_ms}ms -",
+        ),
+        (
+            "paplay",
+            "paplay --raw --format=s16le --rate={rate} --channels={channels}"
+            " --latency-msec={latency_ms} --client-name=piper",
+        ),
+        (
+            "aplay",
+            "aplay -q -t raw -f S16_LE -r {rate} -c {channels}"
+            " --buffer-time={buffer_us} -",
+        ),
+        (
+            "ffplay",
+            "ffplay -hide_banner -loglevel quiet -nodisp -autoexit -f s16le"
+            " -ar {rate} -ch_layout mono -",
+        ),
+    )
+
+    def resolve(self, rate: int, channels: int = 1, width: int = 2) -> List[str]:
+        """Return the player command as an argv list."""
+        command = self.command
+        if command in ("auto", "", None):
+            for executable, template in self.templates:
+                if shutil.which(executable):
+                    command = template
+                    break
+            else:
+                raise RuntimeError(
+                    "No audio player found. Install pipewire (pw-play), "
+                    "pulseaudio-utils (paplay), alsa-utils (aplay) or ffmpeg "
+                    "(ffplay), or set --player."
+                )
+
+        command = command.format(
+            rate=rate,
+            channels=channels,
+            width=width,
+            latency_ms=self.latency_ms,
+            buffer_us=self.latency_ms * 1000,
+        )
+        return shlex.split(command)
+
+    @staticmethod
+    def is_available() -> bool:
+        return any(
+            shutil.which(executable) for executable, _ in PlayerConfig().templates
+        )
+
+
+class AudioSink:
+    """Plays raw PCM through a player subprocess, and can be killed instantly.
+
+    A fresh player process is started for each utterance and killed on
+    :meth:`stop`, which is the only reliable way to drop audio that is already
+    buffered in the sound server.
+    """
+
+    def __init__(
+        self, config: PlayerConfig, sample_rate: int, num_channels: int = 1
+    ) -> None:
+        self.config = config
+        self.sample_rate = sample_rate
+        self.num_channels = num_channels
+        self._lock = threading.Lock()
+        self._proc: Optional[subprocess.Popen] = None
+
+    def write(self, audio_bytes: bytes) -> None:
+        """Write PCM to the player, starting it on first use."""
+        if not audio_bytes:
+            return
+
+        with self._lock:
+            proc = self._proc
+            if (proc is None) or (proc.poll() is not None):
+                command = self.config.resolve(self.sample_rate, self.num_channels)
+                _LOGGER.debug("Starting player: %s", command)
+                # pylint: disable=consider-using-with
+                proc = subprocess.Popen(
+                    command,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                self._proc = proc
+
+        assert proc.stdin is not None
+        try:
+            proc.stdin.write(audio_bytes)
+            proc.stdin.flush()
+        except (BrokenPipeError, ValueError):
+            # Player was killed (stop) or died
+            _LOGGER.debug("Player is gone, dropping %d bytes", len(audio_bytes))
+
+    def drain(self, timeout: Optional[float] = None) -> None:
+        """Wait for buffered audio to finish playing."""
+        with self._lock:
+            proc, self._proc = self._proc, None
+
+        if proc is None:
+            return
+
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+        except (BrokenPipeError, ValueError):
+            pass
+
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _LOGGER.warning("Player did not exit, killing it")
+            proc.kill()
+
+    def stop(self) -> None:
+        """Kill the player immediately, dropping buffered audio."""
+        with self._lock:
+            proc, self._proc = self._proc, None
+
+        if proc is None:
+            return
+
+        _LOGGER.debug("Killing player")
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+        except (BrokenPipeError, ValueError, OSError):
+            pass
+
+        # Reap without blocking playback of the next utterance
+        threading.Thread(target=proc.wait, daemon=True).start()
+
+
+class FileSink:
+    """Writes raw PCM to a binary stream (a file, or stdout in a pipeline)."""
+
+    def __init__(self, output_file: Any) -> None:
+        self._file = output_file
+
+    def write(self, audio_bytes: bytes) -> None:
+        self._file.write(audio_bytes)
+        self._file.flush()
+
+    def drain(self, timeout: Optional[float] = None) -> None:
+        try:
+            self._file.flush()
+        except (BrokenPipeError, ValueError):
+            pass
+
+    def stop(self) -> None:
+        self.drain()
+
+
+# -----------------------------------------------------------------------------
+# Client
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class ClientConfig:
+    """Everything the client needs to talk to the server."""
+
+    url: str = DEFAULT_URL
+    voice: Optional[str] = None
+    speaker: Optional[str] = None
+    speaker_id: Optional[int] = None
+    #
+    length_scale: Optional[float] = None
+    noise_scale: Optional[float] = None
+    noise_w_scale: Optional[float] = None
+    volume: Optional[float] = None
+    normalize_audio: Optional[bool] = None
+    """None means: let the server decide (it disables normalization when the
+    text is chunked, because normalizing every chunk separately makes the
+    loudness jump)."""
+
+    sentence_silence: Optional[float] = None
+    chunk_silence: Optional[float] = None
+    #
+    chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
+    chunk_mode: str = "client"
+    """``client`` (one request per chunk, default) or ``server`` (send the whole
+    text and let the server chunk it)."""
+
+    prefetch: int = 1
+    """Number of chunks synthesized ahead of playback (0 = strictly serial)."""
+
+    channel: str = "default"
+    """Preemption group on the server: a new utterance in the same channel
+    cancels the previous one."""
+
+    preempt: bool = True
+    timeout: float = 30.0
+    """Socket timeout in seconds for a single chunk request."""
+
+    def synthesis_params(self) -> Dict[str, Any]:
+        """Synthesis parameters to send with every request."""
+        params: Dict[str, Any] = {}
+        for name in (
+            "voice",
+            "speaker",
+            "speaker_id",
+            "length_scale",
+            "noise_scale",
+            "noise_w_scale",
+            "volume",
+            "normalize_audio",
+            "sentence_silence",
+            "chunk_silence",
+        ):
+            value = getattr(self, name)
+            if value is not None:
+                params[name] = value
+
+        return params
+
+
+class PiperClient:
+    """Streaming client for the Piper HTTP server."""
+
+    def __init__(self, config: Optional[ClientConfig] = None) -> None:
+        self.config = config or ClientConfig()
+        split = urlsplit(
+            self.config.url if "://" in self.config.url else f"http://{self.config.url}"
+        )
+        self._host = split.hostname or "localhost"
+        self._port = split.port or (443 if split.scheme == "https" else 80)
+        self._https = split.scheme == "https"
+        self._base_path = split.path.rstrip("/")
+
+        self._stop_event = threading.Event()
+        self._connections_lock = threading.Lock()
+        self._connections: List[http.client.HTTPConnection] = []
+        self._sample_rate: Optional[int] = None
+        self._voice_sample_rates: Dict[str, int] = {}
+
+    # -- server info ------------------------------------------------------
+
+    def _connect(self) -> http.client.HTTPConnection:
+        if self._https:
+            connection: http.client.HTTPConnection = http.client.HTTPSConnection(
+                self._host, self._port, timeout=self.config.timeout
+            )
+        else:
+            connection = http.client.HTTPConnection(
+                self._host, self._port, timeout=self.config.timeout
+            )
+
+        with self._connections_lock:
+            self._connections.append(connection)
+
+        return connection
+
+    def _close(self, connection: http.client.HTTPConnection) -> None:
+        with self._connections_lock:
+            if connection in self._connections:
+                self._connections.remove(connection)
+
+        try:
+            connection.close()
+        except OSError:
+            pass
+
+    def _request(
+        self, path: str, body: Optional[Dict[str, Any]] = None, method: str = "POST"
+    ) -> Tuple[http.client.HTTPConnection, http.client.HTTPResponse]:
+        connection = self._connect()
+        data = json.dumps(body or {}).encode("utf-8")
+        connection.request(
+            method,
+            f"{self._base_path}{path}",
+            body=data,
+            headers={"Content-Type": "application/json", "Accept": "audio/pcm"},
+        )
+        response = connection.getresponse()
+        if response.status != 200:
+            error = response.read().decode("utf-8", errors="replace")
+            self._close(connection)
+            raise RuntimeError(f"{path} failed with {response.status}: {error[:500]}")
+
+        return connection, response
+
+    def info(self) -> Dict[str, Any]:
+        """Get server info (voice, sample rate, chunking defaults)."""
+        connection, response = self._request("/info", method="GET")
+        try:
+            return json.loads(response.read().decode("utf-8"))
+        finally:
+            self._close(connection)
+
+    def voices(self) -> Dict[str, Any]:
+        """Get the voices available on the server."""
+        connection, response = self._request("/voices", method="GET")
+        try:
+            return json.loads(response.read().decode("utf-8"))
+        finally:
+            self._close(connection)
+
+    def sample_rate(self, voice: Optional[str] = None) -> int:
+        """Sample rate of ``voice``, or of the configured one (cached).
+
+        Voices do not all share a sample rate (22.05 kHz and 44.1 kHz are both
+        common), and audio played at the wrong rate is slowed down or sped up.
+        The rate of the *requested* voice is therefore used, not the rate of
+        the server's default voice.
+        """
+        name = voice or self.config.voice
+        if name:
+            rate = self._voice_sample_rates.get(name)
+            if rate is None:
+                rate = self._lookup_sample_rate(name)
+
+            if rate:
+                return rate
+
+        if self._sample_rate is None:
+            self._sample_rate = int(self.info()["voice"]["sample_rate"])
+
+        return self._sample_rate
+
+    def _lookup_sample_rate(self, voice: str) -> Optional[int]:
+        """Ask the server for the sample rate of one voice."""
+        try:
+            voice_config = self.voices().get(voice) or {}
+            rate = int(voice_config.get("audio", {}).get("sample_rate", 0))
+        except (OSError, RuntimeError, ValueError, TypeError, AttributeError) as error:
+            _LOGGER.debug("Cannot get the sample rate of %s: %s", voice, error)
+            return None
+
+        if rate > 0:
+            self._voice_sample_rates[voice] = rate
+            return rate
+
+        return None
+
+    def _note_sample_rate(
+        self, voice: Optional[str], sample_rate: Optional[str]
+    ) -> None:
+        """Remember the sample rate a response reported (it is authoritative)."""
+        if not sample_rate:
+            return
+
+        try:
+            rate = int(sample_rate)
+        except ValueError:
+            return
+
+        if rate <= 0:
+            return
+
+        if voice:
+            self._voice_sample_rates[voice] = rate
+        elif self._sample_rate is None:
+            self._sample_rate = rate
+
+    # -- synthesis --------------------------------------------------------
+
+    def iter_audio(
+        self, text: str, group: Optional[str] = None, read_size: int = 4096
+    ) -> Iterator[Tuple[TextChunk, bytes]]:
+        """Yield ``(chunk, audio_bytes)`` for ``text`` as it is synthesized.
+
+        Text is chunked client-side (unless ``chunk_mode="server"``) and chunks
+        are requested ahead of time so that playback never has to wait for the
+        network. Knowing which chunk each piece of audio belongs to is what
+        makes progress reporting (index marks) possible.
+
+        Iteration stops as soon as :meth:`stop` is called. All requests of one
+        call share a ``group`` so they never preempt each other.
+        """
+        self._stop_event.clear()
+
+        if self.config.chunk_mode == "server":
+            text = text.strip()
+            chunks = (
+                [TextChunk(text=text, start=0, end=len(text), index=0, is_last=True)]
+                if text
+                else []
+            )
+        else:
+            chunks = list(iter_chunks(text, self.config.chunking))
+
+        if not chunks:
+            return
+
+        pipeline = _ChunkPipeline(
+            client=self,
+            chunks=chunks,
+            group=group or uuid.uuid4().hex,
+            read_size=read_size,
+            prefetch=max(0, int(self.config.prefetch)),
+        )
+        # Optional silence between chunks: a cheap way to hide artifacts at
+        # chunk boundaries without giving up small chunks.
+        silence = b""
+        if self.config.chunk_silence and (len(chunks) > 1):
+            silence = bytes(int(self.sample_rate() * self.config.chunk_silence) * 2)
+
+        previous: Optional[TextChunk] = None
+        try:
+            for chunk, audio_bytes in pipeline:
+                if self._stop_event.is_set():
+                    break
+
+                if silence and (previous is not None) and (chunk is not previous):
+                    yield chunk, silence
+
+                previous = chunk
+                yield chunk, audio_bytes
+        finally:
+            pipeline.close()
+
+    def stream(
+        self, text: str, group: Optional[str] = None, read_size: int = 4096
+    ) -> Iterator[bytes]:
+        """Yield raw PCM for ``text`` as it is synthesized."""
+        for _chunk, audio_bytes in self.iter_audio(
+            text, group=group, read_size=read_size
+        ):
+            yield audio_bytes
+
+    def speak(self, text: str, sink: Any, drain: bool = True) -> bool:
+        """Synthesize ``text`` and write the audio to ``sink``.
+
+        :return: True if the whole text was spoken, False if interrupted.
+        """
+        completed = True
+        for audio_bytes in self.stream(text):
+            if self._stop_event.is_set():
+                completed = False
+                break
+
+            sink.write(audio_bytes)
+
+        if self._stop_event.is_set():
+            completed = False
+            sink.stop()
+        elif drain:
+            sink.drain()
+
+        return completed
+
+    # -- interruption -----------------------------------------------------
+
+    @property
+    def stopped(self) -> bool:
+        return self._stop_event.is_set()
+
+    def stop(self, notify_server: bool = True) -> None:
+        """Interrupt everything, immediately.
+
+        Safe to call from a signal handler or another thread: it only closes
+        sockets and sets a flag. The server is told to abandon the inference in
+        progress so the next utterance is not queued behind it.
+        """
+        self._stop_event.set()
+
+        with self._connections_lock:
+            connections = list(self._connections)
+            self._connections.clear()
+
+        for connection in connections:
+            try:
+                connection.close()
+            except OSError:
+                pass
+
+        if not notify_server:
+            return
+
+        # Best effort, on a separate connection with a short timeout: never let
+        # stopping block on the network.
+        try:
+            connection = (  # pylint: disable=consider-using-with
+                http.client.HTTPSConnection(self._host, self._port, timeout=1.0)
+                if self._https
+                else http.client.HTTPConnection(self._host, self._port, timeout=1.0)
+            )
+            body = json.dumps({"channel": self.config.channel}).encode("utf-8")
+            connection.request(
+                "POST",
+                f"{self._base_path}/stop",
+                body=body,
+                headers={"Content-Type": "application/json"},
+            )
+            connection.getresponse().read()
+            connection.close()
+        except OSError as error:
+            _LOGGER.debug("Failed to notify server of stop: %s", error)
+
+    def reset(self) -> None:
+        """Clear the stop flag before speaking again."""
+        self._stop_event.clear()
+
+    # -- internal ---------------------------------------------------------
+
+    @property
+    def normalize_audio(self) -> Optional[bool]:
+        return self.config.normalize_audio
+
+    @property
+    def chunking(self) -> ChunkingConfig:
+        return self.config.chunking
+
+    def _chunk_request_body(self, text: str, group: str, index: int) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "text": text,
+            "stream_id": f"{group}-{index}",
+            # Chunks of one utterance share a group, so they preempt whatever
+            # was playing before but never each other (requests can arrive out
+            # of order).
+            "group": group,
+            "channel": self.config.channel,
+            "preempt": self.config.preempt,
+        }
+        body.update(self.config.synthesis_params())
+
+        if self.config.chunk_mode == "server":
+            body["chunk"] = {
+                "enabled": self.config.chunking.enabled,
+                "max_words": self.config.chunking.max_words,
+                "first_max_words": self.config.chunking.first_max_words,
+                "min_words": self.config.chunking.min_words,
+                "max_chars": self.config.chunking.max_chars,
+            }
+        else:
+            # Already chunked here: don't split again on the server. The server
+            # can no longer see that the text was chunked, so normalization has
+            # to be turned off explicitly to keep the loudness stable.
+            body["chunk"] = {"enabled": False}
+            if (self.normalize_audio is None) and self.chunking.enabled:
+                body["normalize_audio"] = False
+
+        return body
+
+
+class _ChunkPipeline:
+    """Requests chunks ahead of time and yields their audio in order.
+
+    This is an implementation detail of :class:`PiperClient` and uses its
+    internals on purpose.
+    """
+
+    # pylint: disable=protected-access
+
+    def __init__(
+        self,
+        client: PiperClient,
+        chunks: Sequence[TextChunk],
+        group: str,
+        read_size: int = 4096,
+        prefetch: int = 1,
+    ) -> None:
+        self._client = client
+        self._chunks = chunks
+        self._group = group
+        self._read_size = read_size
+        self._closed = threading.Event()
+        # Number of chunks that may be in flight at the same time
+        self._slots = threading.Semaphore(max(1, prefetch + 1))
+        self._queues: "queue.Queue[Any]" = queue.Queue()
+        self._threads: List[threading.Thread] = []
+        self._error: Optional[BaseException] = None
+
+        self._producer = threading.Thread(target=self._produce, daemon=True)
+        self._producer.start()
+
+    def _produce(self) -> None:
+        for chunk in self._chunks:
+            if self._closed.is_set() or self._client.stopped:
+                break
+
+            self._slots.acquire()  # pylint: disable=consider-using-with
+            if self._closed.is_set() or self._client.stopped:
+                self._slots.release()
+                break
+
+            chunk_queue: "queue.Queue[Any]" = queue.Queue(maxsize=64)
+            self._queues.put((chunk, chunk_queue))
+            thread = threading.Thread(
+                target=self._fetch, args=(chunk, chunk_queue), daemon=True
+            )
+            self._threads.append(thread)
+            thread.start()
+
+        self._queues.put(None)  # type: ignore[arg-type]
+
+    def _fetch(self, chunk: TextChunk, chunk_queue: "queue.Queue[Any]") -> None:
+        connection = None
+        try:
+            body = self._client._chunk_request_body(
+                chunk.text, self._group, chunk.index
+            )
+            connection, response = self._client._request("/stream", body)
+            # The response says which sample rate the audio really has.
+            self._client._note_sample_rate(
+                self._client.config.voice, response.getheader("X-Piper-Sample-Rate")
+            )
+            while not (self._closed.is_set() or self._client.stopped):
+                data = response.read(self._read_size)
+                if not data:
+                    break
+
+                chunk_queue.put(data)
+        except BaseException as error:  # pylint: disable=broad-except
+            if not (self._closed.is_set() or self._client.stopped):
+                chunk_queue.put(error)
+        finally:
+            if connection is not None:
+                self._client._close(connection)
+
+            chunk_queue.put(None)
+            self._slots.release()
+
+    def __iter__(self) -> Iterator[Tuple[TextChunk, bytes]]:
+        while True:
+            item = self._queues.get()
+            if item is None:
+                return
+
+            chunk, chunk_queue = item
+            while True:
+                data = chunk_queue.get()
+                if data is None:
+                    break
+
+                if isinstance(data, BaseException):
+                    raise data
+
+                yield chunk, data
+
+    def close(self) -> None:
+        self._closed.set()
+        # Unblock the producer if it is waiting for a slot
+        for _ in range(len(self._chunks) + 1):
+            self._slots.release()
+
+
+# -----------------------------------------------------------------------------
+# Command line
+# -----------------------------------------------------------------------------
+
+
+def _env(*names: str, default: Optional[str] = None) -> Optional[str]:
+    """First non-empty environment variable among ``names``."""
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            value = value.strip()
+            # speech-dispatcher generic modules pass this when the client did
+            # not ask for a specific voice
+            if value and (value != "no_voice"):
+                return value
+
+    return default
+
+
+def _env_float(*names: str, default: Optional[float] = None) -> Optional[float]:
+    value = _env(*names)
+    if value is None:
+        return default
+
+    try:
+        return float(value)
+    except ValueError:
+        _LOGGER.warning("Invalid number in environment: %s", value)
+        return default
+
+
+def normalize_voice_name(voice: Optional[str]) -> Optional[str]:
+    """Clean up a voice name coming from speech-dispatcher.
+
+    Generic modules pass ``no_voice`` when the client did not select a voice,
+    and voices are sometimes configured with their file name.
+    """
+    if not voice:
+        return None
+
+    voice = voice.strip()
+    if voice in ("no_voice", "NULL", "none", "default"):
+        return None
+
+    for suffix in (".onnx.json", ".onnx"):
+        if voice.endswith(suffix):
+            return voice[: -len(suffix)]
+
+    return voice
+
+
+def add_client_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add the options shared by the CLI and the speech-dispatcher module."""
+    parser.add_argument(
+        "--url",
+        default=_env("PIPER_URL", default=DEFAULT_URL),
+        help=f"Base URL of the Piper HTTP server (default: {DEFAULT_URL})",
+    )
+    parser.add_argument(
+        "--voice",
+        default=_env("PIPER_VOICE", "VOICE"),
+        help="Voice name, e.g. en_US-kristin-medium ($VOICE)",
+    )
+    parser.add_argument("--speaker", help="Speaker name for multi-speaker voices")
+    parser.add_argument("--speaker-id", type=int, help="Speaker id")
+    #
+    parser.add_argument(
+        "--rate",
+        type=float,
+        default=_env_float("PIPER_RATE", "RATE"),
+        help="Speech rate in speech-dispatcher units [-100, 100] ($RATE)",
+    )
+    parser.add_argument(
+        "--rate-factor",
+        type=float,
+        default=_env_float("PIPER_RATE_FACTOR", default=DEFAULT_RATE_FACTOR),
+        help="How much faster/slower rate=+/-100 is (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--length-scale",
+        type=float,
+        default=_env_float("PIPER_LENGTH_SCALE"),
+        help="Phoneme length (overrides --rate; < 1 is faster)",
+    )
+    parser.add_argument("--noise-scale", type=float, help="Generator noise")
+    parser.add_argument("--noise-w-scale", type=float, help="Phoneme width noise")
+    parser.add_argument(
+        "--sd-volume",
+        type=float,
+        default=_env_float("PIPER_VOLUME", "VOLUME"),
+        help="Volume in speech-dispatcher units [-100, 100] ($VOLUME)",
+    )
+    parser.add_argument(
+        "--volume", type=float, help="Audio multiplier (overrides --sd-volume)"
+    )
+    parser.add_argument(
+        "--normalize",
+        dest="normalize_audio",
+        action="store_true",
+        default=None,
+        help="Scale each chunk to the full volume range (may cause loudness jumps)",
+    )
+    parser.add_argument(
+        "--no-normalize",
+        dest="normalize_audio",
+        action="store_false",
+        default=None,
+        help="Never normalize audio",
+    )
+    parser.add_argument(
+        "--sentence-silence",
+        type=float,
+        default=_env_float("PIPER_SENTENCE_SILENCE"),
+        help="Seconds of silence after each sentence",
+    )
+    parser.add_argument(
+        "--chunk-silence",
+        type=float,
+        default=_env_float("PIPER_CHUNK_SILENCE"),
+        help="Seconds of silence between chunks (hides boundary artifacts)",
+    )
+    #
+    # Chunking
+    parser.add_argument(
+        "--chunk-profile",
+        default=_env("PIPER_CHUNK_PROFILE"),
+        help="Chunking preset: instant, responsive, balanced, smooth, off",
+    )
+    parser.add_argument(
+        "--chunk-max-words",
+        type=int,
+        default=_env_float("PIPER_CHUNK_MAX_WORDS"),
+        help="Maximum words per chunk sent to the server",
+    )
+    parser.add_argument(
+        "--chunk-first-max-words",
+        type=int,
+        default=_env_float("PIPER_CHUNK_FIRST_MAX_WORDS"),
+        help="Maximum words in the first chunk (lower = faster first audio)",
+    )
+    parser.add_argument(
+        "--chunk-min-words",
+        type=int,
+        default=_env_float("PIPER_CHUNK_MIN_WORDS"),
+        help="Minimum words before breaking at a clause boundary",
+    )
+    parser.add_argument(
+        "--chunk-max-chars",
+        type=int,
+        default=_env_float("PIPER_CHUNK_MAX_CHARS"),
+        help="Hard limit on chunk length in characters",
+    )
+    parser.add_argument(
+        "--chunk-mode",
+        choices=("client", "server"),
+        default=_env("PIPER_CHUNK_MODE", default="client"),
+        help="Chunk here (default) or let the server do it",
+    )
+    parser.add_argument(
+        "--prefetch",
+        type=int,
+        default=int(_env_float("PIPER_PREFETCH", default=1) or 0),
+        help="Chunks to synthesize ahead of playback (default: 1)",
+    )
+    #
+    parser.add_argument(
+        "--channel",
+        default=_env("PIPER_CHANNEL", default="default"),
+        help="Preemption group on the server (default: default)",
+    )
+    parser.add_argument(
+        "--no-preempt",
+        action="store_true",
+        help="Don't cancel audio that is already playing on the server",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=_env_float("PIPER_TIMEOUT", default=30.0),
+        help="Request timeout in seconds",
+    )
+    #
+    parser.add_argument(
+        "--player",
+        default=_env("PIPER_PLAYER", default="auto"),
+        help=(
+            "Player command template reading raw PCM on stdin"
+            " ({rate}, {channels}, {latency_ms}), or 'auto'"
+        ),
+    )
+    parser.add_argument(
+        "--player-latency-ms",
+        type=int,
+        default=int(_env_float("PIPER_PLAYER_LATENCY_MS", default=40) or 40),
+        help="Playback buffer in milliseconds (default: 40)",
+    )
+
+
+def client_config_from_args(args: argparse.Namespace) -> ClientConfig:
+    """Build a :class:`ClientConfig` from parsed arguments/environment."""
+    overrides: Dict[str, Any] = {}
+    if args.chunk_profile:
+        overrides["profile"] = args.chunk_profile
+
+    for name in (
+        "chunk_max_words",
+        "chunk_first_max_words",
+        "chunk_min_words",
+        "chunk_max_chars",
+    ):
+        value = getattr(args, name, None)
+        if value is not None:
+            overrides[name[len("chunk_") :]] = int(value)
+
+    chunking = ChunkingConfig.from_mapping(overrides, base=ChunkingConfig())
+
+    length_scale = args.length_scale
+    if (length_scale is None) and (args.rate is not None):
+        length_scale = rate_to_length_scale(
+            args.rate, rate_factor=args.rate_factor or DEFAULT_RATE_FACTOR
+        )
+
+    volume = args.volume
+    if (volume is None) and (args.sd_volume is not None):
+        volume = sd_volume_to_multiplier(args.sd_volume)
+
+    return ClientConfig(
+        url=args.url,
+        voice=normalize_voice_name(args.voice),
+        speaker=args.speaker,
+        speaker_id=args.speaker_id,
+        length_scale=length_scale,
+        noise_scale=args.noise_scale,
+        noise_w_scale=args.noise_w_scale,
+        volume=volume,
+        normalize_audio=args.normalize_audio,
+        sentence_silence=args.sentence_silence,
+        chunk_silence=args.chunk_silence,
+        chunking=chunking,
+        chunk_mode=args.chunk_mode,
+        prefetch=max(0, args.prefetch),
+        channel=args.channel,
+        preempt=not args.no_preempt,
+        timeout=args.timeout,
+    )
+
+
+def main() -> int:
+    """Run the command line client."""
+    parser = argparse.ArgumentParser(
+        prog="piper-client",
+        description="Stream text to a Piper HTTP server and play it.",
+    )
+    parser.add_argument(
+        "text", nargs="*", help="Text to speak (default: read from stdin)"
+    )
+    add_client_arguments(parser)
+    parser.add_argument(
+        "--output",
+        choices=("play", "raw", "wav"),
+        default="play",
+        help="Play the audio (default), or write raw PCM/WAV to --output-file",
+    )
+    parser.add_argument(
+        "-f",
+        "--output-file",
+        help="Where to write audio for --output raw/wav (default: stdout)",
+    )
+    parser.add_argument(
+        "--stop",
+        action="store_true",
+        help="Stop whatever is being synthesized on the server and exit",
+    )
+    parser.add_argument(
+        "--info", action="store_true", help="Print server info and exit"
+    )
+    parser.add_argument(
+        "--list-voices", action="store_true", help="List server voices and exit"
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Print DEBUG messages to stderr"
+    )
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.WARNING, stream=sys.stderr
+    )
+
+    config = client_config_from_args(args)
+    client = PiperClient(config)
+
+    if args.stop:
+        client.stop()
+        return 0
+
+    if args.info:
+        json.dump(client.info(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    if args.list_voices:
+        for voice_name in sorted(client.voices()):
+            print(voice_name)
+
+        return 0
+
+    if args.text:
+        text = " ".join(args.text)
+    else:
+        text = sys.stdin.read()
+
+    text = text.strip()
+    if not text:
+        return 0
+
+    # speech-dispatcher (and anything else) stops us with SIGTERM/SIGINT:
+    # playback and inference must end immediately.
+    def handle_signal(signum: int, _frame: Any) -> None:
+        _LOGGER.debug("Received signal %s, stopping", signum)
+        client.stop()
+
+    for signal_name in ("SIGTERM", "SIGINT", "SIGHUP"):
+        signal_number = getattr(signal, signal_name, None)
+        if signal_number is not None:
+            try:
+                signal.signal(signal_number, handle_signal)
+            except ValueError:
+                pass
+
+    sink: Any
+    if args.output == "play":  # pylint: disable=consider-using-with
+        sink = AudioSink(
+            PlayerConfig(command=args.player, latency_ms=args.player_latency_ms),
+            sample_rate=client.sample_rate(),
+        )
+    else:
+        output_file = (
+            open(args.output_file, "wb")  # pylint: disable=consider-using-with
+            if args.output_file
+            else sys.stdout.buffer
+        )
+        if args.output == "wav":
+            output_file.write(wav_header(client.sample_rate()))
+
+        sink = FileSink(output_file)
+
+    start_time = time.monotonic()
+    try:
+        completed = client.speak(text, sink)
+    except BrokenPipeError:
+        return 0
+    except (OSError, RuntimeError) as error:
+        if client.stopped:
+            return 0
+
+        print(f"piper-client: {error}", file=sys.stderr)
+        return 1
+
+    _LOGGER.debug(
+        "%s in %.3fs",
+        "Spoke" if completed else "Interrupted",
+        time.monotonic() - start_time,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/piper/speechd_module.py
+++ b/src/piper/speechd_module.py
@@ -1,0 +1,1731 @@
+"""Speech Dispatcher output module for Piper.
+
+Speech Dispatcher can drive Piper through its *generic* module (a shell command
+per utterance), but a generic module cannot stop speech reliably and pays the
+process startup cost every time. This module speaks the Speech Dispatcher
+output module protocol directly and talks to a long-running
+:mod:`piper.http_server`, which means:
+
+* the voice model stays loaded (no warm-up per utterance),
+* ``STOP``/``CANCEL`` interrupt playback *and* inference within a few tens of
+  milliseconds, without restarting anything,
+* text is chunked (see :mod:`piper.chunking`) so speech starts after a few
+  words, and index marks are reported as they are reached.
+
+Installation (no root required)::
+
+    mkdir -p ~/.local/libexec/speech-dispatcher-modules
+    ln -s "$(which sd_piper)" ~/.local/libexec/speech-dispatcher-modules/sd_piper
+    mkdir -p ~/.config/speech-dispatcher/modules
+    sd_piper --print-config > ~/.config/speech-dispatcher/modules/piper.conf
+
+Speech Dispatcher discovers ``sd_<name>`` binaries in that directory and passes
+``<name>.conf`` as the only argument. See docs/SPEECHD.md.
+
+Protocol reference: the module reads commands from stdin and writes replies and
+events to stdout, LF-terminated, UTF-8. stderr is free-form logging (Speech
+Dispatcher redirects it to ``<LogDir>/piper.log``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field, replace
+from queue import Empty, Queue
+from typing import IO, Any, Dict, List, Optional, Sequence, Tuple
+from urllib.parse import urlsplit
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - not Linux
+    fcntl = None  # type: ignore[assignment]
+
+from .chunking import PROFILES, ChunkingConfig, TextChunk
+from .client import (
+    DEFAULT_RATE_FACTOR,
+    DEFAULT_URL,
+    AudioSink,
+    ClientConfig,
+    PiperClient,
+    PlayerConfig,
+    rate_to_length_scale,
+    sd_volume_to_multiplier,
+)
+
+_LOGGER = logging.getLogger("piper.speechd")
+
+MODULE_NAME = "piper"
+
+# Speech Dispatcher inserts these marks between sentences
+SPD_MARK_PREFIX = "__spd_"
+
+# Maximum size of one 705 audio block (matches module_tts_output_server)
+MAX_AUDIO_BLOCK = 10000
+
+# HDLC-style escaping used for audio sent to the server
+ESCAPE_BYTE = 0x7D
+ESCAPE_MASK = 0x20
+ESCAPED_BYTES = (0x0A, ESCAPE_BYTE)
+
+# Autostart
+#: Hosts we may start a server for (starting a *remote* server is impossible).
+LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0", ""})
+
+#: systemd user unit looked up before starting anything ourselves.
+DEFAULT_SERVER_SERVICE = "piper-server.service"
+
+#: Transient unit name used with ``systemd-run`` (port appended).
+TRANSIENT_UNIT_PREFIX = "piper-server"
+
+#: How long to wait before trying to start the server again after a failure.
+START_RETRY_SECONDS = 30.0
+
+#: Timeout of the "is the server there?" request (it must never delay speech).
+PROBE_TIMEOUT = 2.0
+
+SERVICE_UNIT = """# Piper text-to-speech server (Speech Dispatcher backend)
+#
+# Install:
+#   sd_piper --print-service > ~/.config/systemd/user/piper-server.service
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now piper-server.service
+#
+# The Piper output module starts this unit on demand, so "enable" is optional:
+# it only makes the very first utterance after login fast.
+
+[Unit]
+Description=Piper text-to-speech server
+Documentation=https://github.com/OHF-voice/piper1-gpl
+Before=speech-dispatcher.service
+# A missing voice or a bad option cannot be fixed by restarting: stop trying
+# after a few attempts instead of looping (journalctl --user -u piper-server).
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
+[Service]
+Type=exec
+# Paths must be absolute: systemd does not expand "~".
+ExecStart={command}
+Restart=on-failure
+# Back off progressively (2s, 5s, 11s, 26s, 60s) instead of hammering the
+# machine when the server cannot start. RestartSteps and RestartMaxDelaySec
+# need systemd 254; older versions just use RestartSec.
+RestartSec=2
+RestartSteps=5
+RestartMaxDelaySec=60
+# Speech must never wait behind other work.
+Nice=-5
+# The model is loaded once and stays in memory.
+TimeoutStopSec=5
+
+[Install]
+WantedBy=default.target
+"""
+
+
+EXAMPLE_CONFIG = """# Piper output module for Speech Dispatcher (native module, sd_piper)
+#
+# Install:
+#   mkdir -p ~/.config/speech-dispatcher/modules
+#   sd_piper --print-config > ~/.config/speech-dispatcher/modules/piper.conf
+#   mkdir -p ~/.local/libexec/speech-dispatcher-modules
+#   ln -sf "$(command -v sd_piper)" ~/.local/libexec/speech-dispatcher-modules/sd_piper
+#
+# Speech Dispatcher then discovers the module automatically as "piper".
+# See docs/SPEECHD.md.
+
+# Where piper.http_server is listening.
+PiperURL "http://localhost:5000"
+
+# Audio output:
+#   player - this module plays audio itself (default). Interruption drops
+#            buffered audio immediately, which is what a screen reader needs.
+#   server - hand PCM back to Speech Dispatcher and let it play (uses the
+#            AudioOutputMethod from speechd.conf).
+PiperAudio player
+
+# Player command used in "player" mode. "auto" picks the first available of
+# pw-play, paplay, aplay, ffplay. {rate}, {channels} and {latency_ms} are
+# substituted; the command must read raw PCM on stdin.
+PiperPlayer "auto"
+
+# Playback buffer. Lower = speech stops sooner after STOP, but drop-outs become
+# more likely on a loaded machine.
+PiperPlayerLatencyMs 40
+
+# Chunking: how text is split before synthesis. This is the main
+# latency/quality trade-off, tune it to taste.
+#   instant    - start after 2 words, chunks of 3 (fastest, most artifacts)
+#   responsive - start after 3 words, chunks of 5 (default)
+#   balanced   - start after 4 words, chunks of 10
+#   smooth     - only split at sentences (best prosody, slowest start)
+#   off        - no splitting at all
+PiperChunkProfile responsive
+
+# Individual chunking knobs (override the profile).
+#PiperChunkMaxWords 5
+#PiperChunkFirstMaxWords 3
+#PiperChunkMinWords 2
+#PiperChunkMaxChars 0
+#PiperChunkAbbreviations "mr,mrs,dr,prof,etc"
+
+# Number of chunks synthesized ahead of playback.
+PiperPrefetch 1
+
+# Insert a little silence between chunks if you hear clicks at chunk
+# boundaries (seconds).
+#PiperChunkSilence 0.02
+#PiperSentenceSilence 0.0
+
+# Speech rate mapping: rate=+100 is this many times faster than rate=0,
+# rate=-100 this many times slower. Screen reader users often want 3 or more.
+PiperRateFactor 3.0
+
+# Length scale used at rate=0 (< 1 is faster).
+#PiperLengthScale 1.0
+
+# Starting the server
+# -------------------
+# The server is started on demand when it is not already running (the first
+# utterance then waits for the model to load). The best setup is still to run
+# it as a user service, so it is ready before the screen reader speaks:
+#
+#   sd_piper --print-service > ~/.config/systemd/user/piper-server.service
+#   systemctl --user daemon-reload && systemctl --user enable --now piper-server
+#
+#   auto - start it if PiperURL is local and it does not answer (default)
+#   yes  - same, and complain in the log when it is not possible
+#   no   - never start anything; only use a server that is already running
+PiperAutostart auto
+
+# How to start it:
+#   auto    - systemd user service if available, otherwise a plain process
+#   systemd - only systemd (the unit below, or a transient one)
+#   process - only a detached child process
+PiperServerManager auto
+
+# systemd user unit started when it exists. Use "none" to always start a
+# transient unit / plain process instead.
+PiperServerService "piper-server.service"
+
+# Command used to start the server ("~" is expanded). The default is derived
+# from DefaultVoice:
+#   python3 -m piper.http_server --host 127.0.0.1 --port 5000 --model <voice>
+#PiperServerCommand "python3 -m piper.http_server -m /home/user/.piper-voices/en_US-kristin-medium.onnx"
+
+# How long the first utterance waits for the server (seconds).
+PiperServerTimeout 20
+
+# Voices: AddVoice <language> <symbolic voice> <Piper voice name>
+# The Piper voice name is what the server knows (see: curl localhost:5000/voices).
+AddVoice "en-US" "FEMALE1" "en_US-kristin-medium"
+#AddVoice "en-US" "MALE1"   "en_US-ryan-medium"
+#AddVoice "fr-FR" "FEMALE1" "fr_FR-siwis-medium"
+
+# Voice used when the client does not ask for anything specific.
+DefaultVoice "en_US-kristin-medium"
+"""
+
+
+# -----------------------------------------------------------------------------
+# Module configuration file
+# -----------------------------------------------------------------------------
+
+
+#: Chunking options of the module config file -> ChunkingConfig fields
+_CHUNK_OPTIONS = {
+    "piperchunkprofile": "profile",
+    "piperchunkenabled": "enabled",
+    "piperchunkmaxwords": "max_words",
+    "piperchunkfirstmaxwords": "first_max_words",
+    "piperchunkminwords": "min_words",
+    "piperchunkmaxchars": "max_chars",
+    "piperchunkmergeshorttail": "merge_short_tail",
+    "piperchunkbreakonsentence": "break_on_sentence",
+    "piperchunkbreakonclause": "break_on_clause",
+    "piperchunksentencepunctuation": "sentence_punctuation",
+    "piperchunkclausepunctuation": "clause_punctuation",
+    "piperchunkabbreviations": "abbreviations",
+    "piperchunkstripurls": "strip_urls",
+}
+
+
+@dataclass
+class VoiceEntry:
+    """An ``AddVoice`` entry: language, symbolic voice type, Piper voice name."""
+
+    language: str
+    voice_type: str
+    name: str
+
+    @property
+    def variant(self) -> str:
+        return "none"
+
+
+@dataclass
+class ModuleConfig:
+    """Options read from the module configuration file."""
+
+    url: str = DEFAULT_URL
+    default_voice: Optional[str] = None
+    voices: List[VoiceEntry] = field(default_factory=list)
+    #
+    audio_output: str = "player"
+    """``player`` (this module plays audio, default) or ``server`` (hand PCM
+    back to Speech Dispatcher, which plays it)."""
+
+    player: str = "auto"
+    player_latency_ms: int = 40
+    #
+    chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
+    chunk_mode: str = "client"
+    prefetch: int = 1
+    channel: str = "speech-dispatcher"
+    #
+    rate_factor: float = DEFAULT_RATE_FACTOR
+    base_length_scale: float = 1.0
+    sentence_silence: Optional[float] = None
+    chunk_silence: Optional[float] = None
+    normalize_audio: Optional[bool] = None
+    noise_scale: Optional[float] = None
+    noise_w_scale: Optional[float] = None
+    #
+    autostart: str = "auto"
+    """``auto`` (start a local server on demand, default), ``yes`` (same, but
+    complain if it cannot be done) or ``no``."""
+
+    server_manager: str = "auto"
+    """How the server is started: ``auto`` (systemd if available, otherwise a
+    plain process), ``systemd``, ``process`` or ``none``."""
+
+    server_service: str = DEFAULT_SERVER_SERVICE
+    """systemd user unit to start if it exists (``none`` to ignore units)."""
+
+    server_command: Optional[str] = None
+    """Command used to start the server (default: derived from the voice)."""
+
+    server_timeout: float = 20.0
+    """How long to wait for the server to answer after starting it."""
+    #
+    log_level: int = 3
+
+    @staticmethod
+    def load(config_path: Optional[str]) -> "ModuleConfig":
+        """Parse a Speech Dispatcher style module config file.
+
+        Unknown options are ignored so the same file can also be used by the
+        generic module.
+        """
+        config = ModuleConfig()
+        chunk_overrides: Dict[str, Any] = {}
+
+        if not config_path:
+            return config
+
+        try:
+            with open(config_path, "r", encoding="utf-8") as config_file:
+                lines = config_file.readlines()
+        except OSError as error:
+            _LOGGER.warning("Cannot read config %s: %s", config_path, error)
+            return config
+
+        for line in lines:
+            line = line.strip()
+            if (not line) or line.startswith("#"):
+                continue
+
+            try:
+                parts = shlex.split(line, comments=True)
+            except ValueError:
+                _LOGGER.warning("Ignoring unparsable config line: %s", line)
+                continue
+
+            if not parts:
+                continue
+
+            key, values = parts[0].lower(), parts[1:]
+            value = values[0] if values else ""
+
+            if key == "addvoice" and (len(values) >= 3):
+                config.voices.append(
+                    VoiceEntry(
+                        language=values[0], voice_type=values[1].upper(), name=values[2]
+                    )
+                )
+            elif key in ("defaultvoice", "pipervoice"):
+                config.default_voice = value
+            elif key in ("piperurl", "url"):
+                config.url = value
+            elif key == "piperaudio":
+                config.audio_output = value.lower()
+            elif key == "piperplayer":
+                config.player = value
+            elif key == "piperplayerlatencyms":
+                config.player_latency_ms = int(value)
+            elif key in _CHUNK_OPTIONS:
+                chunk_overrides[_CHUNK_OPTIONS[key]] = value
+            elif key == "piperchunkmode":
+                config.chunk_mode = value.lower()
+            elif key == "piperprefetch":
+                config.prefetch = int(value)
+            elif key == "piperchannel":
+                config.channel = value
+            elif key == "piperratefactor":
+                config.rate_factor = float(value)
+            elif key == "piperlengthscale":
+                config.base_length_scale = float(value)
+            elif key == "pipersentencesilence":
+                config.sentence_silence = float(value)
+            elif key == "piperchunksilence":
+                config.chunk_silence = float(value)
+            elif key == "pipernormalize":
+                config.normalize_audio = value.lower() in ("1", "true", "yes", "on")
+            elif key == "pipernoisescale":
+                config.noise_scale = float(value)
+            elif key == "pipernoisewscale":
+                config.noise_w_scale = float(value)
+            elif key == "piperautostart":
+                config.autostart = _autostart_mode(value)
+            elif key == "piperservermanager":
+                config.server_manager = value.lower()
+            elif key == "piperserverservice":
+                config.server_service = value
+            elif key == "piperservercommand":
+                config.server_command = " ".join(values)
+            elif key == "piperservertimeout":
+                config.server_timeout = float(value)
+
+        if chunk_overrides:
+            config.chunking = ChunkingConfig.from_mapping(
+                chunk_overrides, base=config.chunking
+            )
+
+        return config
+
+
+# -----------------------------------------------------------------------------
+# Starting the server
+# -----------------------------------------------------------------------------
+
+
+def _autostart_mode(value: str) -> str:
+    """Normalize ``PiperAutostart`` (``1``/``0`` are accepted for old configs)."""
+    lowered = value.strip().lower()
+    if lowered in ("0", "no", "off", "false", "never"):
+        return "no"
+
+    if lowered in ("1", "yes", "on", "true", "always"):
+        return "yes"
+
+    return "auto"
+
+
+def split_url(url: str) -> Tuple[str, int]:
+    """Return ``(host, port)`` of a server URL."""
+    parts = urlsplit(url if "//" in url else f"http://{url}")
+    port = parts.port or (443 if parts.scheme == "https" else 80)
+    return (parts.hostname or "localhost"), port
+
+
+def is_local_url(url: str) -> bool:
+    """True if a server for this URL could run on this machine."""
+    host, _port = split_url(url)
+    return host.lower() in LOCAL_HOSTS
+
+
+def default_server_command(config: ModuleConfig) -> Optional[List[str]]:
+    """Build the command that starts a server matching this configuration.
+
+    ``None`` if no voice is configured, in which case the server cannot be
+    started without an explicit ``PiperServerCommand``.
+    """
+    voice = config.default_voice or (config.voices[0].name if config.voices else None)
+    if not voice:
+        return None
+
+    host, port = split_url(config.url)
+    return [
+        sys.executable or "python3",
+        "-m",
+        "piper.http_server",
+        "--host",
+        "127.0.0.1" if host.lower() in ("localhost", "0.0.0.0", "") else host,
+        "--port",
+        str(port),
+        "--model",
+        voice,
+    ]
+
+
+def expand_user(argument: str) -> str:
+    """Expand a leading ``~``, including after ``=`` (``--data-dir=~/voices``).
+
+    Speech Dispatcher configuration files are not read by a shell, so nothing
+    else expands the home directory.
+    """
+    if argument.startswith("~"):
+        return os.path.expanduser(argument)
+
+    option, separator, value = argument.partition("=")
+    if separator and value.startswith("~"):
+        return f"{option}={os.path.expanduser(value)}"
+
+    return argument
+
+
+def server_command(config: ModuleConfig) -> Optional[List[str]]:
+    """The configured start command, or the derived one."""
+    if config.server_command:
+        try:
+            return [expand_user(part) for part in shlex.split(config.server_command)]
+        except ValueError:
+            _LOGGER.error("Cannot parse PiperServerCommand: %s", config.server_command)
+            return None
+
+    return default_server_command(config)
+
+
+def _run(command: Sequence[str], timeout: float = 10.0) -> Optional[str]:
+    """Run a helper command; return its stderr on success, None on failure."""
+    try:
+        result = subprocess.run(  # pylint: disable=subprocess-run-check
+            list(command),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        _LOGGER.debug("%s failed: %s", command[0], error)
+        return None
+
+    stderr = result.stderr.decode("utf-8", errors="replace").strip()
+    if result.returncode != 0:
+        _LOGGER.debug("%s exited with %s: %s", command[0], result.returncode, stderr)
+        return None
+
+    return stderr
+
+
+def systemd_user_available() -> bool:
+    """True if there is a systemd user manager we can talk to."""
+    return bool(os.environ.get("XDG_RUNTIME_DIR")) and (
+        shutil.which("systemctl") is not None
+    )
+
+
+def _unit_failed(unit: str) -> bool:
+    """True if a systemd user unit gave up starting."""
+    return (
+        _run(["systemctl", "--user", "is-failed", "--quiet", "--", unit], timeout=5.0)
+        is not None
+    )
+
+
+def server_log_path() -> str:
+    """Where a self-started server writes its log."""
+    base = os.environ.get("XDG_STATE_HOME") or os.path.expanduser("~/.local/state")
+    return os.path.join(base, "piper", "http_server.log")
+
+
+def _open_server_log() -> Optional[IO[bytes]]:
+    """Open the server log, or None if it cannot be written."""
+    path = server_log_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        return open(path, "ab", buffering=0)  # pylint: disable=consider-using-with
+    except OSError as error:
+        _LOGGER.debug("Cannot write %s: %s", path, error)
+        return None
+
+
+class StartLock:
+    """Advisory lock so that two modules never start two servers.
+
+    Held only while the server is being started. If another process holds it,
+    that process is starting the server and we simply wait for it.
+    """
+
+    def __init__(self, port: int) -> None:
+        directory = os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir()
+        self.path = os.path.join(directory, f"piper-server-{port}.lock")
+        self._file: Optional[Any] = None
+
+    def __enter__(self) -> bool:
+        """True if we own the lock (or if locking is unavailable)."""
+        if fcntl is None:
+            return True
+
+        try:
+            # pylint: disable=consider-using-with
+            self._file = open(self.path, "a", encoding="utf-8")
+        except OSError as error:
+            # No lock file: starting the server is still better than not
+            # speaking at all (the server itself refuses a second bind).
+            _LOGGER.debug("Cannot use %s: %s", self.path, error)
+            return True
+
+        try:
+            fcntl.flock(self._file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            _LOGGER.debug("Another process is starting the server")
+            self._close()
+            return False
+        except OSError as error:
+            _LOGGER.debug("Cannot lock %s: %s", self.path, error)
+            return True
+
+        return True
+
+    def __exit__(self, *_exception: Any) -> None:
+        self._close()
+
+    def _close(self) -> None:
+        if self._file is not None:
+            try:
+                self._file.close()
+            except OSError:
+                pass
+
+            self._file = None
+
+
+# -----------------------------------------------------------------------------
+# SSML
+# -----------------------------------------------------------------------------
+
+_ENTITIES = (("&lt;", "<"), ("&gt;", ">"), ("&quot;", '"'), ("&apos;", "'"))
+
+
+def parse_ssml(message: str) -> Tuple[str, List[Tuple[int, str]]]:
+    """Extract plain text and index marks from a Speech Dispatcher message.
+
+    Speech Dispatcher always sends SSML, with ``<mark name="__spd_N"/>`` markers
+    inserted between sentences.
+
+    :return: (text, [(offset in text, mark name), ...])
+    """
+    text_parts: List[str] = []
+    marks: List[Tuple[int, str]] = []
+    length = 0
+    index = 0
+    message_length = len(message)
+
+    while index < message_length:
+        start = message.find("<", index)
+        if start < 0:
+            chunk = _unescape(message[index:])
+            text_parts.append(chunk)
+            length += len(chunk)
+            break
+
+        if start > index:
+            chunk = _unescape(message[index:start])
+            text_parts.append(chunk)
+            length += len(chunk)
+
+        end = message.find(">", start)
+        if end < 0:
+            # Unterminated tag: treat the rest as text
+            chunk = _unescape(message[start:])
+            text_parts.append(chunk)
+            length += len(chunk)
+            break
+
+        tag = message[start + 1 : end]
+        if tag.lstrip("/").lower().startswith("mark"):
+            name = _tag_attribute(tag, "name")
+            if name:
+                marks.append((length, name))
+
+        index = end + 1
+
+    return "".join(text_parts), marks
+
+
+def _unescape(text: str) -> str:
+    # &amp; last so "&amp;lt;" does not become "<"
+    for entity, char in _ENTITIES:
+        text = text.replace(entity, char)
+
+    return text.replace("&amp;", "&")
+
+
+def _tag_attribute(tag: str, name: str) -> Optional[str]:
+    lowered = tag.lower()
+    position = lowered.find(name.lower() + "=")
+    if position < 0:
+        return None
+
+    rest = tag[position + len(name) + 1 :].lstrip()
+    if not rest:
+        return None
+
+    quote = rest[0]
+    if quote in ("'", '"'):
+        end = rest.find(quote, 1)
+        return rest[1:end] if end > 0 else None
+
+    return rest.split()[0].rstrip("/")
+
+
+# -----------------------------------------------------------------------------
+# Audio sinks
+# -----------------------------------------------------------------------------
+
+
+def escape_audio(audio_bytes: bytes) -> bytes:
+    """Escape PCM for a 705 AUDIO block (0x0A and 0x7D are escaped)."""
+    if not any(byte in audio_bytes for byte in ESCAPED_BYTES):
+        return audio_bytes
+
+    escaped = bytearray()
+    for byte in audio_bytes:
+        if byte in ESCAPED_BYTES:
+            escaped.append(ESCAPE_BYTE)
+            escaped.append(byte ^ ESCAPE_MASK)
+        else:
+            escaped.append(byte)
+
+    return bytes(escaped)
+
+
+class ServerAudioSink:
+    """Sends PCM back to Speech Dispatcher as ``705 AUDIO`` blocks."""
+
+    def __init__(self, writer: "ProtocolWriter", sample_rate: int) -> None:
+        self._writer = writer
+        self._sample_rate = sample_rate
+
+    def write(self, audio_bytes: bytes) -> None:
+        for offset in range(0, len(audio_bytes), MAX_AUDIO_BLOCK):
+            block = audio_bytes[offset : offset + MAX_AUDIO_BLOCK]
+            self._writer.write_audio(block, self._sample_rate)
+
+    def drain(self, timeout: Optional[float] = None) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
+# -----------------------------------------------------------------------------
+# Protocol I/O
+# -----------------------------------------------------------------------------
+
+
+class ProtocolWriter:
+    """Writes protocol replies and events, one complete message at a time.
+
+    A single lock guarantees that an asynchronous event never splits a
+    multi-line reply, which Speech Dispatcher treats as a fatal error.
+    """
+
+    def __init__(self, output: Any) -> None:
+        self._output = output
+        self._lock = threading.Lock()
+
+    def write_lines(self, *lines: str) -> None:
+        data = "".join(f"{line}\n" for line in lines).encode("utf-8")
+        with self._lock:
+            self._output.write(data)
+            self._output.flush()
+
+    def write_audio(self, audio_bytes: bytes, sample_rate: int) -> None:
+        """Write one ``705 AUDIO`` block (binary, HDLC-escaped)."""
+        num_samples = len(audio_bytes) // 2
+        header = (
+            f"705-bits=16\n"
+            f"705-num_channels=1\n"
+            f"705-sample_rate={sample_rate}\n"
+            f"705-num_samples={num_samples}\n"
+            f"705-big_endian=0\n"
+            f"705-AUDIO"
+        ).encode("utf-8")
+        with self._lock:
+            self._output.write(header)
+            self._output.write(b"\0")
+            self._output.write(escape_audio(audio_bytes))
+            self._output.write(b"\n705 AUDIO\n")
+            self._output.flush()
+
+
+# -----------------------------------------------------------------------------
+# The module
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class Utterance:
+    """One message to speak, with its own cancellation token."""
+
+    text: str
+    marks: List[Tuple[int, str]] = field(default_factory=list)
+    group: str = ""
+    chunking: Optional[ChunkingConfig] = None
+    """Chunking to use for this message (None = the module default)."""
+
+    cancelled: threading.Event = field(default_factory=threading.Event)
+    paused: bool = False
+
+    started: bool = False
+    """True once ``701 BEGIN`` has been sent for this message."""
+
+    def cancel(self, pause: bool = False) -> None:
+        self.paused = pause
+        self.cancelled.set()
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self.cancelled.is_set()
+
+
+class PiperSpeechdModule:
+    """Speech Dispatcher output module backed by the Piper HTTP server."""
+
+    def __init__(
+        self,
+        config: ModuleConfig,
+        stdin: Any = None,
+        stdout: Any = None,
+    ) -> None:
+        self.config = config
+        self._stdin = stdin if stdin is not None else sys.stdin.buffer
+        self._writer = ProtocolWriter(
+            stdout if stdout is not None else sys.stdout.buffer
+        )
+
+        # Voice parameters from SET
+        self._rate = 0.0
+        self._volume = 100.0
+        self._voice_type = "FEMALE1"
+        self._language: Optional[str] = None
+        self._synthesis_voice: Optional[str] = None
+
+        self._client = PiperClient(self._client_config())
+        self._sample_rate = 22050
+        self._server_audio = False
+
+        # Server startup. The flag is the fast path: it is only cleared when
+        # the server turns out to be gone, so speaking costs no extra request.
+        self._server_process: Optional[subprocess.Popen] = None
+        self._server_unit: Optional[str] = None
+        self._server_ready = threading.Event()
+        self._server_lock = threading.Lock()
+        self._retry_server_at = 0.0
+
+        self._queue: "Queue[Optional[Utterance]]" = Queue()
+        self._current_lock = threading.Lock()
+        self._current: Optional[Utterance] = None
+        self._quit = threading.Event()
+        self._worker = threading.Thread(target=self._speak_loop, daemon=True)
+
+    # -- configuration ----------------------------------------------------
+
+    def _client_config(self) -> ClientConfig:
+        return ClientConfig(
+            url=self.config.url,
+            voice=self._current_voice(),
+            length_scale=rate_to_length_scale(
+                self._rate,
+                base_length_scale=self.config.base_length_scale,
+                rate_factor=self.config.rate_factor,
+            ),
+            noise_scale=self.config.noise_scale,
+            noise_w_scale=self.config.noise_w_scale,
+            volume=sd_volume_to_multiplier(self._volume),
+            normalize_audio=self.config.normalize_audio,
+            sentence_silence=self.config.sentence_silence,
+            chunk_silence=self.config.chunk_silence,
+            chunking=self.config.chunking,
+            chunk_mode=self.config.chunk_mode,
+            prefetch=self.config.prefetch,
+            channel=self.config.channel,
+        )
+
+    def _current_voice(self) -> Optional[str]:
+        """Resolve the Piper voice name from the current SET parameters."""
+        if self._synthesis_voice:
+            return self._synthesis_voice
+
+        # Symbolic voice type + language, as configured with AddVoice
+        candidates = self.config.voices
+        if self._language:
+            language = self._language.lower()
+            matching = [
+                voice for voice in candidates if voice.language.lower() == language
+            ]
+            if not matching:
+                # Match just the language part ("en" for "en-GB")
+                prefix = language.split("-")[0]
+                matching = [
+                    voice
+                    for voice in candidates
+                    if voice.language.lower().split("-")[0] == prefix
+                ]
+
+            if matching:
+                candidates = matching
+
+        for voice in candidates:
+            if voice.voice_type == self._voice_type:
+                return voice.name
+
+        if candidates:
+            return candidates[0].name
+
+        return self.config.default_voice
+
+    def _voice_list(self) -> List[Tuple[str, str, str]]:
+        """Voices to report for ``LIST VOICES`` (at least one, always)."""
+        voices: List[Tuple[str, str, str]] = []
+        seen = set()
+
+        for entry in self.config.voices:
+            if entry.name in seen:
+                continue
+
+            seen.add(entry.name)
+            voices.append((entry.name, entry.language, entry.variant))
+
+        try:
+            for name, voice_config in sorted(self._client.voices().items()):
+                if name in seen:
+                    continue
+
+                seen.add(name)
+                language = _voice_language(name, voice_config)
+                voices.append((name, language, "none"))
+        except (OSError, RuntimeError, ValueError) as error:
+            _LOGGER.warning("Cannot list server voices: %s", error)
+
+        if not voices:
+            name = self.config.default_voice or MODULE_NAME
+            voices.append((name, "en-US", "none"))
+
+        return voices
+
+    # -- server -----------------------------------------------------------
+
+    def _server_is_up(self) -> bool:
+        """Probe the server, remembering its sample rate.
+
+        The probe uses its own short-lived client: it must not disturb (or wait
+        as long as) a synthesis request, and it may run while the worker thread
+        is speaking.
+        """
+        try:
+            probe = PiperClient(replace(self._client_config(), timeout=PROBE_TIMEOUT))
+            info = probe.info()
+            self._sample_rate = int(info["voice"]["sample_rate"])
+            return True
+        except (OSError, RuntimeError, ValueError, KeyError) as error:
+            _LOGGER.debug("Server not available: %s", error)
+            return False
+
+    def _autostart_wanted(self) -> bool:
+        mode = self.config.autostart
+        if (mode == "no") or (self.config.server_manager == "none"):
+            return False
+
+        if not is_local_url(self.config.url):
+            # Nothing we can do about a server on another machine.
+            log = _LOGGER.warning if mode == "yes" else _LOGGER.debug
+            log("Not starting a server: %s is not local", self.config.url)
+            return False
+
+        return True
+
+    def ensure_server(self, cancel: Optional[threading.Event] = None) -> bool:
+        """Make sure the server is running, starting it if necessary.
+
+        Idempotent and safe to call from any thread: the first caller does the
+        work while the others wait on the same lock, so a burst of utterances
+        can never start two servers. ``cancel`` (the current utterance's stop
+        token) aborts the wait early.
+        """
+        if self._server_ready.is_set():
+            return True
+
+        # Someone else may already be starting the server (the background
+        # thread from INIT, typically): wait for it, but stay interruptible.
+        # pylint: disable=consider-using-with
+        while not self._server_lock.acquire(timeout=0.1):
+            if self._server_ready.is_set():
+                return True
+
+            if self._aborted(cancel):
+                return False
+
+        try:
+            if self._server_ready.is_set():
+                return True
+
+            if self._server_is_up():
+                self._server_ready.set()
+                return True
+
+            if not self._autostart_wanted():
+                return False
+
+            if time.monotonic() < self._retry_server_at:
+                # A recent attempt failed: fail fast instead of making every
+                # utterance wait for the same timeout again.
+                return False
+
+            if self._start_server(cancel=cancel):
+                self._server_ready.set()
+                return True
+
+            if not self._aborted(cancel):
+                # Genuine failure (not "the user pressed stop while we waited").
+                self._retry_server_at = time.monotonic() + START_RETRY_SECONDS
+
+            return False
+        finally:
+            self._server_lock.release()
+
+    def _aborted(self, cancel: Optional[threading.Event] = None) -> bool:
+        """True if waiting for the server was interrupted rather than failed."""
+        return self._quit.is_set() or ((cancel is not None) and cancel.is_set())
+
+    def server_lost(self) -> None:
+        """Forget that the server was up, so the next utterance re-checks it."""
+        self._server_ready.clear()
+
+    def _start_server(self, cancel: Optional[threading.Event] = None) -> bool:
+        """Start the server and wait for it to answer."""
+        command = server_command(self.config)
+        if not command:
+            _LOGGER.error(
+                "Cannot start a server: no voice configured "
+                "(add DefaultVoice or PiperServerCommand to the module config)"
+            )
+            return False
+
+        _, port = split_url(self.config.url)
+        with StartLock(port) as owned:
+            if not owned:
+                # Another module instance is already starting the same
+                # server: wait for it instead of starting a second one.
+                return self._wait_for_server(cancel=cancel)
+
+            manager = self.config.server_manager
+            started = False
+            if manager in ("auto", "systemd"):
+                started = self._start_with_systemd(command)
+
+            if (not started) and (manager in ("auto", "process")):
+                started = self._spawn(command)
+
+            if not started:
+                return False
+
+            # The lock is held until the server answers, so a module starting at
+            # the same time waits for this server instead of starting its own.
+            if self._wait_for_server(cancel=cancel):
+                _LOGGER.info("Piper server is ready at %s", self.config.url)
+                return True
+
+        if not self._aborted(cancel):
+            _LOGGER.error(
+                "Piper server did not answer at %s within %.0fs (see %s)",
+                self.config.url,
+                self.config.server_timeout,
+                server_log_path(),
+            )
+
+        return False
+
+    def _start_with_systemd(self, command: Sequence[str]) -> bool:
+        """Start the server as a systemd user unit.
+
+        Preferred when available: systemd owns the process, so it survives this
+        module, is restarted if it crashes, is stopped at logout, and starting
+        an already-running unit is a no-op — no locking needed.
+        """
+        if not systemd_user_available():
+            return False
+
+        unit = self.config.server_service.strip()
+        if unit and (unit.lower() not in ("none", "off", "")):
+            if _run(["systemctl", "--user", "cat", "--", unit]) is not None:
+                _LOGGER.info("Starting systemd user unit %s", unit)
+                self._server_unit = unit
+                return _run(["systemctl", "--user", "start", "--", unit]) is not None
+
+        if shutil.which("systemd-run") is None:
+            return False
+
+        _, port = split_url(self.config.url)
+        transient = f"{TRANSIENT_UNIT_PREFIX}-{port}"
+        _LOGGER.debug("Trying transient unit %s: %s", transient, " ".join(command))
+        result = _run(
+            [
+                "systemd-run",
+                "--user",
+                "--quiet",
+                "--collect",
+                f"--unit={transient}",
+                "--description=Piper text-to-speech server",
+                "--",
+                *command,
+            ]
+        )
+        if result is not None:
+            _LOGGER.info("Started transient unit %s", transient)
+            self._server_unit = transient
+            return True
+
+        # Someone else won the race: the unit is already running.
+        return _run(["systemctl", "--user", "is-active", "--", transient]) is not None
+
+    def _spawn(self, command: Sequence[str]) -> bool:
+        """Start the server as a detached child process (no systemd)."""
+        log_file = _open_server_log()
+        _LOGGER.info("Starting Piper server: %s", " ".join(command))
+        try:
+            # start_new_session: the server outlives this module, so the next
+            # Speech Dispatcher restart finds a warm voice, and Speech
+            # Dispatcher's signals do not reach it.
+            self._server_process = (
+                subprocess.Popen(  # pylint: disable=consider-using-with
+                    list(command),
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_file if log_file is not None else subprocess.DEVNULL,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            )
+            return True
+        except OSError as error:
+            _LOGGER.error("Failed to start Piper server: %s", error)
+            return False
+        finally:
+            if log_file is not None:
+                log_file.close()
+
+    def _wait_for_server(self, cancel: Optional[threading.Event] = None) -> bool:
+        deadline = time.monotonic() + self.config.server_timeout
+        while time.monotonic() < deadline:
+            if self._aborted(cancel):
+                return False
+
+            if self._server_is_up():
+                return True
+
+            process = self._server_process
+            if (process is not None) and (process.poll() is not None):
+                _LOGGER.error(
+                    "Piper server exited with %s (see %s)",
+                    process.returncode,
+                    server_log_path(),
+                )
+                return False
+
+            if (self._server_unit is not None) and _unit_failed(self._server_unit):
+                _LOGGER.error(
+                    "%s failed to start (journalctl --user -u %s)",
+                    self._server_unit,
+                    self._server_unit,
+                )
+                return False
+
+            time.sleep(0.2)
+
+        return False
+
+    # -- main loop --------------------------------------------------------
+
+    def run(self) -> int:
+        """Run the module until QUIT or end of input."""
+        line = self._read_line()
+        if line != "INIT":
+            _LOGGER.error("Expected INIT, got %r", line)
+            return 3
+
+        self._worker.start()
+
+        # Speech Dispatcher blocks while a module loads, so the server is
+        # started in the background: the daemon (and the whole desktop session)
+        # must not wait for a model to load. Utterances that arrive before the
+        # server is up wait for it in the worker thread instead.
+        threading.Thread(
+            target=self.ensure_server, name="piper-autostart", daemon=True
+        ).start()
+
+        self._writer.write_lines(
+            f"299-{MODULE_NAME}: streaming Piper via {self.config.url}",
+            "299 OK LOADED SUCCESSFULLY",
+        )
+
+        while not self._quit.is_set():
+            line = self._read_line()
+            if line is None:
+                break
+
+            try:
+                self._handle(line)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Error handling command %r", line)
+                self._writer.write_lines("401 ERROR INTERNAL")
+
+        self.close()
+        return 0
+
+    def close(self) -> None:
+        self._quit.set()
+        self._drain_queue()
+        self._interrupt(notify_server=False)
+        self._queue.put(None)
+
+    def _read_line(self) -> Optional[str]:
+        """Read one LF-terminated line, or None at end of input."""
+        data = self._stdin.readline()
+        if not data:
+            return None
+
+        if isinstance(data, bytes):
+            return data.decode("utf-8", errors="replace").rstrip("\n")
+
+        return data.rstrip("\n")
+
+    def _read_block(self) -> Optional[List[str]]:
+        """Read lines until a line containing only a dot."""
+        lines: List[str] = []
+        while True:
+            line = self._read_line()
+            if line is None:
+                return None
+
+            if line == ".":
+                return lines
+
+            # Dot-stuffing: a leading dot was doubled by the server
+            if line.startswith("."):
+                line = line[1:]
+
+            lines.append(line)
+
+    def _handle(self, line: str) -> None:
+        command = line.strip()
+        upper = command.upper()
+
+        if upper == "SPEAK":
+            self._cmd_speak()
+        elif upper == "CHAR":
+            self._cmd_speak(single_line=True, mode="char")
+        elif upper == "KEY":
+            self._cmd_speak(single_line=True, mode="key")
+        elif upper == "SOUND_ICON":
+            # No sound icons: let Speech Dispatcher fall back
+            block = self._read_block()
+            if block is not None:
+                self._writer.write_lines("301 ERROR CANT SPEAK")
+        elif upper == "STOP":
+            self._cmd_stop()
+        elif upper == "PAUSE":
+            # Piper has no resume position: pausing behaves like stopping.
+            self._cmd_stop(pause=True)
+        elif upper == "SET":
+            self._cmd_settings("203 OK RECEIVING SETTINGS", "203 OK SETTINGS RECEIVED")
+        elif upper == "AUDIO":
+            self._cmd_audio()
+        elif upper == "LOGLEVEL":
+            self._cmd_settings(
+                "207 OK RECEIVING LOGLEVEL SETTINGS", "203 OK LOGLEVEL SET"
+            )
+        elif upper.startswith("LIST VOICES"):
+            self._cmd_list_voices(command[len("LIST VOICES") :].split())
+        elif upper.startswith("DEBUG"):
+            self._cmd_debug(command.split())
+        elif upper == "QUIT":
+            self._writer.write_lines("210 OK QUIT")
+            self._quit.set()
+            self.close()
+        else:
+            self._writer.write_lines("300 ERR UNKNOWN COMMAND")
+
+    # -- commands ---------------------------------------------------------
+
+    def _cmd_speak(self, single_line: bool = False, mode: str = "text") -> None:
+        self._writer.write_lines("202 OK RECEIVING MESSAGE")
+        block = self._read_block()
+        if block is None:
+            return
+
+        if single_line and (len(block) > 1):
+            self._writer.write_lines("305 DATA MORE THAN ONE LINE")
+            return
+
+        message = "\n".join(block)
+        chunking: Optional[ChunkingConfig] = None
+        marks: List[Tuple[int, str]] = []
+        if mode == "char":
+            # Single characters and key names are short and must stay in one
+            # piece: chunking them would be pointless and could split a name.
+            text = _char_to_text(message)
+            chunking = PROFILES["off"]
+        elif mode == "key":
+            text = _key_to_text(message)
+            chunking = PROFILES["off"]
+        else:
+            text, marks = parse_ssml(message)
+
+        text = text.strip()
+        if not text:
+            self._writer.write_lines("301 ERROR CANT SPEAK")
+            return
+
+        # Cancel anything queued and stop what is playing: the new message
+        # wins. Cancelled messages are still reported as stopped.
+        self._cancel_queued()
+        self._interrupt()
+
+        # Each utterance carries its own cancellation token, created *before*
+        # the acknowledgement: Speech Dispatcher may send STOP as soon as it has
+        # the reply, and that STOP must apply to this utterance, not the
+        # previous one.
+        utterance = Utterance(
+            text=text, marks=marks, group=uuid.uuid4().hex, chunking=chunking
+        )
+        with self._current_lock:
+            self._current = utterance
+
+        self._writer.write_lines("200 OK SPEAKING")
+        self._queue.put(utterance)
+
+    def _cmd_stop(self, pause: bool = False) -> None:
+        # No reply is allowed for STOP/PAUSE: the 703/704 event is the answer.
+        _LOGGER.debug("Stop requested (pause=%s)", pause)
+        self._cancel_queued(pause=pause)
+        self._interrupt(pause=pause)
+
+    def _cmd_settings(self, receiving: str, received: str) -> None:
+        self._writer.write_lines(receiving)
+        block = self._read_block()
+        if block is None:
+            return
+
+        error: Optional[str] = None
+        for line in block:
+            if "=" not in line:
+                error = error or "302 ERROR BAD SYNTAX"
+                continue
+
+            key, _, value = line.partition("=")
+            try:
+                self._set_parameter(key.strip().lower(), value.strip())
+            except ValueError:
+                error = error or "303 ERROR INVALID PARAMETER OR VALUE"
+
+        self._client.config = self._client_config()
+        self._writer.write_lines(error or received)
+
+    def _set_parameter(self, key: str, value: str) -> None:
+        if key == "rate":
+            self._rate = float(value)
+        elif key == "volume":
+            self._volume = float(value)
+        elif key == "voice":
+            self._voice_type = value.upper()
+        elif key == "language":
+            self._language = None if value == "NULL" else value
+        elif key == "synthesis_voice":
+            self._synthesis_voice = None if value == "NULL" else value
+        elif key == "log_level":
+            self.config.log_level = int(value)
+            logging.getLogger().setLevel(_log_level(int(value)))
+        elif key in (
+            "pitch",
+            "pitch_range",
+            "punctuation_mode",
+            "spelling_mode",
+            "cap_let_recogn",
+        ):
+            # Not supported by Piper voices; ignored on purpose.
+            _LOGGER.debug("Ignoring unsupported parameter %s=%s", key, value)
+        else:
+            _LOGGER.debug("Unknown parameter %s=%s", key, value)
+
+    def _cmd_audio(self) -> None:
+        self._writer.write_lines("207 OK RECEIVING AUDIO SETTINGS")
+        block = self._read_block()
+        if block is None:
+            return
+
+        settings = dict(
+            line.partition("=")[::2] for line in block if "=" in line  # type: ignore[misc]
+        )
+        method = settings.get("audio_output_method", "")
+
+        if method == "server":
+            if self.config.audio_output == "server":
+                self._server_audio = True
+                self._writer.write_lines("203 OK AUDIO INITIALIZED")
+            else:
+                # Refuse server-side audio: we play the audio ourselves, which
+                # lets us drop buffered audio instantly on STOP.
+                self._writer.write_lines(
+                    "300-piper plays audio itself", "300 MODULE ERROR"
+                )
+
+            return
+
+        self._server_audio = False
+        self._writer.write_lines("203 OK AUDIO INITIALIZED")
+
+    def _cmd_list_voices(self, arguments: Sequence[str]) -> None:
+        voices = self._voice_list()
+        if arguments:
+            language = arguments[0].lower()
+            variant = arguments[1].lower() if len(arguments) > 1 else None
+            filtered = [
+                voice
+                for voice in voices
+                if voice[1].lower() == language
+                and ((variant is None) or (voice[2].lower() == variant))
+            ]
+            if not filtered:
+                prefix = language.split("-")[0]
+                filtered = [
+                    voice
+                    for voice in voices
+                    if voice[1].lower().split("-")[0] == prefix
+                    and ((variant is None) or (voice[2].lower() == variant))
+                ]
+
+            voices = filtered
+
+        if not voices:
+            self._writer.write_lines("304 CANT LIST VOICES")
+            return
+
+        self._writer.write_lines(
+            *[
+                f"200-{name}\t{language}\t{variant}"
+                for name, language, variant in voices
+            ],
+            "200 OK VOICE LIST SENT",
+        )
+
+    def _cmd_debug(self, parts: Sequence[str]) -> None:
+        if (len(parts) >= 2) and (parts[1].upper() == "ON"):
+            path = parts[2] if len(parts) > 2 else None
+            if path:
+                try:
+                    handler = logging.FileHandler(path, encoding="utf-8")
+                    handler.setFormatter(
+                        logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+                    )
+                    logging.getLogger().addHandler(handler)
+                    logging.getLogger().setLevel(logging.DEBUG)
+                except OSError as error:
+                    _LOGGER.warning("Cannot open debug file %s: %s", path, error)
+                    self._writer.write_lines("303 CANT OPEN CUSTOM DEBUG FILE")
+                    return
+
+            self._writer.write_lines("200 OK DEBUGGING ON")
+        else:
+            logging.getLogger().setLevel(_log_level(self.config.log_level))
+            self._writer.write_lines("200 OK DEBUGGING OFF")
+
+    # -- speaking ---------------------------------------------------------
+
+    def _drain_queue(self) -> None:
+        """Throw away everything queued (used when shutting down)."""
+        while True:
+            try:
+                self._queue.get_nowait()
+            except Empty:
+                break
+
+    def _cancel_queued(self, pause: bool = False) -> None:
+        """Cancel queued messages, but leave them in the queue.
+
+        Every queued message has already been acknowledged with ``200 OK
+        SPEAKING``, so Speech Dispatcher waits for a begin/end pair for each of
+        them. The worker sends those pairs, in order, when it picks the
+        cancelled messages up again.
+        """
+        pending: List[Utterance] = []
+        quit_sentinel = False
+
+        while True:
+            try:
+                utterance = self._queue.get_nowait()
+            except Empty:
+                break
+
+            if utterance is None:
+                quit_sentinel = True
+                continue
+
+            utterance.cancel(pause=pause)
+            pending.append(utterance)
+
+        for utterance in pending:
+            self._queue.put(utterance)
+
+        if quit_sentinel:
+            self._queue.put(None)
+
+    def _interrupt(self, pause: bool = False, notify_server: bool = True) -> None:
+        """Stop playback and inference immediately."""
+        with self._current_lock:
+            current = self._current
+
+        if current is not None:
+            current.cancel(pause=pause)
+
+        # Kills the player process, aborts the HTTP streams and tells the
+        # server to abandon the inference in progress.
+        self._client.stop(notify_server=notify_server)
+
+    def _voice_sample_rate(self) -> int:
+        """Sample rate of the voice that is about to be spoken.
+
+        Voices do not share one sample rate (``fr_FR-tom-medium`` is 44.1 kHz,
+        ``en_US-kristin-medium`` 22.05 kHz): playing one at the rate of another
+        makes speech slow and low-pitched (or fast and high-pitched).
+        """
+        try:
+            return self._client.sample_rate(self._current_voice())
+        except (OSError, RuntimeError, ValueError, KeyError) as error:
+            _LOGGER.warning("Cannot get the sample rate of the voice: %s", error)
+            return self._sample_rate
+
+    def _make_sink(self, sample_rate: int) -> Any:
+        if self._server_audio:
+            return ServerAudioSink(self._writer, sample_rate)
+
+        return AudioSink(
+            PlayerConfig(
+                command=self.config.player, latency_ms=self.config.player_latency_ms
+            ),
+            sample_rate=sample_rate,
+        )
+
+    def _speak_loop(self) -> None:
+        while not self._quit.is_set():
+            utterance = self._queue.get()
+            if utterance is None:
+                return
+
+            if utterance.is_cancelled:
+                # Cancelled before synthesis even started. Speech Dispatcher
+                # has already been told "200 OK SPEAKING", so it waits for a
+                # begin/end pair no matter what: report an empty message.
+                self._begin(utterance)
+                self._writer.write_lines(
+                    "704 PAUSE" if utterance.paused else "703 STOP"
+                )
+                continue
+
+            try:
+                self._speak(utterance)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Synthesis failed")
+                # The server may have died or been restarted: check (and start
+                # it again if needed) before the next utterance.
+                self.server_lost()
+                # 702 END is only valid after 701 BEGIN; without it Speech
+                # Dispatcher keeps waiting for the message to start.
+                self._begin(utterance)
+                self._writer.write_lines("702 END")
+
+    def _begin(self, utterance: Utterance) -> None:
+        """Send ``701 BEGIN`` unless this message already started."""
+        if utterance.started:
+            return
+
+        utterance.started = True
+        self._writer.write_lines("701 BEGIN")
+
+    def _speak(self, utterance: Utterance) -> None:
+        # First utterance after a cold start: the server may still be loading
+        # its model (or not started at all). This also refreshes the sample
+        # rate, which the audio sink needs.
+        self.ensure_server(cancel=utterance.cancelled)
+        if utterance.is_cancelled:
+            self._begin(utterance)
+            self._writer.write_lines("704 PAUSE" if utterance.paused else "703 STOP")
+            return
+
+        marks = list(utterance.marks)
+        current_chunk: Optional[TextChunk] = None
+
+        # Clearing the client's stop flag is done here, in the worker, so a STOP
+        # that arrives for this utterance can never be lost.
+        self._client.reset()
+        config = self._client_config()
+        if utterance.chunking is not None:
+            config = replace(config, chunking=utterance.chunking)
+
+        self._client.config = config
+        # The sink is created after the voice is known: its sample rate must be
+        # the one of that voice.
+        sink = self._make_sink(self._voice_sample_rate())
+
+        for chunk, audio_bytes in self._client.iter_audio(
+            utterance.text, group=utterance.group
+        ):
+            if utterance.is_cancelled:
+                break
+
+            self._begin(utterance)
+
+            if (current_chunk is not None) and (chunk is not current_chunk):
+                # Everything up to the end of the previous chunk has been
+                # handed to the audio output: report the marks it passed.
+                marks = self._report_marks(marks, current_chunk.end)
+
+            current_chunk = chunk
+            sink.write(audio_bytes)
+
+        if utterance.is_cancelled:
+            sink.stop()
+            # Even if playback never started, the message was acknowledged and
+            # must be closed, or Speech Dispatcher blocks waiting for it.
+            self._begin(utterance)
+            self._writer.write_lines("704 PAUSE" if utterance.paused else "703 STOP")
+            return
+
+        sink.drain()
+        # Nothing was produced (e.g. punctuation only): still open the message
+        # so the server does not wait forever.
+        self._begin(utterance)
+
+        self._report_marks(marks, None)
+        self._writer.write_lines("702 END")
+
+    def _report_marks(
+        self, marks: List[Tuple[int, str]], up_to: Optional[int]
+    ) -> List[Tuple[int, str]]:
+        """Emit index marks up to a text offset (all of them if None)."""
+        while marks and ((up_to is None) or (marks[0][0] <= up_to)):
+            _, name = marks.pop(0)
+            self._writer.write_lines(f"700-{name}", "700 INDEX MARK")
+
+        return marks
+
+
+def _char_to_text(message: str) -> str:
+    if message == "space":
+        return " "
+
+    return message
+
+
+def _key_to_text(message: str) -> str:
+    if message == "space":
+        return "space"
+
+    return message.replace("_", " ")
+
+
+def _voice_language(name: str, voice_config: Optional[Dict[str, Any]] = None) -> str:
+    """Guess a language tag like ``en-US`` from a voice name/config."""
+    if voice_config:
+        language = voice_config.get("language")
+        if isinstance(language, dict):
+            code = language.get("code")
+            if code:
+                return str(code).replace("_", "-")
+
+        espeak = voice_config.get("espeak")
+        if isinstance(espeak, dict) and espeak.get("voice"):
+            return str(espeak["voice"])
+
+    # en_US-kristin-medium -> en-US
+    return name.split("-")[0].replace("_", "-")
+
+
+def _log_level(log_level: int) -> int:
+    if log_level >= 5:
+        return logging.DEBUG
+
+    if log_level >= 3:
+        return logging.INFO
+
+    if log_level >= 2:
+        return logging.WARNING
+
+    return logging.ERROR
+
+
+def print_service(config_path: Optional[str] = None) -> str:
+    """Render a systemd user unit for the server this module would start."""
+    config = ModuleConfig.load(config_path) if config_path else default_module_config()
+    command = server_command(config) or default_server_command(
+        replace(config, default_voice="en_US-kristin-medium")
+    )
+    assert command is not None
+
+    # systemd wants an absolute ExecStart and does not search the caller's PATH.
+    program = shutil.which(command[0])
+    if program:
+        command = [program, *command[1:]]
+    elif not os.path.isabs(command[0]):
+        _LOGGER.warning("%s is not in PATH: fix ExecStart by hand", command[0])
+
+    return SERVICE_UNIT.format(command=" ".join(shlex.quote(part) for part in command))
+
+
+def default_module_config() -> ModuleConfig:
+    """The configuration the module uses when installed as documented."""
+    return ModuleConfig.load(
+        os.path.join(
+            os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config"),
+            "speech-dispatcher",
+            "modules",
+            f"{MODULE_NAME}.conf",
+        )
+    )
+
+
+def main() -> int:
+    """Entry point used by Speech Dispatcher (``sd_piper <config file>``)."""
+    logging.basicConfig(
+        level=logging.INFO,
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    arguments = sys.argv[1:]
+    # Not part of the module protocol: convenience for installation.
+    # (Speech Dispatcher only ever passes a configuration file path.)
+    if arguments and (arguments[0] in ("--print-config", "-c")):
+        sys.stdout.write(EXAMPLE_CONFIG)
+        return 0
+
+    if arguments and (arguments[0] == "--print-service"):
+        sys.stdout.write(print_service(arguments[1] if len(arguments) > 1 else None))
+        return 0
+
+    config_path = arguments[0] if arguments else None
+    if config_path and (not os.path.isabs(config_path)):
+        config_path = os.path.abspath(config_path)
+
+    config = ModuleConfig.load(config_path)
+    _LOGGER.info("Starting %s module (url=%s)", MODULE_NAME, config.url)
+
+    module = PiperSpeechdModule(config)
+    try:
+        return module.run()
+    finally:
+        module.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/stub_server.py
+++ b/tests/stub_server.py
@@ -1,0 +1,249 @@
+"""Minimal stand-in for piper.http_server, used by client/module tests.
+
+Synthesis is replaced by silence whose length is proportional to the text, so
+tests stay fast and do not need a voice model.
+"""
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qs, urlsplit
+
+SAMPLE_RATE = 22050
+FR_SAMPLE_RATE = 44100
+"""Voices do not all share a sample rate: the French stub voice uses another
+one, like fr_FR-tom-medium does."""
+
+BYTES_PER_WORD = 2205 * 2  # 100 ms of 16-bit audio per word
+
+VOICES = {
+    "en_US-test-medium": {
+        "audio": {"sample_rate": SAMPLE_RATE},
+        "espeak": {"voice": "en-us"},
+        "language": {"code": "en_US"},
+    },
+    "fr_FR-test-medium": {
+        "audio": {"sample_rate": FR_SAMPLE_RATE},
+        "espeak": {"voice": "fr"},
+        "language": {"code": "fr_FR"},
+    },
+}
+
+
+def voice_sample_rate(voice: Optional[str]) -> int:
+    """Sample rate of a voice, as the real server reports it."""
+    config = VOICES.get(voice or "")
+    if not config:
+        return SAMPLE_RATE
+
+    return int(config["audio"]["sample_rate"])
+
+
+class StubServer:
+    """A stub Piper HTTP server that records the requests it receives."""
+
+    def __init__(self, chunk_delay: float = 0.0, port: int = 0) -> None:
+        self.requests: List[Dict[str, Any]] = []
+        self.stops: List[Dict[str, Any]] = []
+        self.chunk_delay = chunk_delay
+        """Seconds of "synthesis time" per audio chunk sent."""
+
+        self.lock = threading.Lock()
+        self.cancelled: Dict[str, bool] = {}
+        self.shutdown_requested = threading.Event()
+        stub = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args: Any) -> None:
+                pass
+
+            def _body(self) -> Dict[str, Any]:
+                length = int(self.headers.get("Content-Length") or 0)
+                data: Dict[str, Any] = {}
+                query = urlsplit(self.path).query
+                if query:
+                    data.update(
+                        {key: values[0] for key, values in parse_qs(query).items()}
+                    )
+
+                if length:
+                    raw = self.rfile.read(length)
+                    try:
+                        parsed = json.loads(raw)
+                        if isinstance(parsed, dict):
+                            data.update(parsed)
+                    except ValueError:
+                        data["text"] = raw.decode("utf-8")
+
+                return data
+
+            def _json(self, payload: Any) -> None:
+                encoded = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            def do_GET(self) -> None:  # noqa: N802
+                path = urlsplit(self.path).path
+                if path == "/info":
+                    self._json(
+                        {
+                            "voice": {
+                                "name": "en_US-test-medium",
+                                "language": "en-us",
+                                "num_speakers": 1,
+                                "sample_rate": SAMPLE_RATE,
+                                "sample_width": 2,
+                                "num_channels": 1,
+                            },
+                            "loaded_voices": sorted(VOICES),
+                            "streams": [],
+                            "last": None,
+                        }
+                    )
+                elif path == "/voices":
+                    self._json(VOICES)
+                else:
+                    self.send_error(404)
+
+            def do_POST(self) -> None:  # noqa: N802
+                path = urlsplit(self.path).path
+                data = self._body()
+
+                if path == "/shutdown":
+                    # Only used by the tests, to stop a stub started as a
+                    # standalone process (see main()).
+                    self._json({"stopping": True})
+                    stub.shutdown_requested.set()
+                    threading.Thread(target=stub.stop, daemon=True).start()
+                    return
+
+                if path == "/stop":
+                    with stub.lock:
+                        stub.stops.append(data)
+                        for key in list(stub.cancelled):
+                            stub.cancelled[key] = True
+
+                    self._json({"stopped": [], "num_stopped": 0})
+                    return
+
+                if path not in ("/stream", "/synthesize", "/"):
+                    self.send_error(404)
+                    return
+
+                text = str(data.get("text", ""))
+                with stub.lock:
+                    stub.requests.append(data)
+                    stream_id = str(data.get("stream_id", ""))
+                    stub.cancelled[stream_id] = False
+
+                num_bytes = max(1, len(text.split())) * BYTES_PER_WORD
+                sample_rate = voice_sample_rate(data.get("voice"))
+                self.send_response(200)
+                self.send_header("Content-Type", "audio/L16")
+                self.send_header("X-Piper-Sample-Rate", str(sample_rate))
+                self.send_header("X-Piper-Stream-Id", stream_id)
+                self.send_header("Transfer-Encoding", "chunked")
+                self.end_headers()
+
+                sent = 0
+                block = 4410 * 2
+                try:
+                    while sent < num_bytes:
+                        with stub.lock:
+                            if stub.cancelled.get(stream_id):
+                                break
+
+                        if stub.chunk_delay:
+                            time.sleep(stub.chunk_delay)
+
+                        size = min(block, num_bytes - sent)
+                        self.wfile.write(b"%x\r\n" % size)
+                        self.wfile.write(bytes(size))
+                        self.wfile.write(b"\r\n")
+                        self.wfile.flush()
+                        sent += size
+
+                    self.wfile.write(b"0\r\n\r\n")
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    @property
+    def url(self) -> str:
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def start(self) -> "StubServer":
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+    def texts(self) -> List[str]:
+        """Texts of the requests received, in arrival order."""
+        with self.lock:
+            return [str(request.get("text", "")) for request in self.requests]
+
+    def chunk_texts(self) -> List[str]:
+        """Texts of the requests received, in chunk order.
+
+        Chunks of one utterance are requested concurrently (the client
+        synthesizes ahead of playback), so arrival order is not chunk order.
+        The chunk index is the suffix of ``stream_id`` ("<group>-<index>").
+        """
+
+        def index(request: Dict[str, Any]) -> int:
+            suffix = str(request.get("stream_id", "")).rpartition("-")[2]
+            return int(suffix) if suffix.isdigit() else 0
+
+        with self.lock:
+            requests = sorted(self.requests, key=index)
+
+        return [str(request.get("text", "")) for request in requests]
+
+    def groups(self) -> List[Optional[str]]:
+        with self.lock:
+            return [request.get("group") for request in self.requests]
+
+    def __enter__(self) -> "StubServer":
+        return self.start()
+
+    def __exit__(self, *args: Any) -> None:
+        self.stop()
+
+
+def main() -> None:
+    """Run the stub as a standalone server (used to test autostart).
+
+    Unknown options (``--model``, ``--host``, ...) are ignored so that the stub
+    can stand in for ``python3 -m piper.http_server``.
+    """
+    import argparse  # pylint: disable=import-outside-toplevel
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=5000)
+    parser.add_argument("--startup-delay", type=float, default=0.0)
+    parser.add_argument("--lifetime", type=float, default=120.0)
+    args, _unknown = parser.parse_known_args()
+
+    time.sleep(args.startup_delay)
+    server = StubServer(port=args.port).start()
+    # Never outlive the test run, even if the test forgets to stop it.
+    server.shutdown_requested.wait(args.lifetime)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,126 @@
+"""Tests for text chunking."""
+
+import pytest
+
+from piper.chunking import (
+    PROFILES,
+    ChunkingConfig,
+    chunk_text,
+    iter_chunks,
+    normalize_text,
+)
+
+
+def test_disabled_chunking() -> None:
+    """Text is passed through unchanged (but normalized) when disabled."""
+    chunks = list(chunk_text("Hello\nworld.  Again.", PROFILES["off"]))
+    assert chunks == ["Hello world. Again."]
+
+
+def test_empty_text() -> None:
+    assert not list(chunk_text("   \n\t "))
+
+
+def test_normalize_text() -> None:
+    assert normalize_text(" a \n b\tc  ") == "a b c"
+
+
+def test_first_chunk_is_shorter() -> None:
+    """Time-to-first-audio is what matters: the first chunk is smaller."""
+    config = ChunkingConfig(max_words=5, first_max_words=2, min_words=1)
+    chunks = list(chunk_text("one two three four five six seven eight", config))
+    assert chunks[0] == "one two"
+    assert all(len(chunk.split()) <= 5 for chunk in chunks)
+
+
+def test_break_on_sentence() -> None:
+    """A sentence boundary always ends a chunk."""
+    chunks = list(chunk_text("Alpha beta. Gamma delta epsilon zeta.", ChunkingConfig()))
+    assert chunks[0] == "Alpha beta."
+
+
+def test_break_on_clause() -> None:
+    config = ChunkingConfig(max_words=10, first_max_words=0, min_words=2)
+    chunks = list(chunk_text("Hello there, my dear friend, how are you?", config))
+    assert chunks[0] == "Hello there,"
+    assert chunks[1] == "my dear friend,"
+
+
+def test_clause_break_respects_min_words() -> None:
+    config = ChunkingConfig(max_words=10, first_max_words=0, min_words=3)
+    chunks = list(chunk_text("Yes, indeed my friend, this is fine.", config))
+    assert chunks[0] == "Yes, indeed my friend,"
+
+
+def test_abbreviations_are_not_sentence_ends() -> None:
+    config = ChunkingConfig(max_words=10, first_max_words=0, min_words=1)
+    chunks = list(chunk_text("Mr. Smith and Dr. Jones arrived.", config))
+    assert chunks == ["Mr. Smith and Dr. Jones arrived."]
+
+
+def test_initials_are_not_sentence_ends() -> None:
+    config = ChunkingConfig(max_words=10, first_max_words=0, min_words=1)
+    chunks = list(chunk_text("Written by J. R. Tolkien here.", config))
+    assert chunks == ["Written by J. R. Tolkien here."]
+
+
+def test_short_tail_is_merged() -> None:
+    """A dangling one-word chunk is merged into the previous one."""
+    config = ChunkingConfig(max_words=3, first_max_words=3, min_words=2)
+    chunks = list(chunk_text("one two three four", config))
+    assert chunks == ["one two three four"]
+
+    config.merge_short_tail = False
+    assert list(chunk_text("one two three four", config)) == ["one two three", "four"]
+
+
+def test_max_chars_splits_long_words() -> None:
+    """Inference time must stay bounded even without whitespace."""
+    text = "x" * 100
+    chunks = list(chunk_text(text, ChunkingConfig(max_chars=30)))
+    assert all(len(chunk) <= 30 for chunk in chunks)
+    assert "".join(chunks) == text
+
+
+def test_chunk_offsets() -> None:
+    """Offsets allow the caller to map audio back to the source text."""
+    text = "Alpha beta. Gamma delta."
+    chunks = list(iter_chunks(text, ChunkingConfig()))
+    for chunk in chunks:
+        assert text[chunk.start : chunk.end] == chunk.text
+
+    assert chunks[-1].is_last
+    assert not chunks[0].is_last
+    assert [chunk.index for chunk in chunks] == list(range(len(chunks)))
+
+
+def test_profiles_are_ordered_by_latency() -> None:
+    assert PROFILES["instant"].first_limit <= PROFILES["responsive"].first_limit
+    assert PROFILES["responsive"].first_limit <= PROFILES["balanced"].first_limit
+    assert not PROFILES["off"].enabled
+    assert not PROFILES["smooth"].break_on_clause
+
+
+def test_from_mapping_with_prefix_and_profile() -> None:
+    config = ChunkingConfig.from_mapping(
+        {
+            "PIPER_CHUNK_PROFILE": "instant",
+            "PIPER_CHUNK_MAX_WORDS": "7",
+            "PIPER_CHUNK_MERGE_SHORT_TAIL": "false",
+            "UNRELATED": "x",
+        },
+        prefix="piper_chunk_",
+    )
+    assert config.max_words == 7
+    assert config.first_max_words == PROFILES["instant"].first_max_words
+    assert config.merge_short_tail is False
+
+
+def test_from_mapping_rejects_unknown_profile() -> None:
+    with pytest.raises(ValueError):
+        ChunkingConfig.from_mapping({"profile": "nope"})
+
+
+def test_from_mapping_abbreviations_from_string() -> None:
+    config = ChunkingConfig.from_mapping({"abbreviations": "abc,Def"})
+    assert config.abbreviations == {"abc", "def"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,316 @@
+"""Tests for the streaming HTTP client."""
+
+import threading
+import time
+from typing import Iterator, List
+
+import pytest
+
+from piper.chunking import PROFILES, ChunkingConfig
+from piper.client import (
+    ClientConfig,
+    PiperClient,
+    PlayerConfig,
+    rate_to_length_scale,
+    sd_volume_to_multiplier,
+    wav_header,
+)
+
+from .stub_server import BYTES_PER_WORD, FR_SAMPLE_RATE, SAMPLE_RATE, StubServer
+
+
+@pytest.fixture(name="server")
+def server_fixture() -> Iterator[StubServer]:
+    with StubServer() as server:
+        yield server
+
+
+def make_client(server: StubServer, **kwargs) -> PiperClient:
+    config = ClientConfig(url=server.url, **kwargs)
+    return PiperClient(config)
+
+
+# -----------------------------------------------------------------------------
+# Parameter mapping
+# -----------------------------------------------------------------------------
+
+
+def test_rate_to_length_scale() -> None:
+    assert rate_to_length_scale(0) == pytest.approx(1.0)
+    assert rate_to_length_scale(100, rate_factor=3.0) == pytest.approx(1 / 3)
+    assert rate_to_length_scale(-100, rate_factor=3.0) == pytest.approx(3.0)
+    # Out of range values are clamped, never rejected
+    assert rate_to_length_scale(1000, rate_factor=2.0) == pytest.approx(0.5)
+
+
+def test_rate_scales_a_custom_base() -> None:
+    assert rate_to_length_scale(0, base_length_scale=0.8) == pytest.approx(0.8)
+
+
+def test_sd_volume_to_multiplier() -> None:
+    # speech-dispatcher's nominal volume is 100
+    assert sd_volume_to_multiplier(100) == pytest.approx(1.0)
+    assert sd_volume_to_multiplier(0) == pytest.approx(0.5)
+    assert sd_volume_to_multiplier(-100) == pytest.approx(0.25)
+
+
+# -----------------------------------------------------------------------------
+# Server info
+# -----------------------------------------------------------------------------
+
+
+def test_info_and_sample_rate(server: StubServer) -> None:
+    client = make_client(server)
+    assert client.info()["voice"]["name"] == "en_US-test-medium"
+    assert client.sample_rate() == SAMPLE_RATE
+
+
+def test_voices(server: StubServer) -> None:
+    client = make_client(server)
+    assert "fr_FR-test-medium" in client.voices()
+
+
+def test_sample_rate_follows_the_voice(server: StubServer) -> None:
+    """Not every voice is 22.05 kHz: the wrong rate slows speech down."""
+    client = make_client(server, voice="fr_FR-test-medium")
+    assert client.sample_rate() == FR_SAMPLE_RATE
+    assert client.sample_rate("en_US-test-medium") == SAMPLE_RATE
+
+    # Unknown voices fall back to the server's default
+    assert client.sample_rate("xx_XX-unknown-medium") == SAMPLE_RATE
+
+
+def test_url_without_scheme(server: StubServer) -> None:
+    client = PiperClient(ClientConfig(url=server.url.replace("http://", "")))
+    assert client.sample_rate() == SAMPLE_RATE
+
+
+# -----------------------------------------------------------------------------
+# Chunking and streaming
+# -----------------------------------------------------------------------------
+
+
+def test_client_chunks_text_into_several_requests(server: StubServer) -> None:
+    client = make_client(
+        server, chunking=ChunkingConfig(max_words=3, first_max_words=2, min_words=1)
+    )
+    audio = b"".join(client.stream("one two three four five six seven eight nine"))
+
+    assert server.chunk_texts() == [
+        "one two",
+        "three four five",
+        "six seven eight",
+        "nine",
+    ]
+    assert len(audio) == 9 * BYTES_PER_WORD
+
+
+def test_chunks_of_one_utterance_share_a_group(server: StubServer) -> None:
+    """Otherwise the server would preempt the chunks of the same utterance."""
+    client = make_client(server, chunking=ChunkingConfig(max_words=2, min_words=1))
+    list(client.stream("one two three four"))
+
+    groups = server.groups()
+    assert len(groups) > 1
+    assert len(set(groups)) == 1
+    assert all(request["preempt"] for request in server.requests)
+
+
+def test_different_utterances_use_different_groups(server: StubServer) -> None:
+    client = make_client(server)
+    list(client.stream("first utterance."))
+    list(client.stream("second utterance."))
+    assert len(set(server.groups())) == 2
+
+
+def test_server_chunk_mode_sends_one_request(server: StubServer) -> None:
+    client = make_client(server, chunk_mode="server")
+    text = "one two three four five six seven eight"
+    list(client.stream(text))
+
+    assert server.texts() == [text]
+    assert server.requests[0]["chunk"]["enabled"] is True
+
+
+def test_client_chunk_mode_disables_server_chunking(server: StubServer) -> None:
+    client = make_client(server)
+    list(client.stream("one two three four five six"))
+    assert all(request["chunk"] == {"enabled": False} for request in server.requests)
+
+
+def test_iter_audio_reports_the_chunk_of_each_piece(server: StubServer) -> None:
+    """Audio must be attributable to a piece of text (for index marks)."""
+    client = make_client(
+        server, chunking=ChunkingConfig(max_words=2, first_max_words=2, min_words=1)
+    )
+    text = "alpha beta gamma delta"
+    pieces = list(client.iter_audio(text))
+
+    assert pieces
+    for chunk, audio_bytes in pieces:
+        assert audio_bytes
+        assert text[chunk.start : chunk.end] == chunk.text
+
+    assert [chunk.text for chunk, _ in pieces][0] == "alpha beta"
+    assert pieces[-1][0].is_last
+
+
+def test_synthesis_parameters_are_sent(server: StubServer) -> None:
+    client = make_client(
+        server,
+        voice="fr_FR-test-medium",
+        length_scale=0.75,
+        volume=0.5,
+        sentence_silence=0.1,
+        chunking=PROFILES["off"],
+    )
+    list(client.stream("bonjour."))
+
+    request = server.requests[0]
+    assert request["voice"] == "fr_FR-test-medium"
+    assert request["length_scale"] == 0.75
+    assert request["volume"] == 0.5
+    assert request["sentence_silence"] == 0.1
+
+
+def test_chunk_silence_is_inserted_between_chunks(server: StubServer) -> None:
+    """Silence between chunks hides boundary artifacts."""
+    config = ChunkingConfig(max_words=2, first_max_words=2, min_words=1)
+    client = make_client(server, chunking=config, chunk_silence=0.1)
+    audio = b"".join(client.stream("one two three four"))
+
+    silence_bytes = int(SAMPLE_RATE * 0.1) * 2
+    assert len(audio) == (4 * BYTES_PER_WORD) + silence_bytes
+
+
+def test_wav_header_is_written_for_an_unknown_length(server: StubServer) -> None:
+    """--output wav writes a header players accept before the length is known."""
+    header = wav_header(FR_SAMPLE_RATE)
+
+    assert len(header) == 44
+    assert header[:4] == b"RIFF"
+    assert header[8:12] == b"WAVE"
+    assert int.from_bytes(header[24:28], "little") == FR_SAMPLE_RATE
+    # Length fields are "big enough", not zero: players stop at end of stream
+    data_size = int.from_bytes(header[40:44], "little")
+    assert data_size > 0
+    assert int.from_bytes(header[4:8], "little") == data_size + 36
+
+
+def test_empty_text_sends_nothing(server: StubServer) -> None:
+    client = make_client(server)
+    assert not list(client.stream("   "))
+    assert not server.requests
+
+
+def test_prefetch_keeps_the_engine_busy() -> None:
+    """With prefetch, the next chunk is requested before the current one ends."""
+    with StubServer(chunk_delay=0.05) as server:
+        client = make_client(
+            server,
+            chunking=ChunkingConfig(max_words=2, first_max_words=2, min_words=1),
+            prefetch=2,
+        )
+        stream = client.iter_audio("one two three four five six")
+        next(stream)  # first piece of audio of the first chunk
+        time.sleep(0.2)
+
+        # More than one chunk has been requested while we were "playing"
+        assert len(server.requests) > 1
+        stream.close()
+
+
+# -----------------------------------------------------------------------------
+# Interruption
+# -----------------------------------------------------------------------------
+
+
+def test_stop_ends_iteration_and_notifies_the_server() -> None:
+    with StubServer(chunk_delay=0.02) as server:
+        client = make_client(server, chunking=PROFILES["off"])
+        received: List[bytes] = []
+
+        def consume() -> None:
+            for audio_bytes in client.stream(" ".join(["word"] * 200)):
+                received.append(audio_bytes)
+
+        thread = threading.Thread(target=consume)
+        thread.start()
+        time.sleep(0.2)
+
+        client.stop()
+        thread.join(timeout=10)
+
+        assert not thread.is_alive()
+        assert client.stopped
+        assert server.stops, "server was not told to stop"
+        # Far less than the 200 words of audio
+        assert sum(len(data) for data in received) < 200 * BYTES_PER_WORD
+
+
+def test_stop_before_speaking_is_cleared_by_reset(server: StubServer) -> None:
+    client = make_client(server)
+    client.stop(notify_server=False)
+    assert client.stopped
+
+    client.reset()
+    assert not client.stopped
+    assert list(client.stream("hello."))
+
+
+def test_speak_writes_to_a_sink(server: StubServer) -> None:
+    class Sink:
+        def __init__(self) -> None:
+            self.data = bytearray()
+            self.drained = False
+            self.stopped = False
+
+        def write(self, audio_bytes: bytes) -> None:
+            self.data.extend(audio_bytes)
+
+        def drain(self, timeout=None) -> None:
+            self.drained = True
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    client = make_client(server)
+    sink = Sink()
+    assert client.speak("one two three.", sink) is True
+    assert len(sink.data) == 3 * BYTES_PER_WORD
+    assert sink.drained
+    assert not sink.stopped
+
+
+# -----------------------------------------------------------------------------
+# Player configuration
+# -----------------------------------------------------------------------------
+
+
+def test_player_template_substitution() -> None:
+    config = PlayerConfig(
+        command="myplayer --rate={rate} --channels={channels} --lat={latency_ms}",
+        latency_ms=25,
+    )
+    assert config.resolve(16000, 1) == [
+        "myplayer",
+        "--rate=16000",
+        "--channels=1",
+        "--lat=25",
+    ]
+
+
+def test_player_auto_detection_uses_a_known_player() -> None:
+    config = PlayerConfig()
+    if not PlayerConfig.is_available():
+        pytest.skip("no audio player installed")
+
+    command = config.resolve(SAMPLE_RATE)
+    assert command[0] in [executable for executable, _ in config.templates]
+    assert str(SAMPLE_RATE) in " ".join(command)
+
+
+def test_player_auto_detection_without_player() -> None:
+    config = PlayerConfig(templates=(("definitely-not-a-player", "nope -"),))
+    with pytest.raises(RuntimeError):
+        config.resolve(SAMPLE_RATE)

--- a/tests/test_speechd_module.py
+++ b/tests/test_speechd_module.py
@@ -1,0 +1,1059 @@
+"""Tests for the Speech Dispatcher output module.
+
+The module protocol is exercised the way Speech Dispatcher does it: commands on
+stdin, replies and events on stdout, LF-terminated.
+"""
+
+import http.client
+import os
+import re
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Iterator, List, Tuple
+
+import pytest
+
+from piper.chunking import ChunkingConfig
+from piper.speechd_module import (
+    EXAMPLE_CONFIG,
+    ModuleConfig,
+    PiperSpeechdModule,
+    StartLock,
+    VoiceEntry,
+    default_server_command,
+    escape_audio,
+    is_local_url,
+    parse_ssml,
+    print_service,
+    server_command,
+    split_url,
+)
+
+from .stub_server import FR_SAMPLE_RATE, SAMPLE_RATE, StubServer
+
+# A player that consumes audio at (roughly) real time, so that interruption is
+# observable in tests.
+SLOW_PLAYER = (
+    "python3 -c "
+    "'import sys,time\n"
+    "while sys.stdin.buffer.read(4410):\n"
+    "    time.sleep(0.05)'"
+)
+NULL_PLAYER = "python3 -c 'import sys;sys.stdin.buffer.read()'"
+
+
+# -----------------------------------------------------------------------------
+# SSML and audio encoding
+# -----------------------------------------------------------------------------
+
+
+def test_parse_ssml_plain_text() -> None:
+    text, marks = parse_ssml("<speak>Hello world.</speak>")
+    assert text == "Hello world."
+    assert not marks
+
+
+def test_parse_ssml_index_marks() -> None:
+    text, marks = parse_ssml(
+        '<speak>One. <mark name="__spd_0"/>Two. <mark name="__spd_1"/>Three.</speak>'
+    )
+    assert text == "One. Two. Three."
+    assert marks == [(5, "__spd_0"), (10, "__spd_1")]
+    for offset, _name in marks:
+        assert 0 <= offset <= len(text)
+
+
+def test_parse_ssml_unescapes_entities() -> None:
+    text, _marks = parse_ssml("<speak>a &lt; b &amp; c &gt; d</speak>")
+    assert text == "a < b & c > d"
+
+
+def test_parse_ssml_ignores_unknown_tags() -> None:
+    text, _marks = parse_ssml(
+        '<speak><prosody rate="fast">Fast</prosody> and slow</speak>'
+    )
+    assert text == "Fast and slow"
+
+
+def test_escape_audio_roundtrip() -> None:
+    """Audio handed back to Speech Dispatcher is HDLC-escaped."""
+    raw = bytes(range(256))
+    escaped = escape_audio(raw)
+    assert b"\n" not in escaped
+
+    unescaped = bytearray()
+    pending = False
+    for byte in escaped:
+        if pending:
+            unescaped.append(byte ^ 0x20)
+            pending = False
+        elif byte == 0x7D:
+            pending = True
+        else:
+            unescaped.append(byte)
+
+    assert bytes(unescaped) == raw
+
+
+def test_escape_audio_leaves_clean_audio_untouched() -> None:
+    raw = bytes([0x01, 0x02, 0x03])
+    assert escape_audio(raw) is raw
+
+
+# -----------------------------------------------------------------------------
+# Configuration file
+# -----------------------------------------------------------------------------
+
+
+def test_module_config_parsing(tmp_path: Path) -> None:
+    config_path = tmp_path / "piper.conf"
+    config_path.write_text(
+        """
+# Comment
+PiperURL "http://localhost:5123"
+PiperAudio server
+PiperPlayer "aplay -q -"
+PiperChunkProfile instant
+PiperChunkMaxWords 4
+PiperChunkMinWords 2
+PiperChunkMaxChars 200
+PiperRateFactor 2.5
+PiperPrefetch 3
+AddVoice "en-US" "FEMALE1" "en_US-test-medium"
+AddVoice "fr-FR" "MALE1"   "fr_FR-test-medium"
+DefaultVoice "en_US-test-medium"
+""",
+        encoding="utf-8",
+    )
+
+    config = ModuleConfig.load(str(config_path))
+    assert config.url == "http://localhost:5123"
+    assert config.audio_output == "server"
+    assert config.player == "aplay -q -"
+    assert config.chunking.max_words == 4
+    assert config.chunking.min_words == 2
+    assert config.chunking.max_chars == 200
+    assert config.chunking.first_max_words == 2  # from the "instant" profile
+    assert config.rate_factor == 2.5
+    assert config.prefetch == 3
+    assert config.default_voice == "en_US-test-medium"
+    assert [voice.name for voice in config.voices] == [
+        "en_US-test-medium",
+        "fr_FR-test-medium",
+    ]
+
+
+def test_example_config_matches_the_repository_copy() -> None:
+    """`sd_piper --print-config` must stay in sync with etc/."""
+    repo_config = (
+        Path(__file__).parent.parent
+        / "etc"
+        / "speech-dispatcher"
+        / "modules"
+        / "piper.conf"
+    )
+    if not repo_config.exists():
+        pytest.skip("not running from a source checkout")
+
+    assert EXAMPLE_CONFIG == repo_config.read_text(encoding="utf-8")
+
+
+def test_example_config_is_valid(tmp_path: Path) -> None:
+    """The shipped example must parse and describe a usable setup."""
+    config_path = tmp_path / "piper.conf"
+    config_path.write_text(EXAMPLE_CONFIG, encoding="utf-8")
+
+    config = ModuleConfig.load(str(config_path))
+    assert config.url.startswith("http")
+    assert config.audio_output in ("player", "server")
+    assert config.chunking.enabled
+    assert config.voices
+    assert config.default_voice
+
+
+def test_module_config_missing_file_uses_defaults() -> None:
+    config = ModuleConfig.load("/nonexistent/piper.conf")
+    assert config.url
+    assert config.audio_output == "player"
+
+
+# -----------------------------------------------------------------------------
+# Starting the server
+# -----------------------------------------------------------------------------
+
+
+def test_autostart_options(tmp_path: Path) -> None:
+    config_path = tmp_path / "piper.conf"
+    config_path.write_text(
+        """
+PiperAutostart no
+PiperServerManager process
+PiperServerService none
+PiperServerCommand "python3 -m piper.http_server -m voice.onnx"
+PiperServerTimeout 5
+""",
+        encoding="utf-8",
+    )
+
+    config = ModuleConfig.load(str(config_path))
+    assert config.autostart == "no"
+    assert config.server_manager == "process"
+    assert config.server_service == "none"
+    assert config.server_timeout == 5.0
+    assert server_command(config) == [
+        "python3",
+        "-m",
+        "piper.http_server",
+        "-m",
+        "voice.onnx",
+    ]
+
+
+def test_server_command_expands_the_home_directory(tmp_path: Path) -> None:
+    """Configuration files are not read by a shell, so "~" must be expanded."""
+    config_path = tmp_path / "piper.conf"
+    config_path.write_text(
+        'PiperServerCommand "python3 -m piper.http_server'
+        ' -m ~/.piper-voices/en_US-kristin-medium.onnx --data-dir=~/.piper-voices"\n',
+        encoding="utf-8",
+    )
+
+    command = server_command(ModuleConfig.load(str(config_path)))
+    assert command is not None
+    home = os.path.expanduser("~")
+    assert command[-2:] == [
+        f"{home}/.piper-voices/en_US-kristin-medium.onnx",
+        f"--data-dir={home}/.piper-voices",
+    ]
+    assert "~" not in " ".join(command)
+
+
+@pytest.mark.parametrize(
+    "value,expected", [("1", "yes"), ("0", "no"), ("on", "yes"), ("auto", "auto")]
+)
+def test_autostart_accepts_boolean_values(
+    tmp_path: Path, value: str, expected: str
+) -> None:
+    """`PiperAutostart 1` from older configurations must keep working."""
+    config_path = tmp_path / "piper.conf"
+    config_path.write_text(f"PiperAutostart {value}\n", encoding="utf-8")
+    assert ModuleConfig.load(str(config_path)).autostart == expected
+
+
+def test_default_autostart_is_enabled_for_a_local_server() -> None:
+    config = ModuleConfig()
+    assert config.autostart == "auto"
+    assert is_local_url(config.url)
+
+
+@pytest.mark.parametrize(
+    "url,local",
+    [
+        ("http://localhost:5000", True),
+        ("http://127.0.0.1:5000", True),
+        ("http://[::1]:5000", True),
+        ("http://piper.invalid:5000", False),
+        ("http://192.168.1.10:5000", False),
+    ],
+)
+def test_is_local_url(url: str, local: bool) -> None:
+    assert is_local_url(url) is local
+
+
+def test_default_server_command_uses_the_configured_voice() -> None:
+    config = ModuleConfig(
+        url="http://localhost:5123", default_voice="en_US-kristin-medium"
+    )
+    command = default_server_command(config)
+    assert command is not None
+    assert command[1:] == [
+        "-m",
+        "piper.http_server",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "5123",
+        "--model",
+        "en_US-kristin-medium",
+    ]
+
+    # Without DefaultVoice, the first AddVoice entry is used
+    config = ModuleConfig(voices=[VoiceEntry("en-US", "FEMALE1", "en_US-test-medium")])
+    assert default_server_command(config)[-1] == "en_US-test-medium"  # type: ignore[index]
+
+    # Nothing to start without a voice
+    assert default_server_command(ModuleConfig()) is None
+
+
+def test_print_service_renders_a_runnable_unit(tmp_path: Path) -> None:
+    config_path = tmp_path / "piper.conf"
+    config_path.write_text(EXAMPLE_CONFIG, encoding="utf-8")
+
+    unit = print_service(str(config_path))
+    assert "[Service]" in unit
+    assert "WantedBy=default.target" in unit
+
+    exec_start = [
+        line[len("ExecStart=") :]
+        for line in unit.splitlines()
+        if line.startswith("ExecStart=")
+    ]
+    assert len(exec_start) == 1
+    assert "piper.http_server" in exec_start[0]
+    assert "en_US-kristin-medium" in exec_start[0]
+    # systemd neither expands "~" nor searches PATH
+    assert os.path.isabs(exec_start[0].split()[0])
+    assert "~" not in exec_start[0]
+
+    # A server that cannot start must back off instead of looping
+    settings = dict(
+        line.split("=", 1)
+        for line in unit.splitlines()
+        if ("=" in line) and (not line.startswith("#"))
+    )
+    assert settings["Restart"] == "on-failure"
+    assert int(settings["RestartSec"]) >= 2
+    assert int(settings["RestartMaxDelaySec"]) > int(settings["RestartSec"])
+    assert int(settings["RestartSteps"]) > 1
+    assert int(settings["StartLimitBurst"]) >= 3
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _stub_server_command(port: int, startup_delay: float = 0.0) -> str:
+    stub = Path(__file__).parent / "stub_server.py"
+    return (
+        f"{sys.executable} {stub} --port {port} --startup-delay {startup_delay}"
+        " --lifetime 60 --model ignored"
+    )
+
+
+@pytest.fixture(name="autostart_config")
+def autostart_config_fixture() -> Iterator[ModuleConfig]:
+    """A module configuration that starts a stub server on a free port."""
+    port = _free_port()
+    config = ModuleConfig(
+        url=f"http://127.0.0.1:{port}",
+        player=NULL_PLAYER,
+        voices=[VoiceEntry("en-US", "FEMALE1", "en_US-test-medium")],
+        chunking=ChunkingConfig(max_words=3, first_max_words=2, min_words=1),
+        # systemd is not available (or wanted) in a test environment
+        server_manager="process",
+        server_service="none",
+        server_command=_stub_server_command(port),
+        server_timeout=20.0,
+    )
+    try:
+        yield config
+    finally:
+        _kill_server(config)
+
+
+def _kill_server(config: ModuleConfig) -> None:
+    """Stop a stub server started by the module (it also exits on its own)."""
+    host, port = split_url(config.url)
+    try:
+        connection = http.client.HTTPConnection(host, port, timeout=2.0)
+        connection.request("POST", "/shutdown")
+        connection.getresponse().read()
+        connection.close()
+    except OSError:
+        pass
+
+
+def test_autostart_starts_the_server_on_demand(autostart_config: ModuleConfig) -> None:
+    """The first utterance must start the server and be spoken."""
+    harness = ModuleHarness(autostart_config).start()
+    try:
+        harness.init()
+        harness.clear()
+        harness.speak("<speak>The server was not running.</speak>")
+        harness.wait_for("702 END", timeout=30)
+        assert _check_event_pairing(harness.replies()) == 1
+    finally:
+        harness.close()
+
+
+def test_init_does_not_wait_for_the_server(autostart_config: ModuleConfig) -> None:
+    """Speech Dispatcher blocks while a module loads: INIT must be fast."""
+    autostart_config.server_command = _stub_server_command(
+        split_url(autostart_config.url)[1], startup_delay=3.0
+    )
+
+    harness = ModuleHarness(autostart_config).start()
+    try:
+        start = time.monotonic()
+        harness.send("INIT")
+        harness.wait_for("299 OK LOADED SUCCESSFULLY", timeout=10)
+        assert (time.monotonic() - start) < 2.0
+
+        # The utterance itself waits for the server that is still starting
+        harness.send("AUDIO", "audio_output_method=alsa", ".")
+        harness.wait_for("203 OK AUDIO INITIALIZED")
+        harness.clear()
+        harness.speak("<speak>Spoken once the server is up.</speak>")
+        harness.wait_for("702 END", timeout=30)
+    finally:
+        harness.close()
+
+
+def test_stop_while_the_server_is_starting(autostart_config: ModuleConfig) -> None:
+    """STOP must interrupt an utterance that is waiting for the server."""
+    autostart_config.server_command = _stub_server_command(
+        split_url(autostart_config.url)[1], startup_delay=10.0
+    )
+
+    harness = ModuleHarness(autostart_config).start()
+    try:
+        harness.init()
+        harness.clear()
+        harness.speak("<speak>Nobody is listening yet.</speak>")
+        harness.wait_for("200 OK SPEAKING")
+
+        start = time.monotonic()
+        harness.send("STOP")
+        harness.wait_for("703 STOP", timeout=5)
+        assert (time.monotonic() - start) < 2.0
+        assert _check_event_pairing(harness.replies()) == 1
+    finally:
+        harness.close()
+
+
+def test_autostart_disabled_starts_nothing(autostart_config: ModuleConfig) -> None:
+    autostart_config.autostart = "no"
+    module = PiperSpeechdModule(autostart_config)
+    try:
+        assert module.ensure_server() is False
+    finally:
+        module.close()
+
+    _, port = split_url(autostart_config.url)
+    with socket.socket() as sock:
+        assert sock.connect_ex(("127.0.0.1", port)) != 0, "a server was started"
+
+
+def test_remote_servers_are_never_started() -> None:
+    config = ModuleConfig(url="http://piper.invalid:5000", autostart="yes")
+    module = PiperSpeechdModule(config)
+    try:
+        assert module.ensure_server() is False
+    finally:
+        module.close()
+
+
+def test_only_one_server_is_started_when_the_lock_is_taken(
+    autostart_config: ModuleConfig,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second module must wait for the first one instead of starting a server."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    _, port = split_url(autostart_config.url)
+    autostart_config.server_timeout = 2.0
+
+    module = PiperSpeechdModule(autostart_config)
+    holder = StartLock(port)
+    with holder as owned:
+        assert owned
+        try:
+            # The lock is held (as if another module were starting the server),
+            # so this one only waits, and times out because nothing comes up.
+            assert module.ensure_server() is False
+        finally:
+            module.close()
+
+    with socket.socket() as sock:
+        assert sock.connect_ex(("127.0.0.1", port)) != 0, "a second server was started"
+
+
+def test_a_running_server_is_reused(server: StubServer) -> None:
+    """No process is started when the configured server already answers."""
+    config = make_config(
+        server,
+        server_manager="process",
+        server_service="none",
+        server_command="false",  # would fail if it were ever run
+    )
+    module = PiperSpeechdModule(config)
+    try:
+        assert module.ensure_server() is True
+        assert module.ensure_server() is True
+    finally:
+        module.close()
+
+
+# -----------------------------------------------------------------------------
+# Protocol
+# -----------------------------------------------------------------------------
+
+
+class ModuleHarness:
+    """Runs the module in a thread and speaks its protocol over pipes."""
+
+    def __init__(self, config: ModuleConfig) -> None:
+        stdin_read, self._stdin_write = os.pipe()
+        self._stdout_read, stdout_write = os.pipe()
+
+        self._stdin = os.fdopen(self._stdin_write, "wb", buffering=0)
+        self._stdout = os.fdopen(self._stdout_read, "rb", buffering=0)
+
+        self.module = PiperSpeechdModule(
+            config,
+            stdin=os.fdopen(stdin_read, "rb", buffering=0),
+            stdout=os.fdopen(stdout_write, "wb", buffering=0),
+        )
+        self.output = bytearray()
+        self.lines: List[str] = []
+        self._lock = threading.Lock()
+
+        self._thread = threading.Thread(target=self.module.run, daemon=True)
+        self._reader = threading.Thread(target=self._read, daemon=True)
+
+    def start(self) -> "ModuleHarness":
+        self._thread.start()
+        self._reader.start()
+        return self
+
+    def _read(self) -> None:
+        while True:
+            data = self._stdout.read(1)
+            if not data:
+                return
+
+            with self._lock:
+                self.output.extend(data)
+                if data == b"\n":
+                    line = bytes(self.output).split(b"\n")[-2]
+                    self.lines.append(line.decode("utf-8", errors="replace"))
+
+    def send(self, *lines: str) -> None:
+        self._stdin.write("".join(f"{line}\n" for line in lines).encode("utf-8"))
+
+    def wait_for(self, pattern: str, timeout: float = 10.0) -> str:
+        """Wait for a line matching a regular expression."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                for line in self.lines:
+                    if re.fullmatch(pattern, line):
+                        return line
+
+            time.sleep(0.01)
+
+        raise AssertionError(f"Timed out waiting for {pattern!r}, got {self.lines}")
+
+    def replies(self) -> List[str]:
+        with self._lock:
+            return list(self.lines)
+
+    def clear(self) -> None:
+        with self._lock:
+            self.lines.clear()
+
+    def init(self, audio: str = "alsa") -> None:
+        self.send("INIT")
+        self.wait_for("299 OK LOADED SUCCESSFULLY")
+        self.send("AUDIO", f"audio_output_method={audio}", ".")
+        self.wait_for("203 OK AUDIO INITIALIZED")
+
+    def speak(self, ssml: str) -> None:
+        self.send("SPEAK", ssml, ".")
+
+    def close(self) -> None:
+        try:
+            self.send("QUIT")
+            self.wait_for("210 OK QUIT", timeout=5)
+        except (AssertionError, OSError):
+            pass
+
+        self.module.close()
+
+
+@pytest.fixture(name="server")
+def server_fixture() -> Iterator[StubServer]:
+    with StubServer() as server:
+        yield server
+
+
+def make_config(server: StubServer, **kwargs: Any) -> ModuleConfig:
+    config = ModuleConfig(
+        url=server.url,
+        player=NULL_PLAYER,
+        voices=[VoiceEntry("en-US", "FEMALE1", "en_US-test-medium")],
+        chunking=ChunkingConfig(max_words=3, first_max_words=2, min_words=1),
+    )
+    for name, value in kwargs.items():
+        setattr(config, name, value)
+
+    return config
+
+
+@pytest.fixture(name="module")
+def module_fixture(server: StubServer) -> Iterator[ModuleHarness]:
+    harness = ModuleHarness(make_config(server)).start()
+    try:
+        yield harness
+    finally:
+        harness.close()
+
+
+def test_init_handshake(module: ModuleHarness) -> None:
+    module.send("INIT")
+    module.wait_for("299 OK LOADED SUCCESSFULLY")
+    replies = module.replies()
+    # Multi-line replies use "-" as the fourth character
+    assert replies[0].startswith("299-")
+    assert len(replies[0]) > 4
+
+
+def test_unknown_command(module: ModuleHarness) -> None:
+    module.init()
+    module.send("NONSENSE")
+    module.wait_for("300 ERR UNKNOWN COMMAND")
+
+
+def test_audio_negotiation_refuses_server_audio_by_default(
+    module: ModuleHarness,
+) -> None:
+    """In player mode the module plays audio itself, so it must refuse."""
+    module.send("INIT")
+    module.wait_for("299 OK LOADED SUCCESSFULLY")
+    module.send("AUDIO", "audio_output_method=server", ".")
+    module.wait_for("300 MODULE ERROR")
+
+    module.send("AUDIO", "audio_output_method=alsa", "audio_alsa_device=default", ".")
+    module.wait_for("203 OK AUDIO INITIALIZED")
+
+
+def test_settings_and_loglevel(module: ModuleHarness) -> None:
+    module.init()
+    module.send(
+        "SET",
+        "pitch=0",
+        "pitch_range=0",
+        "rate=50",
+        "volume=100",
+        "punctuation_mode=none",
+        "spelling_mode=off",
+        "cap_let_recogn=none",
+        "voice=female1",
+        "language=en-US",
+        "synthesis_voice=NULL",
+        ".",
+    )
+    module.wait_for("203 OK SETTINGS RECEIVED")
+
+    module.send("LOGLEVEL", "log_level=3", ".")
+    module.wait_for("203 OK LOGLEVEL SET")
+
+
+def test_settings_bad_syntax(module: ModuleHarness) -> None:
+    module.init()
+    module.send("SET", "this-is-not-a-parameter", ".")
+    module.wait_for("302 ERROR BAD SYNTAX")
+
+
+def test_settings_invalid_value(module: ModuleHarness) -> None:
+    module.init()
+    module.send("SET", "rate=fast", ".")
+    module.wait_for("303 ERROR INVALID PARAMETER OR VALUE")
+
+
+def test_rate_changes_length_scale(server: StubServer, module: ModuleHarness) -> None:
+    module.init()
+    module.send("SET", "rate=100", ".")
+    module.wait_for("203 OK SETTINGS RECEIVED")
+    module.speak("<speak>Hello.</speak>")
+    module.wait_for("702 END")
+
+    assert server.requests[0]["length_scale"] < 1.0
+
+
+def test_voice_selection_by_language(server: StubServer) -> None:
+    config = make_config(
+        server,
+        voices=[
+            VoiceEntry("en-US", "FEMALE1", "en_US-test-medium"),
+            VoiceEntry("fr-FR", "FEMALE1", "fr_FR-test-medium"),
+        ],
+    )
+    harness = ModuleHarness(config).start()
+    try:
+        harness.init()
+        harness.send("SET", "voice=female1", "language=fr-FR", ".")
+        harness.wait_for("203 OK SETTINGS RECEIVED")
+        harness.speak("<speak>Bonjour.</speak>")
+        harness.wait_for("702 END")
+
+        assert server.requests[0]["voice"] == "fr_FR-test-medium"
+    finally:
+        harness.close()
+
+
+def test_synthesis_voice_overrides_symbolic_voice(
+    server: StubServer, module: ModuleHarness
+) -> None:
+    module.init()
+    module.send("SET", "voice=female1", "synthesis_voice=fr_FR-test-medium", ".")
+    module.wait_for("203 OK SETTINGS RECEIVED")
+    module.speak("<speak>Bonjour.</speak>")
+    module.wait_for("702 END")
+
+    assert server.requests[0]["voice"] == "fr_FR-test-medium"
+
+
+def test_list_voices(module: ModuleHarness) -> None:
+    module.init()
+    module.send("LIST VOICES")
+    module.wait_for("200 OK VOICE LIST SENT")
+
+    voice_lines = [line for line in module.replies() if line.startswith("200-")]
+    assert voice_lines
+    for line in voice_lines:
+        # name TAB language TAB variant
+        assert len(line[4:].split("\t")) == 3
+        assert len(line) > 4
+
+
+def test_list_voices_with_language_filter(module: ModuleHarness) -> None:
+    module.init()
+    module.send("LIST VOICES fr-FR")
+    module.wait_for("200 OK VOICE LIST SENT")
+    assert any("fr_FR-test-medium" in line for line in module.replies())
+
+
+def test_list_voices_unknown_language(module: ModuleHarness) -> None:
+    module.init()
+    module.send("LIST VOICES xx-XX")
+    module.wait_for("304 CANT LIST VOICES")
+
+
+def test_speak_event_sequence(server: StubServer, module: ModuleHarness) -> None:
+    module.init()
+    module.clear()
+    module.speak('<speak>One two. <mark name="__spd_0"/>Three four five.</speak>')
+    module.wait_for("702 END")
+
+    events = [line for line in module.replies() if line[:1] in ("2", "7")]
+    assert events[0] == "202 OK RECEIVING MESSAGE"
+    assert events[1] == "200 OK SPEAKING"
+    assert events[2] == "701 BEGIN"
+    assert events[-1] == "702 END"
+    assert "700 INDEX MARK" in events
+    assert events.index("700-__spd_0") < events.index("702 END")
+
+    # Text was chunked before being sent
+    assert len(server.requests) > 1
+
+
+def test_empty_message_is_refused(module: ModuleHarness) -> None:
+    module.init()
+    module.speak("<speak></speak>")
+    module.wait_for("301 ERROR CANT SPEAK")
+
+
+def test_char_and_key(server: StubServer, module: ModuleHarness) -> None:
+    module.init()
+    module.send("CHAR", "space", ".")
+    module.wait_for("301 ERROR CANT SPEAK")  # a space alone has nothing to say
+
+    module.clear()
+    module.send("CHAR", "a", ".")
+    module.wait_for("702 END")
+    assert server.texts()[-1] == "a"
+
+    module.clear()
+    module.send("KEY", "control_alt_delete", ".")
+    module.wait_for("702 END")
+    # Keys and characters are never split into chunks
+    assert server.texts()[-1] == "control alt delete"
+
+
+def test_char_rejects_multiple_lines(module: ModuleHarness) -> None:
+    module.init()
+    module.send("CHAR", "a", "b", ".")
+    module.wait_for("305 DATA MORE THAN ONE LINE")
+
+
+def test_sound_icon_is_refused(module: ModuleHarness) -> None:
+    module.init()
+    module.send("SOUND_ICON", "bell", ".")
+    module.wait_for("301 ERROR CANT SPEAK")
+
+
+def test_dot_stuffing_is_undone(server: StubServer, module: ModuleHarness) -> None:
+    module.init()
+    # Speech Dispatcher doubles a leading dot
+    module.send("SPEAK", "<speak>", "..hidden dot</speak>", ".")
+    module.wait_for("702 END")
+    assert any(".hidden dot" in text for text in server.texts())
+
+
+def test_stop_interrupts_and_reports_stop(server: StubServer) -> None:
+    harness = ModuleHarness(make_config(server, player=SLOW_PLAYER)).start()
+    try:
+        harness.init()
+        harness.clear()
+        harness.speak("<speak>" + " ".join(["word"] * 60) + ".</speak>")
+        harness.wait_for("701 BEGIN")
+
+        time.sleep(0.2)
+        start = time.monotonic()
+        harness.send("STOP")
+        harness.wait_for("703 STOP", timeout=5)
+        stop_seconds = time.monotonic() - start
+
+        # Interruption must be immediate, not "at the end of the utterance"
+        assert stop_seconds < 2.0
+        assert server.stops, "the server was not told to abandon synthesis"
+
+        # No event may follow the terminating event
+        replies = harness.replies()
+        assert replies[-1] == "703 STOP"
+        assert "702 END" not in replies
+
+        # Speaking again works right away: nothing was restarted
+        harness.clear()
+        harness.speak("<speak>Next message.</speak>")
+        harness.wait_for("702 END", timeout=10)
+    finally:
+        harness.close()
+
+
+def test_stop_with_nothing_playing_is_silent(module: ModuleHarness) -> None:
+    """STOP must never produce a reply of its own."""
+    module.init()
+    module.clear()
+    module.send("STOP")
+    time.sleep(0.3)
+    assert module.replies() == []
+
+
+def _check_event_pairing(replies: List[str]) -> int:
+    """Check begin/end pairing and return the number of finished messages.
+
+    Speech Dispatcher blocks forever if a message it acknowledged with "200 OK
+    SPEAKING" is never opened with 701 and closed with 702/703/704.
+    """
+    finished = 0
+    open_message = False
+
+    for line in replies:
+        if line == "701 BEGIN":
+            assert not open_message, f"701 BEGIN inside a message: {replies}"
+            open_message = True
+        elif line in ("702 END", "703 STOP", "704 PAUSE"):
+            assert open_message, f"{line} without 701 BEGIN: {replies}"
+            open_message = False
+            finished += 1
+
+    assert not open_message, f"message left open: {replies}"
+    return finished
+
+
+def test_stop_before_playback_starts_still_reports_events(server: StubServer) -> None:
+    """STOP right after SPEAK must still produce a begin/end pair."""
+    harness = ModuleHarness(make_config(server, player=SLOW_PLAYER)).start()
+    try:
+        harness.init()
+        harness.clear()
+        harness.speak("<speak>" + " ".join(["word"] * 60) + ".</speak>")
+        harness.wait_for("200 OK SPEAKING")
+        harness.send("STOP")
+        harness.wait_for("703 STOP", timeout=5)
+
+        replies = harness.replies()
+        assert _check_event_pairing(replies) == 1
+        assert "702 END" not in replies
+    finally:
+        harness.close()
+
+
+def test_preempted_messages_are_all_terminated(server: StubServer) -> None:
+    """Bursts of messages (the screen reader case) must stay in sync.
+
+    Every acknowledged message needs its own begin/end pair, including the ones
+    that never reach the audio output.
+    """
+    harness = ModuleHarness(make_config(server, player=SLOW_PLAYER)).start()
+    try:
+        harness.init()
+        harness.clear()
+
+        for index in range(6):
+            harness.speak(f"<speak>message number {index} with a few words.</speak>")
+
+        harness.send("STOP")
+
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            if _check_event_pairing(harness.replies()) == 6:
+                break
+
+            time.sleep(0.05)
+
+        replies = harness.replies()
+        assert replies.count("200 OK SPEAKING") == 6
+        assert _check_event_pairing(replies) == 6
+    finally:
+        harness.close()
+
+
+def test_pause_reports_pause(server: StubServer) -> None:
+    harness = ModuleHarness(make_config(server, player=SLOW_PLAYER)).start()
+    try:
+        harness.init()
+        harness.clear()
+        harness.speak("<speak>" + " ".join(["word"] * 60) + ".</speak>")
+        harness.wait_for("701 BEGIN")
+        time.sleep(0.2)
+        harness.send("PAUSE")
+        harness.wait_for("704 PAUSE", timeout=5)
+    finally:
+        harness.close()
+
+
+def test_new_message_preempts_the_previous_one(server: StubServer) -> None:
+    """This is the screen reader case: the pointer moved to another area."""
+    harness = ModuleHarness(make_config(server, player=SLOW_PLAYER)).start()
+    try:
+        harness.init()
+        harness.clear()
+        harness.speak("<speak>" + " ".join(["first"] * 60) + ".</speak>")
+        harness.wait_for("701 BEGIN")
+        time.sleep(0.2)
+
+        harness.speak("<speak>Second area.</speak>")
+        harness.wait_for("703 STOP", timeout=5)
+        harness.wait_for("702 END", timeout=10)
+
+        assert any("Second area." in text for text in server.texts())
+    finally:
+        harness.close()
+
+
+def test_server_audio_mode_sends_audio_blocks(server: StubServer) -> None:
+    """In server audio mode, PCM is handed back to Speech Dispatcher."""
+    harness = ModuleHarness(make_config(server, audio_output="server")).start()
+    try:
+        harness.send("INIT")
+        harness.wait_for("299 OK LOADED SUCCESSFULLY")
+        harness.send("AUDIO", "audio_output_method=server", ".")
+        harness.wait_for("203 OK AUDIO INITIALIZED")
+
+        harness.speak("<speak>Server audio.</speak>")
+        harness.wait_for("702 END")
+
+        blocks = _parse_audio_blocks(bytes(harness.output))
+        assert blocks
+        for sample_rate, num_samples, audio in blocks:
+            assert sample_rate == SAMPLE_RATE
+            assert len(audio) == num_samples * 2
+    finally:
+        harness.close()
+
+
+def test_audio_uses_the_sample_rate_of_the_selected_voice(server: StubServer) -> None:
+    """Voices have different sample rates: playing at the wrong one slows speech."""
+    config = make_config(
+        server,
+        audio_output="server",
+        voices=[
+            VoiceEntry("en-US", "FEMALE1", "en_US-test-medium"),
+            VoiceEntry("fr-FR", "FEMALE1", "fr_FR-test-medium"),
+        ],
+    )
+    harness = ModuleHarness(config).start()
+    try:
+        harness.send("INIT")
+        harness.wait_for("299 OK LOADED SUCCESSFULLY")
+        harness.send("AUDIO", "audio_output_method=server", ".")
+        harness.wait_for("203 OK AUDIO INITIALIZED")
+
+        harness.send("SET", "voice=female1", "language=fr-FR", ".")
+        harness.wait_for("203 OK SETTINGS RECEIVED")
+        harness.speak("<speak>Bonjour.</speak>")
+        harness.wait_for("702 END")
+
+        assert server.texts()[-1].startswith("Bonjour")
+        blocks = _parse_audio_blocks(bytes(harness.output))
+        assert blocks
+        assert {sample_rate for sample_rate, _samples, _audio in blocks} == {
+            FR_SAMPLE_RATE
+        }
+    finally:
+        harness.close()
+
+
+def _parse_audio_blocks(data: bytes) -> List[Tuple[int, int, bytes]]:
+    """Decode 705 AUDIO blocks the way Speech Dispatcher does."""
+    blocks: List[Tuple[int, int, bytes]] = []
+    position = 0
+    while True:
+        start = data.find(b"705-bits=16\n", position)
+        if start < 0:
+            return blocks
+
+        marker = data.find(b"705-AUDIO\0", start)
+        end = data.find(b"\n705 AUDIO\n", marker)
+        assert marker > 0 and end > 0
+
+        header = data[start:marker].decode("utf-8")
+        sample_rate = int(re.search(r"sample_rate=(\d+)", header).group(1))  # type: ignore[union-attr]
+        num_samples = int(re.search(r"num_samples=(\d+)", header).group(1))  # type: ignore[union-attr]
+        assert "big_endian=0" in header
+        assert "num_channels=1" in header
+
+        payload = data[marker + len(b"705-AUDIO\0") : end]
+        audio = bytearray()
+        pending = False
+        for byte in payload:
+            if pending:
+                audio.append(byte ^ 0x20)
+                pending = False
+            elif byte == 0x7D:
+                pending = True
+            else:
+                audio.append(byte)
+
+        blocks.append((sample_rate, num_samples, bytes(audio)))
+        position = end + 1
+
+
+def test_quit_exits_cleanly(server: StubServer) -> None:
+    harness = ModuleHarness(make_config(server)).start()
+    harness.init()
+    harness.send("QUIT")
+    harness.wait_for("210 OK QUIT")
+
+
+def test_module_survives_a_dead_server(tmp_path: Path) -> None:
+    """A missing server must not prevent the module from loading."""
+    config = ModuleConfig(url="http://127.0.0.1:1", player=NULL_PLAYER)
+    harness = ModuleHarness(config).start()
+    try:
+        harness.send("INIT")
+        harness.wait_for("299 OK LOADED SUCCESSFULLY", timeout=30)
+
+        # LIST VOICES must still return at least one voice
+        harness.send("LIST VOICES")
+        harness.wait_for("200 OK VOICE LIST SENT", timeout=30)
+
+        # And a failed synthesis must still open and terminate the message
+        harness.send("AUDIO", "audio_output_method=alsa", ".")
+        harness.clear()
+        harness.speak("<speak>Nobody can hear this.</speak>")
+        harness.wait_for("702 END", timeout=30)
+
+        replies = harness.replies()
+        assert _check_event_pairing(replies) == 1
+        assert replies.index("701 BEGIN") < replies.index("702 END")
+    finally:
+        harness.close()


### PR DESCRIPTION
Counterpart of #285

The client is enabled with the dedicated chunking logic introduced in the server (98ef84471a23e81ba5709f0cec66b8989d5b215e is just the same 388bc6a8c65f2392c2e13820de5f77a2ae3e4bd0 in #285)

It's a more powerful substitute to curl which can handle streaming http semantics and, by controlling tightly the player, can actually stop playback when needed. It also adapts to the sample-rate corresponding to the voice used/disclosed by the server (`X-Piper-Sample-Rate`)

The `sd_piper` module (cb739266758ba60648a73fa6d8e2445f019e549a) speaks the Speech Dispatcher protocol, drives the client (can also auto-start the server and provide the helpers for the configuration of the speech-dispatcher and an optional unpriviledge-user systemd service)

A thousand thanks to the LLM (Opus 5) for  figuring out the intrinsic of the SD verbs order and resolving involved issues (like edge case where a `702 END` has no corresponding `701 BEGIN` etc...
This provides full features integration with screen-readers (speed, multiple voices etc...), so more features/more complex/more powerful, but definitely gets the job done for users who most need a low-latency setup.

The goal was to serve a visually impaired user and the resulting latency improvements (~ 1+ sec down to dozens of ms) made piper actually usable with orca `mousereview` feature to read what's under the mouse without the usually confusing latency.

Fixes https://github.com/rhasspy/piper/issues/285 , https://github.com/rhasspy/piper/issues/275 , https://github.com/rhasspy/piper/issues/265 / https://github.com/rhasspy/piper/discussions/328

@alexkuz / @patrick-emmabuntus