### PR TITLE
README: add two telephony projects using Piper

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ People/projects using Piper:
 * [POTaTOS](https://www.youtube.com/watch?v=Dz95q6XYjwY)
 * [Narration Studio](https://github.com/phyce/Narration-Studio)
 * [Basic TTS](https://basictts.com/) - Simple online text-to-speech converter.
+* [asterisk-ai-voice-agent](https://github.com/ictinnovations/asterisk-ai-voice-agent) - Self-hosted AI voice agent for Asterisk phone calls, with Piper as the default local voice
+* [piper-tts-server](https://github.com/ictinnovations/piper-tts-server) - Paced, streaming Piper output for real-time voice pipelines (Asterisk AudioSocket, RTP, WebSocket)
 
 Bindings to use Piper in programming languages other than Python and C/C++:
 


### PR DESCRIPTION
Adds two projects to the "People/projects using Piper" list.

- asterisk-ai-voice-agent: a self-hosted AI voice agent for Asterisk phone calls. Piper is the default text-to-speech, resampled to 8 kHz and paced into 20 ms frames. MIT, on PyPI and Docker Hub.
- piper-tts-server: the pacing and caching layer from that project as a standalone library and server, for anyone driving Piper into a real-time transport. MIT, on PyPI.

Both came out of running Piper on live calls; the write-up of what bit us (voice load time, the espeak-ng lock, frame pacing) is in their READMEs. I maintain both.
