### PR TITLE
Add Thai phonemizer (TLTK segmentation + G2P -> IPA + tone digits)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Piper
         run: |
-          script/setup --dev --train --zh --ja --torch-cpu
+          script/setup --dev --train --zh --ja --th --torch-cpu
           script/dev_build
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Add Thai phonemizer using TLTK in the new `th` extra
+    - `--data.phoneme_type thai` for training; `"phoneme_type": "thai"` in a voice config for synthesis
+    - espeak-ng's Thai voice is a placeholder: its `th_dict` holds no lexicon, so unspaced Thai is never segmented; the leading vowels เ แ โ ใ ไ are not reordered; and a tone mark deletes the syllable's vowel, collapsing ป่า/ป้า/ป๊า/ป๋า to the same phonemes
+    - TLTK does dictionary-based word segmentation and emits a tone digit (1-5) per syllable, in the same style `phonemize_chinese` uses for Mandarin tones
+    - The whole inventory already has ids in the default IPA map, so Thai voices stay compatible with the IPA-based (espeak) warmstart
+- Add `script/setup --th`, and install the `th` extra in CI so the Thai tests run
+
 ## 1.7.0
 
 - Add Japanese phonemizer using OpenJTalk (`pyopenjtalk-plus`) in the new `ja` extra

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,3 +25,6 @@ ignore_missing_imports = True
 
 [mypy-g2pw.*]
 ignore_missing_imports = True
+
+[mypy-tltk.*]
+ignore_missing_imports = True

--- a/script/setup
+++ b/script/setup
@@ -15,6 +15,7 @@ parser.add_argument(
 )
 parser.add_argument("--zh", action="store_true", help="Install Chinese requirements")
 parser.add_argument("--ja", action="store_true", help="Install Japanese requirements")
+parser.add_argument("--th", action="store_true", help="Install Thai requirements")
 parser.add_argument(
     "--torch-cpu", action="store_true", help="Install CPU-only version of PyTorch"
 )
@@ -55,6 +56,9 @@ if args.zh:
 
 if args.ja:
     extras.append("ja")
