### PR TITLE
fix: Phase 1 relaxed poly fallback for mobile

### DIFF
--- a/libpiper/src/chinese_phonemizer.cpp
+++ b/libpiper/src/chinese_phonemizer.cpp
@@ -407,13 +407,13 @@ ChinesePhonemizer::phonemize(const std::string &text) {
       continue;
     }
 
-    // Phase 1 relaxed for iOS/macOS: MONOPHONIC_CHARS preferred, otherwise
-    // use first reading from char_bopomofo_dict for polyphonic chars (e.g. 虹/称/绛/简).
-    // Strict mono returned {} for any poly char, causing long sentences like
-    // "彩虹，又称..." to be empty -> PIPER_ERR_GENERIC -> silent in PiperApp.
-    // On mobile we have no 152MB g2pw.onnx (RAM budget), so first-sense fallback
-    // is acceptable: 95% coverage with 2MB dicts, better than silence. 重庆/银行
-    // may pick first sense until Phase 2 BERT.
+    // Phase 1 mono-only: accept only unambiguous one-reading entries.
+    // - mono_dict (MONOPHONIC_CHARS.txt) is authoritative mono table
+    // - otherwise allow char_bopomofo_dict only if it has exactly one reading
+    // - ambiguous (polyphonic) chars are treated as unsupported -> return empty
+    //   to avoid silently assigning first sense. This prevents 重庆/银行/长江
+    //   from being mis-assigned when only char_bopomofo_dict.json is present.
+    // Relaxed: use first reading for poly to avoid empty -> silence.
     std::string bopo;
     auto itm = mono_dict.find(ch_utf8);
     if (itm != mono_dict.end()) {

--- a/libpiper/src/chinese_phonemizer.cpp
+++ b/libpiper/src/chinese_phonemizer.cpp
@@ -407,12 +407,13 @@ ChinesePhonemizer::phonemize(const std::string &text) {
       continue;
     }
 
-    // Phase 1 mono-only: accept only unambiguous one-reading entries.
-    // - mono_dict (MONOPHONIC_CHARS.txt) is authoritative mono table
-    // - otherwise allow char_bopomofo_dict only if it has exactly one reading
-    // - ambiguous (polyphonic) chars are treated as unsupported -> return empty
-    //   to avoid silently assigning first sense. This prevents 重庆/银行/长江
-    //   from being mis-assigned when only char_bopomofo_dict.json is present.
+    // Phase 1 relaxed for iOS/macOS: MONOPHONIC_CHARS preferred, otherwise
+    // use first reading from char_bopomofo_dict for polyphonic chars (e.g. 虹/称/绛/简).
+    // Strict mono returned {} for any poly char, causing long sentences like
+    // "彩虹，又称..." to be empty -> PIPER_ERR_GENERIC -> silent in PiperApp.
+    // On mobile we have no 152MB g2pw.onnx (RAM budget), so first-sense fallback
+    // is acceptable: 95% coverage with 2MB dicts, better than silence. 重庆/银行
+    // may pick first sense until Phase 2 BERT.
     std::string bopo;
     auto itm = mono_dict.find(ch_utf8);
     if (itm != mono_dict.end()) {
@@ -423,13 +424,7 @@ ChinesePhonemizer::phonemize(const std::string &text) {
         // unknown char, skip
         continue;
       }
-      if (itc->second.size() != 1) {
-        // polyphonic char - unsupported in Phase 1 mono-only fallback
-        // Return empty to signal unsupported input rather than silently picking
-        // first pronunciation. Caller (PinyinTest) verifies 重/行/长 are not
-        // assigned.
-        return {};
-      }
+      // relaxed: first reading for polyphonic
       bopo = itc->second[0];
     }
 

--- a/libpiper/tests/test_piper.cpp
+++ b/libpiper/tests/test_piper.cpp
@@ -570,36 +570,31 @@ TEST_F(PinyinTest, PolyphonicKnownLimitation) {
   ASSERT_NE(synth->chinese_phonemizer, nullptr);
   ASSERT_TRUE(synth->chinese_phonemizer->hasDicts());
 
-  // Phase 1 mono-only: ambiguous polyphonic characters must NOT be silently
-  // assigned first sense. They should be treated as unsupported.
-  // This verifies the fix for review: 重/行/长 are polyphonic and must not
-  // return zhong/xing/zhang as first-sense fallback.
+  // Phase 1 relaxed for iOS/macOS (no 152MB g2pw.onnx): first reading fallback
+  // for polyphonic chars. Strict mono returned {} causing long sentences like
+  // "彩虹，又称..." to be silent. Relaxed mode enables 95% coverage with 2MB.
+  // 重庆/银行/长江 now return first sense (acceptable tradeoff vs silence).
   auto seq_zhong = synth->chinese_phonemizer->phonemize("重");
-  EXPECT_TRUE(seq_zhong.empty())
-      << "Phase 1 mono-only: 重 is polyphonic, should be unsupported";
+  EXPECT_FALSE(seq_zhong.empty())
+      << "Phase 1 relaxed: 重 should use first reading for mobile usability";
 
   auto seq_xing = synth->chinese_phonemizer->phonemize("行");
-  EXPECT_TRUE(seq_xing.empty())
-      << "Phase 1 mono-only: 行 is polyphonic, should be unsupported";
+  EXPECT_FALSE(seq_xing.empty())
+      << "Phase 1 relaxed: 行 should use first reading";
 
   auto seq_chang = synth->chinese_phonemizer->phonemize("长");
-  EXPECT_TRUE(seq_chang.empty())
-      << "Phase 1 mono-only: 长 is polyphonic, should be unsupported";
+  EXPECT_FALSE(seq_chang.empty())
+      << "Phase 1 relaxed: 长 should use first reading";
 
-  // Compounds containing poly char should also not silently assign first sense.
-  // Our phonemize returns empty on encountering poly char to avoid wrong
-  // reading.
   auto seq_cq = synth->chinese_phonemizer->phonemize("重庆");
-  // Should be empty or at least not contain first-sense zhong – empty is
-  // cleanest
-  EXPECT_TRUE(seq_cq.empty())
-      << "重庆 contains 重 (poly), should be unsupported in mono-only Phase 1";
+  EXPECT_FALSE(seq_cq.empty())
+      << "重庆 should now speak with first-sense fallback in relaxed Phase 1";
 
   auto seq_yh = synth->chinese_phonemizer->phonemize("银行");
-  EXPECT_TRUE(seq_yh.empty()) << "银行 contains 行 poly, should be unsupported";
+  EXPECT_FALSE(seq_yh.empty()) << "银行 should speak with first-sense fallback";
 
   auto seq_cj = synth->chinese_phonemizer->phonemize("长江");
-  EXPECT_TRUE(seq_cj.empty()) << "长江 contains 长 poly, should be unsupported";
+  EXPECT_FALSE(seq_cj.empty()) << "长江 should speak with first-sense fallback";
 
   // Positive: mono chars still work - "你我" are monophonic (single reading)
   auto seq_nh = synth->chinese_phonemizer->phonemize("你我");


### PR DESCRIPTION
Phase 1 strict mono returned empty for any poly char (虹/称/绛/简/重/行/长), causing long sentences like "彩虹，又称天弓..." to be empty -> PIPER_ERR_GENERIC -> silent in piper-app iOS/macOS.

Mobile has no 152MB g2pw.onnx (RAM budget), Phase 2 BERT not feasible for AU extension. This makes Phase 1 usable with 2MB dicts:

- Change phonemize() to use first reading for poly chars instead of failing
- Mono dict remains preferred when present
- 95% coverage, tradeoff: 重庆 may pick first sense until Phase 2, acceptable vs silence

Tests: 6/6 PinyinTest PASS locally (DirectPinyin, HanziMonoFallback, MissingG2pwFallback, PolyphonicKnownLimitation relaxed, DataDirG2pwSubdir, DataDirRootDicts)

Fixes silent zh voice on long sentences reported in piper-app PR #46 testing