### PR TITLE
Fix/dockerfile build args

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,9 @@
 !src/piper/tashkeel/*.json
 !src/piper/tashkeel/model.onnx
 !src/piper/train/__init__.py
-
+!src/piper/train/vits/__init__.py
+!src/piper/train/vits/monotonic_align/__init__.py
+!src/piper/hebrew/*.py
 !script/setup
 !script/dev_build
 !script/package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +26,8 @@ jobs:
         run: |
           script/setup --dev --train --zh --ja --th --torch-cpu
           script/dev_build
+        shell: bash
 
       - name: Run tests
         run: script/test
+        shell: bash 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.12 AS builder
 
-ARG lang=
-
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
       build-essential cmake ninja-build git
@@ -26,7 +24,8 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 WORKDIR /app
 COPY --from=builder /app/dist/piper_tts-*linux*.whl ./dist/
 RUN WHEEL=$(ls ./dist/piper_tts-*linux*.whl) && \
-    pip3 install "$WHEEL[$(echo "${lang}" | tr -d ' ')]" 'flask>=3,<4'
+    if [ -n "${lang}" ]; then EXTRAS="http,${lang}"; else EXTRAS="http"; fi && \
+    pip3 install "$WHEEL[$EXTRAS]"
 
 COPY docker/entrypoint.sh /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12 AS builder
 
+ARG lang=
+
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
       build-essential cmake ninja-build git
@@ -17,12 +19,14 @@ RUN script/package
 
 FROM python:3.12-slim
 
+ARG lang=
+
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 WORKDIR /app
 COPY --from=builder /app/dist/piper_tts-*linux*.whl ./dist/
-RUN pip3 install ./dist/piper_tts-*linux*.whl
-RUN pip3 install 'flask>=3,<4'
+RUN WHEEL=$(ls ./dist/piper_tts-*linux*.whl) && \
+    pip3 install "$WHEEL[$(echo "${lang}" | tr -d ' ')]" 'flask>=3,<4'
 
 COPY docker/entrypoint.sh /
 

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -150,6 +150,7 @@ class PiperVoice:
             config_dict = json.load(config_file)
 
         providers: list[Union[str, tuple[str, dict[str, Any]]]]
+        session_options = onnxruntime.SessionOptions()
         if use_cuda:
             providers = [
                 (
@@ -160,6 +161,9 @@ class PiperVoice:
             _LOGGER.debug("Using CUDA")
         else:
             providers = ["CPUExecutionProvider"]
+            available_cores = len(os.sched_getaffinity(0))
+            session_options.intra_op_num_threads = available_cores
+
 
         if download_dir is None:
             download_dir = Path.cwd()
@@ -188,10 +192,7 @@ class PiperVoice:
             except ValueError as error:
                 # Tensor not found or model already patched: use it as-is.
                 _LOGGER.debug("Not patching model for alignments: %s", error)
-        available_cores = len(os.sched_getaffinity(0)) 
 
-        session_options = onnxruntime.SessionOptions()
-        session_options.intra_op_num_threads = available_cores
         return PiperVoice(
             config=PiperConfig.from_dict(config_dict),
             session=onnxruntime.InferenceSession(

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -4,6 +4,7 @@ import itertools
 import json
 import logging
 import re
+import os
 import threading
 import unicodedata
 import wave
@@ -187,12 +188,15 @@ class PiperVoice:
             except ValueError as error:
                 # Tensor not found or model already patched: use it as-is.
                 _LOGGER.debug("Not patching model for alignments: %s", error)
+        available_cores = len(os.sched_getaffinity(0)) 
 
+        session_options = onnxruntime.SessionOptions()
+        session_options.intra_op_num_threads = available_cores
         return PiperVoice(
             config=PiperConfig.from_dict(config_dict),
             session=onnxruntime.InferenceSession(
                 model_or_path,
-                sess_options=onnxruntime.SessionOptions(),
+                sess_options=session_options,
                 providers=providers,
             ),
             espeak_data_dir=Path(espeak_data_dir),

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -163,7 +163,7 @@ class PiperVoice:
             providers = ["CPUExecutionProvider"]
             try:
                 session_options.intra_op_num_threads = len(os.sched_getaffinity(0))
-            except AttributeError:
+            except (AttributeError, OSError):
                 # sched_getaffinity only available on Linux
                 pass
 

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -161,9 +161,11 @@ class PiperVoice:
             _LOGGER.debug("Using CUDA")
         else:
             providers = ["CPUExecutionProvider"]
-            available_cores = len(os.sched_getaffinity(0))
-            session_options.intra_op_num_threads = available_cores
-
+            try:
+                session_options.intra_op_num_threads = len(os.sched_getaffinity(0))
+            except AttributeError:
+                # sched_getaffinity only available on Linux
+                pass
 
         if download_dir is None:
             download_dir = Path.cwd()


### PR DESCRIPTION
## Summary

This PR includes two improvements:

### 1. Dockerfile: Add build args support for language selection

- Add `ARG lang=` to enable dynamic language dependency installation during Docker build
- Update `.dockerignore` to include `train/vits` and `hebrew` modules for multi-language support
- Optimize pip install to use language-specific wheel extras (e.g., `piper_tts[zh]`)

**Usage:**

```bash
docker build --build-arg lang=zh -t piper-tts .
```

### 2. Perf: Fix ONNX runtime thread configuration for Docker environments

- Replace fixed thread count with dynamic detection using `os.sched_getaffinity()`
- Fix potential performance degradation caused by inaccurate CPU core detection in Docker containers
- Automatically utilize all available CPU cores for inference

**Problem:**
When running Piper in Docker, the ONNX runtime may use suboptimal thread configuration because the default thread count doesn't account for Docker's CPU limits or host machine's actual core count. This can lead to reduced inference performance on multi-core systems.

```
2026-09-05 12:50:01.439558369 [E:onnxruntime:Default, env.cc:232 ThreadMain] pthread_setaffinity_np failed for thread: 11952, index: 5, mask: {5, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.
2026-09-05 12:50:01.439502875 [E:onnxruntime:Default, env.cc:232 ThreadMain] pthread_setaffinity_np failed for thread: 11947, index: 0, mask: {0, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.
2026-09-05 12:50:01.439595770 [E:onnxruntime:Default, env.cc:232 ThreadMain] pthread_setaffinity_np failed for thread: 11954, index: 7, mask: {7, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.
2026-09-05 12:50:01.439573027 [E:onnxruntime:Default, env.cc:232 ThreadMain] pthread_setaffinity_np failed for thread: 11950, index: 3, mask: {3, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.
2026-09-05 12:50:01.439601451 [E:onnxruntime:Default, env.cc:232 ThreadMain] pthread_setaffinity_np failed for thread: 11953, index: 6, mask: {6, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.
2026-09-05 12:50:01.439507974 [E:onnxruntime:Default, env.cc:232 ThreadMain] pthread_setaffinity_np failed for thread: 11948, index: 1, mask: {1, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.
2026-09-05 12:50:01.439592784 [E:onnxruntime:Default, env.cc:232 ThreadMain] pthread_setaffinity_np failed for thread: 11949, index: 2, mask: {2, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.
 * Serving Flask app 'http_server'
 * Debug mode: off
INFO:werkzeug:WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5000
 * Running on http://192.168.50.200:5000
```

**Solution:**
Use `os.sched_getaffinity()` to detect available CPU cores at runtime, ensuring optimal thread allocation regardless of the execution environment.

## Type of Change

- [x] Bug fix
- [x] Performance improvement

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed changes
- [x] No new warnings introduced