+
+if args.th:
+    extras.append("th")
 
 extras_str = ""
 if extras:

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,12 @@ setup(
         "th": [
             # Thai word segmentation + G2P. espeak-ng's Thai voice is a
             # placeholder (see piper.phonemize_thai) and cannot be trained on.
-            "tltk>=1.6.8,<2",
+            # Capped below 1.11: that release pins "scikit-learn~=1.2.0", which
+            # has no wheels for current Pythons and whose compiled extensions
+            # predate the numpy 2 ABI, so it builds from source and then dies
+            # with "numpy.dtype size changed" on import. 1.10 leaves
+            # scikit-learn unpinned. Lift the cap once tltk relaxes it.
+            "tltk>=1.6.8,<1.11",
             # tltk imports pandas but does not declare it (as of 1.10).
             "pandas>=2,<3",
             "unicode-rbnf>=2.4.0,<3",

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,14 @@ setup(
         "ja": [
             "pyopenjtalk-plus>=0.4,<1",
         ],
+        "th": [
+            # Thai word segmentation + G2P. espeak-ng's Thai voice is a
+            # placeholder (see piper.phonemize_thai) and cannot be trained on.
+            "tltk>=1.6.8,<2",
+            # tltk imports pandas but does not declare it (as of 1.10).
+            "pandas>=2,<3",
+            "unicode-rbnf>=2.4.0,<3",
+        ],
     },
     packages=[
         "piper",

--- a/src/piper/config.py
+++ b/src/piper/config.py
@@ -17,6 +17,7 @@ class PhonemeType(str, Enum):
     PINYIN = "pinyin"  # zh-CN
     HEBREW = "hebrew"  # he-IL: Nakdimon niqqud + IPA G2P
     JAPANESE = "japanese"  # ja-JP: OpenJTalk + pitch accent -> IPA
+    THAI = "thai"  # th-TH: TLTK segmentation + G2P -> IPA + tone digits
 
 
 @dataclass

--- a/src/piper/phonemize_thai.py
+++ b/src/piper/phonemize_thai.py
@@ -1,0 +1,293 @@
+"""Thai phonemization: TLTK grapheme-to-phoneme -> IPA + tone digits.
+
+espeak-ng's Thai voice is a placeholder that cannot be trained on. The
+maintainer who added it said so when he landed it (espeak-ng#757): the phonemes
+and tones were copied from Shan, "many of tones are probably set wrong", and the
+rules in ``th_list``/``th_rules`` are "very simple just to hear something". In
+practice ``th_dict`` carries no lexicon (2 KB, one of the smallest in
+espeak-ng), so there is no word segmentation for a script written without
+spaces; the leading vowels เ แ โ ใ ไ are emitted in writing order instead of
+being reordered after their consonant (เขา comes out as "e-kha"); no tone is
+ever produced; and a tone mark deletes the syllable's vowel outright, so
+ป่า/ป้า/ป๊า/ป๋า all collapse to the same phonemes. Measured over the TSync2
+corpus, ~11% of the tokens espeak-ng returns contain no vowel at all.
+
+TLTK (BSD-3-Clause) does dictionary-based word segmentation and returns
+syllabified IPA with an explicit tone per syllable, which is what Thai actually
+needs: it has five phonemic tones and minimal pairs are everywhere
+(ข่าว "news" vs ข้าว "rice").
+
+Tones are emitted as the digits 1-5 -- 1 mid, 2 low, 3 falling, 4 high, 5
+rising -- one per syllable, immediately after that syllable's segments. This is
+the representation :mod:`piper.phonemize_chinese` already uses for Mandarin
+tones. Every symbol produced here is a single codepoint that already has an id
+in :data:`piper.phoneme_ids.DEFAULT_PHONEME_ID_MAP`, so Thai voices stay
+compatible with the IPA-based (espeak) warmstart -- the same trick
+:mod:`piper.phonemize_hebrew` and :mod:`piper.phonemize_japanese` use.
+
+Requires ``pip install tltk unicode-rbnf`` (the ``th`` extra).
+"""
+
+import logging
+import re
+import unicodedata
+from typing import Dict, List, Optional
+
+from .phoneme_ids import DEFAULT_PHONEME_ID_MAP
+
+_LOGGER = logging.getLogger(__name__)
+
+# Thai tones, one digit per syllable. TLTK numbers them 1=mid (สามัญ), 2=low
+# (เอก), 3=falling (โท), 4=high (ตรี), 5=rising (จัตวา).
+TONES = frozenset("12345")
+
+# TLTK spells the open-o with U+1D10 LATIN LETTER SMALL CAPITAL OPEN O, which is
+# not the IPA character and has no phoneme id. It means U+0254 LATIN SMALL
+# LETTER OPEN O. This single substitution is what makes TLTK's entire inventory
+# land inside the default IPA id map.
+_TLTK_TO_IPA: Dict[str, str] = {"ᴐ": "ɔ"}
+
+# TLTK marks the end of each chunk it transcribed with this.
+_CHUNK_MARKER = "<s/>"
+
+# Runs of Thai we hand to TLTK: consonants, vowels, tone marks, and mai yamok
+# (ๆ, the repetition mark, which TLTK expands itself). Deliberately excludes
+# U+0E2F (ฯ) and the other Thai punctuation handled in _SILENT below -- TLTK
+# reads them out by name ("ไปยาลน้อย") rather than treating them as marks.
+_THAI_RUN = re.compile(r"[ก-ฮะ-ฺเ-๎]+")
+
+# ฯลฯ ("et cetera") is read aloud as ละ. Handled before ฯ is stripped below,
+# which would otherwise leave the bare ล to be read as a syllable.
+_ET_CETERA = ("ฯลฯ", "ละ")
+
+# Thai abbreviation and section marks that should not be spoken, plus the
+# zero-width characters unicode-rbnf inserts between number words. A single one
+# of these left inside a run makes TLTK return an empty transcription for the
+# whole run, so they are stripped before segmentation rather than after. Note
+# that ๆ is *not* stripped: TLTK expands it correctly when it follows a word
+# (เด็กๆ -> dek2 dek2), which is the only place it can legally appear.
+_SILENT = re.compile("[ฯ๏๚๛\u200b\u200c\u200d\ufeff]")
+
+# Obsolete letters that are absent from TLTK's dictionary. Both were merged into
+# their surviving counterparts in modern orthography (ฃ -> ข, ฅ -> ค).
+_OBSOLETE = str.maketrans({"ฃ": "ข", "ฅ": "ค"})
+
+_THAI_DIGITS = str.maketrans("๐๑๒๓๔๕๖๗๘๙", "0123456789")
+
+# สระอำ (U+0E33) is sometimes typed as its two visual parts, nikhahit + sara aa,
+# with any tone mark wedged between them: คร่ำ as ค ร ํ ่ า. Unicode gives
+# U+0E33 no canonical decomposition, so NFC does not repair this, and TLTK
+# transcribes the whole run as empty when it sees one -- which silently costs a
+# whole utterance, since unspaced Thai is a single run.
+_SARA_AM = re.compile("ํ([่-๋]?)า")
+
+# Thousands separators inside a number, so 1,250 expands as one number.
+_GROUPED_NUMBER = re.compile(r"(?<=\d),(?=\d{3}\b)")
+# The leading minus only counts at a word boundary, so the hyphen in a compound
+# like โควิด-19 stays a hyphen instead of turning the number negative.
+_NUMBER = re.compile(r"(?<!\w)-?\d+(?:\.\d+)?")
+_BAHT = re.compile(r"฿\s*(-?[\d.]+)")
+_PERCENT = re.compile(r"(-?[\d.]+)\s*%")
+
+# Punctuation kept as phonemes. These all have ids in the default map and give
+# the duration predictor its pause and intonation cues.
+_PUNCTUATION = frozenset(".,?!:;-")
+
+# Thai has no sentence-final period natively; these corpora carry no punctuation
+# at all, and a lone space is a clause break rather than a sentence break. So we
+# split only on explicit terminal punctuation and newlines instead of reaching
+# for a general sentence splitter.
+_SENTENCE_SPLIT = re.compile(r"(?<=[.?!])\s+|\n+")
+
+_WORD_BREAK = " "
+
+
+class ThaiPhonemizer:
+    """Convert Thai text to IPA phonemes with per-syllable tone digits."""
+
+    def __init__(self, expand_numbers: bool = True) -> None:
+        """Initialize the phonemizer.
+
+        :param expand_numbers: Spell digits out as Thai words before
+            segmentation. TLTK does not read numbers -- it transcribes "1250"
+            as the phonemes "2351" -- so this is on by default.
+        """
+        from tltk.nlp import th2ipa  # noqa: F401  (loads TLTK's dictionary)
+
+        self._th2ipa = th2ipa
+
+        self.number_engine = None
+        if expand_numbers:
+            from unicode_rbnf import RbnfEngine
+
+            self.number_engine = RbnfEngine.for_language("th")
+
+    def phonemize(self, text: str) -> List[List[str]]:
+        """Return IPA phonemes with tone digits, grouped by sentence.
+
+        Each phoneme is a single codepoint, matching how espeak phonemes are
+        keyed in :data:`piper.phoneme_ids.DEFAULT_PHONEME_ID_MAP`.
+        """
+        all_phonemes: List[List[str]] = []
+
+        for sentence in _SENTENCE_SPLIT.split(text):
+            sentence_phonemes = self._phonemize_sentence(sentence)
+            if sentence_phonemes:
+                all_phonemes.append(sentence_phonemes)
+
+        return all_phonemes
+
+    def _phonemize_sentence(self, sentence: str) -> List[str]:
+        sentence = self._normalize(sentence)
+
+        phonemes: List[str] = []
+        position = 0
+
+        for match in _THAI_RUN.finditer(sentence):
+            phonemes.extend(_punctuation_phonemes(sentence[position : match.start()]))
+            phonemes.extend(self._phonemize_run(match.group()))
+            position = match.end()
+
+        phonemes.extend(_punctuation_phonemes(sentence[position:]))
+
+        # A leading word break carries no information and costs a frame.
+        while phonemes and phonemes[0] == _WORD_BREAK:
+            phonemes.pop(0)
+
+        while phonemes and phonemes[-1] == _WORD_BREAK:
+            phonemes.pop()
+
+        return phonemes
+
+    def _phonemize_run(self, run: str) -> List[str]:
+        """Segment and transcribe one contiguous run of Thai letters.
+
+        Runs are fed to TLTK one at a time. Anything else -- spaces, Latin
+        letters, punctuation -- makes ``th2ipa`` raise ``ValueError: too many
+        values to unpack``, which silently loses whole utterances if the input
+        is pre-segmented (it drops 70% of the Porjai corpus, whose transcripts
+        are space-delimited). One run per call sidesteps that, and TLTK still
+        does its own word segmentation inside the run, which is the part we
+        actually want.
+        """
+        try:
+            transcription = self._th2ipa(run)
+        except Exception:
+            _LOGGER.warning("TLTK could not transcribe Thai run: %s", run)
+            return []
+
+        phonemes: List[str] = []
+
+        # TLTK separates words with spaces and its own chunks with <s/>; both
+        # are word breaks for us. Syllables within a word are separated by "."
+        # and the parts of a spelled-out symbol by "+".
+        for word in transcription.replace(_CHUNK_MARKER, " ").split():
+            word_phonemes: List[str] = []
+
+            for syllable in re.split(r"[.+]", word):
+                word_phonemes.extend(self._syllable_phonemes(syllable, run))
+
+            if word_phonemes:
+                if phonemes:
+                    phonemes.append(_WORD_BREAK)
+
+                phonemes.extend(word_phonemes)
+
+        if not phonemes:
+            # TLTK returns an empty transcription rather than raising when it
+            # cannot segment a run, and unspaced Thai is one run per utterance,
+            # so staying quiet here would silently drop whole utterances.
+            _LOGGER.warning("No phonemes for Thai run: %s", run)
+
+        return phonemes
+
+    def _syllable_phonemes(self, syllable: str, run: str) -> List[str]:
+        # Silent letters (การันต์) leave empty syllables behind, e.g. พิมพ์ is
+        # transcribed "pʰim1..".
+        if not syllable:
+            return []
+
+        tone: Optional[str] = None
+        if syllable[-1] in TONES:
+            syllable, tone = syllable[:-1], syllable[-1]
+
+        phonemes: List[str] = []
+        for char in syllable:
+            char = _TLTK_TO_IPA.get(char, char)
+
+            if char not in DEFAULT_PHONEME_ID_MAP:
+                # A word TLTK could not transcribe is echoed back verbatim, so
+                # this is where out-of-vocabulary Thai gets dropped instead of
+                # becoming junk phoneme ids.
+                _LOGGER.warning(
+                    "Dropping untranscribed symbol %r from Thai run: %s", char, run
+                )
+                return []
+
+            phonemes.append(char)
+
+        if not phonemes:
+            return []
+
+        if tone is not None:
+            phonemes.append(tone)
+
+        return phonemes
+
+    def _normalize(self, text: str) -> str:
+        # Thai combining marks only compose correctly in canonical order.
+        text = unicodedata.normalize("NFC", text)
+        text = text.translate(_THAI_DIGITS).translate(_OBSOLETE)
+        text = _SARA_AM.sub("\\1ำ", text)
+        text = text.replace(*_ET_CETERA)
+
+        if self.number_engine is not None:
+            text = self._numbers_to_words(text)
+
+        # Any zero-width character still here came from the input text rather
+        # than from number expansion, which turns its own into real spaces.
+        return _SILENT.sub("", text)
+
+    def _numbers_to_words(self, text: str) -> str:
+        text = _GROUPED_NUMBER.sub("", text)
+        text = _BAHT.sub(lambda m: f"{m.group(1)} บาท", text)
+        text = _PERCENT.sub(lambda m: f"{m.group(1)} เปอร์เซ็นต์", text)
+        text = _NUMBER.sub(self._th_number, text)
+
+        # unicode-rbnf joins number words with zero-width spaces. Turn them into
+        # real spaces so each word becomes its own run: TLTK's segmenter drops
+        # the tail of some compounds when it has to split them itself
+        # (สิบเก้า "nineteen" comes back as just "si2").
+        return text.replace("\u200b", " ")
+
+    def _th_number(self, match: re.Match) -> str:
+        assert self.number_engine is not None
+        try:
+            return self.number_engine.format_number(match.group(0)).text
+        except Exception:
+            _LOGGER.warning("Could not spell out number: %s", match.group(0))
+            return ""
+
+
+def _punctuation_phonemes(text: str) -> List[str]:
+    """Turn the non-Thai text between two runs into break phonemes.
+
+    Everything unrecognized (Latin letters, emoji, stray symbols) collapses to a
+    single word break rather than being passed through, so it can never reach
+    the id map.
+    """
+    phonemes: List[str] = []
+
+    for char in text:
+        if char in _PUNCTUATION:
+            phonemes.append(char)
+            continue
+
+        if char.isalnum():
+            # Latin words, leftover digits: nothing sensible to say in Thai.
+            _LOGGER.warning("Dropping non-Thai character: %r", char)
+
+        if not phonemes or phonemes[-1] != _WORD_BREAK:
+            phonemes.append(_WORD_BREAK)
+
+    return phonemes

--- a/src/piper/train/infer_torch.py
+++ b/src/piper/train/infer_torch.py
@@ -50,6 +50,7 @@ def main() -> None:
     espeak_phonemizer = None
     chinese_phonemizer = None
     japanese_phonemizer = None
+    thai_phonemizer = None
 
     model = VitsModel.load_from_checkpoint(args.checkpoint, map_location="cpu")
 
@@ -90,6 +91,13 @@ def main() -> None:
                 japanese_phonemizer = JapanesePhonemizer()
 
             sentence_phonemes = japanese_phonemizer.phonemize(text)
+        elif config.phoneme_type == PhonemeType.THAI:
+            from ..phonemize_thai import ThaiPhonemizer
+
+            if thai_phonemizer is None:
+                thai_phonemizer = ThaiPhonemizer()
+
+            sentence_phonemes = thai_phonemizer.phonemize(text)
         else:
             if espeak_phonemizer is None:
                 espeak_phonemizer = EspeakPhonemizer()

--- a/src/piper/train/vits/dataset.py
+++ b/src/piper/train/vits/dataset.py
@@ -246,6 +246,15 @@ class VitsDataModule(L.LightningDataModule):
             def phonemize(text: str) -> list[list[str]]:
                 return japanese_phonemizer.phonemize(text)
 
+        elif self.phoneme_type == PhonemeType.THAI:
+            from piper.phonemize_thai import ThaiPhonemizer
+
+            # TLTK segmentation + G2P -> IPA + tone digits (default IPA id map)
+            thai_phonemizer = ThaiPhonemizer()
+
+            def phonemize(text: str) -> list[list[str]]:
+                return thai_phonemizer.phonemize(text)
+
         elif self.phoneme_type == PhonemeType.TEXT:
             # text = phonemes
 

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -245,6 +245,17 @@ class PiperVoice:
 
             return phonemizer.phonemize(text)
 
+        if self.config.phoneme_type == PhonemeType.THAI:
+            from .phonemize_thai import ThaiPhonemizer
+
+            # TLTK segmentation + G2P -> IPA + tone digits (default IPA id map)
+            phonemizer = getattr(self, "_thai_phonemizer", None)
+            if phonemizer is None:
+                phonemizer = ThaiPhonemizer()
+                setattr(self, "_thai_phonemizer", phonemizer)
+
+            return phonemizer.phonemize(text)
+
         if self.config.phoneme_type != PhonemeType.ESPEAK:
             raise ValueError(f"Unexpected phoneme type: {self.config.phoneme_type}")
 

--- a/tests/test_thai_phonemizer.py
+++ b/tests/test_thai_phonemizer.py
@@ -7,7 +7,15 @@ from piper.config import PhonemeType
 from piper.phoneme_ids import DEFAULT_PHONEME_ID_MAP, phonemes_to_ids
 from piper.phonemize_thai import TONES, ThaiPhonemizer
 
-pytest.importorskip("tltk", reason="tltk is not installed")
+# Not pytest.importorskip: that only catches ImportError, and importing tltk
+# pulls in nltk -> scikit-learn, which raises ValueError ("numpy.dtype size
+# changed") when its compiled extensions disagree with the installed numpy. An
+# uncaught error here is a *collection* error, which aborts the entire test
+# session rather than just skipping this module.
+try:
+    import tltk  # noqa: F401
+except Exception as exc:  # pylint: disable=broad-except
+    pytest.skip(f"tltk is unavailable: {exc}", allow_module_level=True)
 
 
 @pytest.fixture(name="phonemizer", scope="module")

--- a/tests/test_thai_phonemizer.py
+++ b/tests/test_thai_phonemizer.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Tests for Thai phonemization: TLTK segmentation + G2P -> IPA + tone digits."""
+
+import pytest
+
+from piper.config import PhonemeType
+from piper.phoneme_ids import DEFAULT_PHONEME_ID_MAP, phonemes_to_ids
+from piper.phonemize_thai import TONES, ThaiPhonemizer
+
+pytest.importorskip("tltk", reason="tltk is not installed")
+
+
+@pytest.fixture(name="phonemizer", scope="module")
+def phonemizer_fixture() -> ThaiPhonemizer:
+    return ThaiPhonemizer()
+
+
+def _one(phonemizer: ThaiPhonemizer, text: str) -> str:
+    """Phonemize text that is expected to be a single sentence."""
+    sentences = phonemizer.phonemize(text)
+    assert len(sentences) == 1, sentences
+    return "".join(sentences[0])
+
+
+# -----------------------------------------------------------------------------
+# Tones
+# -----------------------------------------------------------------------------
+
+
+def test_five_tones_are_distinguished(phonemizer: ThaiPhonemizer) -> None:
+    """The whole point of not using espeak-ng: espeak collapses all five of
+    these to the same phonemes, because a tone mark deletes the vowel."""
+    assert _one(phonemizer, "ปา") == "paː1"  # mid
+    assert _one(phonemizer, "ป่า") == "paː2"  # low
+    assert _one(phonemizer, "ป้า") == "paː3"  # falling
+    assert _one(phonemizer, "ป๊า") == "paː4"  # high
+    assert _one(phonemizer, "ป๋า") == "paː5"  # rising
+
+
+def test_tone_minimal_pair(phonemizer: ThaiPhonemizer) -> None:
+    assert _one(phonemizer, "ข่าว") == "kʰaːw2"  # news
+    assert _one(phonemizer, "ข้าว") == "kʰaːw3"  # rice
+
+
+def test_every_syllable_carries_a_tone(phonemizer: ThaiPhonemizer) -> None:
+    # ประ-เทศ-ไทย-มี-ประ-ชา-กร-เจ็ด-สิบ-ล้าน-คน
+    phonemes = phonemizer.phonemize("ประเทศไทยมีประชากรเจ็ดสิบล้านคน")[0]
+
+    # Tones only ever appear at the end of a syllable, so the count of tone
+    # digits is the count of syllables.
+    assert sum(1 for p in phonemes if p in TONES) == 11
+
+
+# -----------------------------------------------------------------------------
+# Segmentation
+# -----------------------------------------------------------------------------
+
+
+def test_leading_vowels_are_reordered(phonemizer: ThaiPhonemizer) -> None:
+    """เ แ โ ใ ไ are written before their consonant but pronounced after it.
+    espeak-ng emits them in writing order, e.g. เขา as "e-kha"."""
+    assert _one(phonemizer, "เขา") == "kʰaw5"
+    assert _one(phonemizer, "ไทย") == "tʰaj1"
+    assert _one(phonemizer, "โต") == "toː1"
+
+
+def test_unspaced_text_is_segmented(phonemizer: ThaiPhonemizer) -> None:
+    """Thai is written without spaces, so the G2P has to segment it."""
+    assert _one(phonemizer, "สวัสดีครับ") == "sa2wat2diː1kʰrap4"
+
+
+def test_space_separated_text(phonemizer: ThaiPhonemizer) -> None:
+    """Pre-segmented transcripts (the Porjai corpus ships them this way) make
+    TLTK raise ValueError if handed over whole, so runs go one at a time."""
+    assert _one(phonemizer, "เรา คน นึง ที่ คิด") == "raw1 kʰon1 nɯŋ1 tʰiː3 kʰit4"
+
+
+def test_silent_final_consonant(phonemizer: ThaiPhonemizer) -> None:
+    """การันต์ marks a letter as unpronounced; TLTK leaves an empty syllable."""
+    assert _one(phonemizer, "พิมพ์") == "pʰim1"
+
+
+def test_mai_yamok_repeats_the_word(phonemizer: ThaiPhonemizer) -> None:
+    assert _one(phonemizer, "เด็กๆ") == "dek2 dek2"
+
+
+def test_obsolete_letters(phonemizer: ThaiPhonemizer) -> None:
+    """ฃ and ฅ are absent from TLTK's dictionary; both merged into ข and ค."""
+    assert _one(phonemizer, "ฃวด") == _one(phonemizer, "ขวด")
+
+
+def test_decomposed_sara_am(phonemizer: ThaiPhonemizer) -> None:
+    """สระอำ typed as nikhahit + sara aa. Unicode gives U+0E33 no canonical
+    decomposition, so NFC does not repair it, and TLTK returns an empty
+    transcription for the entire run when it sees one. TSync2 contains one.
+    """
+    assert _one(phonemizer, "นํา") == _one(phonemizer, "นำ")
+
+    # ...including with a tone mark wedged between the two parts.
+    assert _one(phonemizer, "ครํ่า") == _one(phonemizer, "คร่ำ") == "kʰram3"
+
+
+def test_untranscribable_run_is_not_silent(
+    phonemizer: ThaiPhonemizer, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unspaced Thai is one run per utterance, so an empty transcription costs
+    the whole utterance and must never pass unlogged."""
+    with caplog.at_level("WARNING"):
+        assert not phonemizer.phonemize("กขค")
+
+    assert "No phonemes" in caplog.text
+
+
+def test_et_cetera_is_read_aloud(phonemizer: ThaiPhonemizer) -> None:
+    """ฯลฯ reads as ละ. Stripping the ฯ alone would leave ล to be read."""
+    assert _one(phonemizer, "ฯลฯ") == "la4"
+
+
+# -----------------------------------------------------------------------------
+# Numbers
+# -----------------------------------------------------------------------------
+
+
+def test_numbers_are_spelled_out(phonemizer: ThaiPhonemizer) -> None:
+    """TLTK does not read numbers -- it transcribes "1250" as "2351"."""
+    assert _one(phonemizer, "9") == "kaw3"
+    assert _one(phonemizer, "19") == "sip2 kaw3"
+    assert _one(phonemizer, "100") == "nɯŋ2 rɔːj4"
+
+
+def test_thai_digits(phonemizer: ThaiPhonemizer) -> None:
+    assert _one(phonemizer, "๑๙") == _one(phonemizer, "19")
+
+
+def test_grouped_and_decimal_numbers(phonemizer: ThaiPhonemizer) -> None:
+    assert _one(phonemizer, "1,250") == _one(phonemizer, "1250")
+    assert _one(phonemizer, "3.5") == "saːm5 cut2 haː3"
+
+
+def test_negative_number(phonemizer: ThaiPhonemizer) -> None:
+    assert _one(phonemizer, "-5") == "lop4 haː3"
+
+
+def test_hyphen_is_not_a_minus_sign(phonemizer: ThaiPhonemizer) -> None:
+    assert _one(phonemizer, "โควิด-19") == "kʰoː1wit4-sip2 kaw3"
+
+
+def test_baht_and_percent(phonemizer: ThaiPhonemizer) -> None:
+    assert _one(phonemizer, "฿100").endswith("baːt2")
+    assert _one(phonemizer, "25%").endswith("pɤː1sen1")
+
+
+def test_numbers_can_be_disabled() -> None:
+    assert not ThaiPhonemizer(expand_numbers=False).phonemize("19")
+
+
+# -----------------------------------------------------------------------------
+# Structure and robustness
+# -----------------------------------------------------------------------------
+
+
+def test_sentences_are_split_on_terminal_punctuation(
+    phonemizer: ThaiPhonemizer,
+) -> None:
+    sentences = phonemizer.phonemize("สวัสดีครับ. สบายดีไหม? ดีมาก!")
+    assert len(sentences) == 3
+    assert sentences[0][-1] == "."
+    assert sentences[1][-1] == "?"
+    assert sentences[2][-1] == "!"
+
+
+def test_empty_input(phonemizer: ThaiPhonemizer) -> None:
+    assert phonemizer.phonemize("") == []
+    assert phonemizer.phonemize("   ") == []
+
+
+def test_non_thai_becomes_a_word_break(phonemizer: ThaiPhonemizer) -> None:
+    """Latin text has no Thai pronunciation; it must not reach the id map."""
+    assert _one(phonemizer, "เขาบอกว่า OK นะ") == "kʰaw5bɔːk2waː3 na4"
+
+
+def test_no_leading_or_trailing_word_break(phonemizer: ThaiPhonemizer) -> None:
+    phonemes = phonemizer.phonemize("  สวัสดี  ")[0]
+    assert phonemes[0] != " "
+    assert phonemes[-1] != " "
+
+
+# -----------------------------------------------------------------------------
+# Piper integration
+# -----------------------------------------------------------------------------
+
+
+def test_every_phoneme_has_an_id(phonemizer: ThaiPhonemizer) -> None:
+    """The whole inventory must live in the default IPA id map, which is what
+    keeps Thai voices warmstartable from the (espeak/IPA) LibriTTS-R base."""
+    text = (
+        "ประเทศไทยมีประชากรประมาณเจ็ดสิบล้านคน "
+        "กรุงเทพมหานครเป็นเมืองหลวง "
+        "ข้าว ข่าว เขา ขาว ป่า ป้า ป๊า ป๋า"
+    )
+    for sentence in phonemizer.phonemize(text):
+        for phoneme in sentence:
+            assert phoneme in DEFAULT_PHONEME_ID_MAP, phoneme
+
+
+def test_phonemes_are_single_codepoints(phonemizer: ThaiPhonemizer) -> None:
+    """The trainer round-trips phonemes through "".join(), so a multi-character
+    phoneme would not survive being written to the cache."""
+    for sentence in phonemizer.phonemize("สวัสดีครับ วันนี้อากาศดีมาก"):
+        for phoneme in sentence:
+            assert len(phoneme) == 1, phoneme
+
+
+def test_phonemes_to_ids(phonemizer: ThaiPhonemizer) -> None:
+    ids = phonemes_to_ids(phonemizer.phonemize("สวัสดีครับ")[0])
+    assert ids
+    assert max(ids) < 256  # fits the LibriTTS-R base's num_symbols
+
+
+def test_phoneme_type_is_registered() -> None:
+    assert PhonemeType("thai") == PhonemeType.THAI


### PR DESCRIPTION
## Why

espeak-ng's Thai voice cannot be trained on. Its `th_dict` holds no lexicon (~2 KB, among the smallest in espeak-ng), so unspaced Thai is never segmented; the leading vowels เ แ โ ใ ไ are emitted in writing order rather than reordered after their consonant; no tone is ever produced; and a tone mark deletes the syllable's vowel.

The maintainer who added it said as much in [espeak-ng#757](https://github.com/espeak-ng/espeak-ng/issues/757): the phonemes and tones were copied from Shan, "many of tones are probably set wrong", and the rules are "very simple just to hear something".

Measured on the TSync2 corpus, **~11% of the tokens espeak-ng returns contain no vowel at all**:

| Input | espeak-ng `-v th` | this PR |
|---|---|---|
| ปา / ป่า / ป้า / ป๊า / ป๋า | `pˈaɜs` / `p s` / `p s` / `p s` / `p s` | `paː1` / `paː2` / `paː3` / `paː4` / `paː5` |
| ข่าว (news) / ข้าว (rice) | `kh sw` / `kh sw` | `kʰaːw2` / `kʰaːw3` |
| เขา | `ˈe5khas` | `kʰaw5` |
| กรุงเทพมหานคร | `kˌa2ɹu2nɡˌe2tha2phˌa2ma5ha2snˈa2kha2r` | `kruŋ1 tʰeːp3 ma4 haː5 na4 kʰɔːn1` |

Thai has five phonemic tones and minimal pairs are everywhere, so this is not a quality tweak — a model trained on the espeak output cannot distinguish ข้าว from ข่าว.

## What

A `ThaiPhonemizer` built on [TLTK](https://pypi.org/project/tltk/) (BSD-3-Clause), which does dictionary-based word segmentation and returns syllabified IPA with an explicit tone per syllable. Wired in as `phoneme_type=thai` at the three existing dispatch sites (`voice.py`, `train/vits/dataset.py`, `train/infer_torch.py`), in the same shape as the Hebrew and Japanese phonemizers.

Tones are emitted as the digits 1-5 (1 mid, 2 low, 3 falling, 4 high, 5 rising), one per syllable — the representation `phonemize_chinese` already uses for Mandarin. **Every symbol produced is a single codepoint that already has an id in `DEFAULT_PHONEME_ID_MAP`**, so Thai voices stay warmstartable from the IPA-based (espeak) LibriTTS-R base.

## TLTK quirks worked around

Each was found by probing rather than assumed, and each has a regression test:

- `th2ipa` raises `ValueError` on input containing spaces, Latin, or hyphens, so runs are fed one contiguous Thai run at a time. Handing it pre-segmented transcripts whole silently drops ~70% of them.
- It emits `ᴐ` (U+1D10 LATIN LETTER SMALL CAPITAL OPEN O) where it means IPA `ɔ` (U+0254). That single substitution is what lands the whole inventory inside the default id map.
- It does not read numbers — `1250` becomes the phonemes `2351` — so digits are spelled out with `unicode-rbnf` first. rbnf's zero-width joiners become real spaces because TLTK mis-segments some compounds itself (สิบเก้า returns just `si2`).
- **It returns an empty string instead of raising when it cannot segment a run.** Unspaced Thai is one run per utterance, so that silently costs the whole utterance; an empty result is now logged.

Also normalizes สระอำ typed as its two visual parts, nikhahit + sara aa, with any tone mark wedged between (`คร่ำ` as ค ร ํ ่ า). Unicode gives U+0E33 no canonical decomposition so **NFC does not repair it**, and TSync2 contains one such utterance that was otherwise lost in full — found only because of the empty-run logging above.

## Verification

Phonemized all 1,823 TSync2 utterances:

- **0 empty results**, 34,405 syllables
- 35-symbol inventory, **nothing missing from `DEFAULT_PHONEME_ID_MAP`**
- max phoneme id **145** (base allows 256)
- tone distribution mid 10,349 / low 8,122 / falling 6,714 / high 5,620 / rising 3,581, which matches natural Thai text

27 new tests (73 total) pass; black, isort, flake8, mypy clean; pylint 10.00/10. Also exercised the real `VitsDataModule` end to end — writes `phoneme_type: "thai"` into the config, caches phoneme and audio tensors, resamples correctly.

A single-speaker th_TH voice has been finetuned from the LibriTTS-R base using this path and produces intelligible Thai.

## Notes

- New `th` extra: `tltk`, `unicode-rbnf`, and `pandas` — the last because **tltk imports pandas without declaring it** (as of 1.10).
- `script/setup --th` added, and the extra is installed in CI so the Thai tests run.
- TLTK is not fast (~200-330 ms/utterance), which matters for the one-time phoneme caching pass but not for the trained model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)