### PR TITLE
Add requests to the th extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,8 +118,11 @@ setup(
             # with "numpy.dtype size changed" on import. 1.10 leaves
             # scikit-learn unpinned. Lift the cap once tltk relaxes it.
             "tltk>=1.6.8,<1.11",
-            # tltk imports pandas but does not declare it (as of 1.10).
+            # tltk imports pandas and requests but declares neither (as of
+            # 1.10). requests is pulled in by tltk/__init__.py -> tltk.corpus,
+            # which runs even though we only use tltk.nlp.
             "pandas>=2,<3",
+            "requests>=2,<3",
             "unicode-rbnf>=2.4.0,<3",
         ],
     },


### PR DESCRIPTION
`piper.phonemize_thai` does `from tltk.nlp import th2ipa`, which first executes `tltk/__init__.py` — and that file does `from tltk import corpus`, whose module top-level has a bare `import requests`. So `requests` is required on every Thai phonemize even though we never touch tltk's corpus API.

tltk does not declare it (same situation as `pandas`, which is already worked around here), and nothing else in the `th` extra requires it unconditionally:

| dep | requires requests? |
| --- | --- |
| `nltk` | only under its `corenlp` / `all` extras |
| `smart_open` (via gensim) | only under `http` / `webhdfs` |
| `scikit-learn`, `sklearn-crfsuite`, `gensim`, `pandas` | no |

It happens to be present in most dev environments because `transformers` (the `zh` extra) pulls it in, which is why this wasn't caught — but a clean `pip install piper-tts[th]` fails at import time.

Verified by blocking `requests` from the import system with tltk 1.10 installed:

```
ModuleNotFoundError: No module named 'requests'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)