### PR TITLE
Use the TorchScript ONNX exporter explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ setup(
     ],
     extras_require={
         "train": [
-            "torch>=2,<3",
+            # 2.5 added the dynamo argument to torch.onnx.export
+            "torch>=2.5,<3",
             "lightning>=2,<3",
             "tensorboard>=2,<3",
             "tensorboardX>=2,<3",

--- a/src/piper/train/export_onnx.py
+++ b/src/piper/train/export_onnx.py
@@ -102,6 +102,10 @@ def main() -> None:
             "input_lengths": {0: "batch_size"},
             "output": {0: "batch_size", 2: "time"},
         },
+        # torch 2.13 flipped this default to True. The dynamo exporter cannot
+        # trace infer(), whose output length depends on the predicted durations,
+        # and dynamic_axes above is a TorchScript exporter argument anyway.
+        dynamo=False,
     )
     _LOGGER.info("Exported model to %s", output_path)
 


### PR DESCRIPTION
Closes #101.

`torch.onnx.export` gained a `dynamo` argument in torch 2.5 defaulting to
`False`, and torch 2.13 flipped that default to `True`. The dynamo exporter runs
the model through `torch.export`, which cannot trace `infer()`: the output length
depends on the predicted durations, so it fails on a data-dependent guard. That
is why pinning `torch==2.8.0` works around it, as several people found in the
thread. 2.8 still defaulted to the TorchScript exporter.

The call already passes `dynamic_axes`, which only the TorchScript exporter
reads, so `dynamo=False` is what this code was always written for.

Reproduced against a `SynthesizerTrn` built from the x-low preset on torch
2.13.0, running the same export call as `export_onnx.py`:

```
current code (no dynamo kwarg): GuardOnDataDependentSymNode:
    Could not guard on data-dependent expression Eq(u3, 1)
with dynamo=False:              OK
```

which is the same exception as the report, at a different symbol index.

The `train` extra floor moves from `torch>=2` to `torch>=2.5` because earlier
releases have no `dynamo` argument and would raise `TypeError`.

No test is added: the repo has no training-path tests and a real ONNX export
would put torch into CI. Happy to add one if you want it.
