### PR TITLE
Add low-latency streaming synthesis through split VITS ONNX graphs

### DIFF
--- a/src/piper/__main__.py
+++ b/src/piper/__main__.py
@@ -87,6 +87,13 @@ def main() -> None:
     parser.add_argument(
         "--no-normalize", action="store_true", help="Don't normalize audio"
     )
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="With --output-raw: write audio in decoder chunks as they are "
+        "synthesized instead of whole sentences (requires the voice halves "
+        "from `python3 -m piper.split`; audio is not normalized)",
+    )
     #
     parser.add_argument(
         "--data-dir",
@@ -100,6 +107,8 @@ def main() -> None:
         "--debug", action="store_true", help="Print DEBUG messages to console"
     )
     args, unknown_args = parser.parse_known_args()
+    if args.stream and not args.output_raw:
+        parser.error("--stream requires --output-raw")
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
     _LOGGER.debug(args)
 
@@ -146,7 +155,7 @@ def main() -> None:
 
     # Load voice
     _LOGGER.debug("Loading voice: '%s'", model_path)
-    voice = PiperVoice.load(model_path, use_cuda=args.cuda)
+    voice = PiperVoice.load(model_path, use_cuda=args.cuda, streaming=args.stream)
     syn_config = SynthesisConfig(
         speaker_id=args.speaker,
         length_scale=args.length_scale,
@@ -184,6 +193,15 @@ def main() -> None:
     if args.output_raw:
         # Write raw audio to stdout as its produced
         for line in lines():
+            if args.stream:
+                # Decoder chunks as they decode (see piper.split); sentence
+                # boundaries are not visible here, so no inter-sentence silence.
+                for audio_chunk in voice.synthesize_stream(line, syn_config):
+                    sys.stdout.buffer.write(audio_chunk.audio_int16_bytes)
+                    sys.stdout.buffer.flush()
+
+                continue
+
             audio_stream = voice.synthesize(line, syn_config)
             for i, audio_chunk in enumerate(audio_stream):
                 if i > 0:

--- a/src/piper/split.py
+++ b/src/piper/split.py
@@ -29,12 +29,14 @@ _LOGGER = logging.getLogger(__name__)
 _DECODER_PREFIX = "/dec/"
 
 
-def find_decoder_input(model) -> str:
+def find_decoder_inputs(model) -> list:
     """
-    Find the one tensor that crosses from the encoder side into the decoder.
+    Find the tensors that cross from the encoder side into the decoder — the
+    masked latent z FIRST, then any conditioning (a multi-speaker voice also
+    feeds the decoder its speaker embedding).
 
     :param model: Loaded ONNX ModelProto of a Piper VITS voice.
-    :return: Name of the boundary tensor (the masked latent z).
+    :return: Boundary tensor names, the latent first.
     """
     graph = model.graph
     producers = {
@@ -62,12 +64,14 @@ def find_decoder_input(model) -> str:
             ):
                 boundary.add(input_name)
 
-    if len(boundary) != 1:
-        raise ValueError(
-            f"Expected exactly one tensor crossing into the decoder, found: {boundary}"
-        )
+    conv_pre = next(
+        node for node in decoder_nodes if node.op_type == "Conv"
+    )
+    z_name = conv_pre.input[0]
+    if z_name not in boundary:
+        raise ValueError(f"Decoder input conv feeds from {z_name}, not a boundary?")
 
-    return boundary.pop()
+    return [z_name] + sorted(boundary - {z_name})
 
 
 def split_voice(
@@ -99,10 +103,12 @@ def split_voice(
     dec_path = output_dir / model_path.with_suffix(".dec.onnx").name
 
     model = onnx.load(str(model_path))
-    z_name = find_decoder_input(model)
+    boundaries = find_decoder_inputs(model)
+    _LOGGER.debug("Decoder boundary tensors: %s", boundaries)
 
-    # conv_pre's weight gives the latent channel count for the boundary's
-    # value_info (older exports never ran shape inference over it).
+    # The boundary tensors need value_info entries for the Extractor (older
+    # exports never ran shape inference over them). The latent's channel
+    # count comes from conv_pre's weight; conditioning shapes stay symbolic.
     conv_pre = next(
         node
         for node in model.graph.node
@@ -114,19 +120,22 @@ def split_voice(
         if tensor.name == conv_pre.input[1]
     )
     z_channels = conv_pre_weight.dims[1]
-    _LOGGER.debug("Boundary %s, %s latent channels", z_name, z_channels)
-
-    if not any(vi.name == z_name for vi in model.graph.value_info):
-        model.graph.value_info.append(
-            helper.make_tensor_value_info(
-                z_name, TensorProto.FLOAT, ["batch_size", z_channels, "z_time"]
+    known = {vi.name for vi in model.graph.value_info}
+    for name in boundaries:
+        if name in known:
+            continue
+        if name == boundaries[0]:
+            vi = helper.make_tensor_value_info(
+                name, TensorProto.FLOAT, ["batch_size", z_channels, "z_time"]
             )
-        )
+        else:
+            vi = helper.make_tensor_value_info(name, TensorProto.FLOAT, None)
+        model.graph.value_info.append(vi)
 
     extractor = onnx.utils.Extractor(model)
     graph_inputs = [graph_input.name for graph_input in model.graph.input]
-    encoder = extractor.extract_model(graph_inputs, [z_name])
-    decoder = extractor.extract_model([z_name], ["output"])
+    encoder = extractor.extract_model(graph_inputs, boundaries)
+    decoder = extractor.extract_model(boundaries, ["output"])
 
     onnx.save(encoder, str(enc_path))
     onnx.save(decoder, str(dec_path))

--- a/src/piper/split.py
+++ b/src/piper/split.py
@@ -1,0 +1,160 @@
+"""Split a VITS voice model for streaming synthesis.
+
+A Piper voice is exported as a single ONNX graph: the text encoder, duration
+predictor, and flow (which must see the whole utterance -- prosody is global)
+followed by the HiFi-GAN decoder that turns latent frames into waveform
+samples. The decoder dominates inference time but is a pure convolutional
+network with a finite receptive field, so it can be run in overlapped chunks
+whose interiors match the monolithic output exactly -- audio can start
+playing after the first chunk instead of after the whole utterance.
+
+This module splits a voice at the single tensor that crosses into the
+decoder (the masked latent feeding the decoder's input convolution), writing
+``<voice>.enc.onnx`` and ``<voice>.dec.onnx`` next to the original.
+``PiperVoice.load(..., streaming=True)`` picks them up for
+``synthesize_stream()``.
+
+Splitting requires the ``onnx`` package (synthesis does not):
+
+    python3 -m piper.split /path/to/voice.onnx
+"""
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Tuple, Union
+
+_LOGGER = logging.getLogger(__name__)
+
+_DECODER_PREFIX = "/dec/"
+
+
+def find_decoder_input(model) -> str:
+    """
+    Find the one tensor that crosses from the encoder side into the decoder.
+
+    :param model: Loaded ONNX ModelProto of a Piper VITS voice.
+    :return: Name of the boundary tensor (the masked latent z).
+    """
+    graph = model.graph
+    producers = {
+        output: node for node in graph.node for output in node.output
+    }
+    initializers = {tensor.name for tensor in graph.initializer}
+
+    decoder_nodes = [
+        node for node in graph.node if node.name.startswith(_DECODER_PREFIX)
+    ]
+    if not decoder_nodes:
+        raise ValueError(
+            f"No {_DECODER_PREFIX} nodes in graph: not a Piper VITS export?"
+        )
+
+    boundary = set()
+    for node in decoder_nodes:
+        for input_name in node.input:
+            if (not input_name) or (input_name in initializers):
+                continue
+
+            producer = producers.get(input_name)
+            if (producer is not None) and (
+                not producer.name.startswith(_DECODER_PREFIX)
+            ):
+                boundary.add(input_name)
+
+    if len(boundary) != 1:
+        raise ValueError(
+            f"Expected exactly one tensor crossing into the decoder, found: {boundary}"
+        )
+
+    return boundary.pop()
+
+
+def split_voice(
+    model_path: Union[str, Path],
+    output_dir: Union[str, Path, None] = None,
+) -> Tuple[Path, Path]:
+    """
+    Split a voice model into encoder and decoder halves for streaming.
+
+    :param model_path: Path to voice ONNX file.
+    :param output_dir: Directory for the halves (default: next to the voice).
+    :return: Paths of (encoder, decoder) ONNX files.
+    """
+    try:
+        import onnx
+        import onnx.utils
+        from onnx import TensorProto, helper
+    except ImportError as err:
+        raise ImportError(
+            "Splitting requires the onnx package: pip install onnx"
+        ) from err
+
+    model_path = Path(model_path)
+    if output_dir is None:
+        output_dir = model_path.parent
+
+    output_dir = Path(output_dir)
+    enc_path = output_dir / model_path.with_suffix(".enc.onnx").name
+    dec_path = output_dir / model_path.with_suffix(".dec.onnx").name
+
+    model = onnx.load(str(model_path))
+    z_name = find_decoder_input(model)
+
+    # conv_pre's weight gives the latent channel count for the boundary's
+    # value_info (older exports never ran shape inference over it).
+    conv_pre = next(
+        node
+        for node in model.graph.node
+        if node.name.startswith(_DECODER_PREFIX) and node.op_type == "Conv"
+    )
+    conv_pre_weight = next(
+        tensor
+        for tensor in model.graph.initializer
+        if tensor.name == conv_pre.input[1]
+    )
+    z_channels = conv_pre_weight.dims[1]
+    _LOGGER.debug("Boundary %s, %s latent channels", z_name, z_channels)
+
+    if not any(vi.name == z_name for vi in model.graph.value_info):
+        model.graph.value_info.append(
+            helper.make_tensor_value_info(
+                z_name, TensorProto.FLOAT, ["batch_size", z_channels, "z_time"]
+            )
+        )
+
+    extractor = onnx.utils.Extractor(model)
+    graph_inputs = [graph_input.name for graph_input in model.graph.input]
+    encoder = extractor.extract_model(graph_inputs, [z_name])
+    decoder = extractor.extract_model([z_name], ["output"])
+
+    onnx.save(encoder, str(enc_path))
+    onnx.save(decoder, str(dec_path))
+
+    return enc_path, dec_path
+
+
+def main() -> None:
+    """Split voices for streaming synthesis."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model", nargs="+", help="Path to voice ONNX file(s)")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        "--output_dir",
+        help="Directory for the split halves (default: next to each voice)",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Print DEBUG messages to console"
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    for model in args.model:
+        enc_path, dec_path = split_voice(model, args.output_dir)
+        print(enc_path)
+        print(dec_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -98,6 +98,43 @@ class AudioChunk:
         return self.audio_int16_array.tobytes()
 
 
+def _iter_decoded_chunks(
+    dec_session: onnxruntime.InferenceSession,
+    z: np.ndarray,
+    chunk_frames: int,
+    overlap_frames: int,
+) -> Iterable[np.ndarray]:
+    """
+    Run the decoder half over latent chunks, yielding audio as it decodes.
+
+    Each chunk is decoded with overlap_frames of latent context on both
+    sides; the context samples are cropped from the output, so as long as the
+    overlap covers the decoder's receptive field the concatenated audio is
+    exactly the monolithic decode.
+
+    :param dec_session: ONNX session for the <voice>.dec.onnx half.
+    :param z: Masked latent from the encoder half, shape (1, channels, frames).
+    :param chunk_frames: Latent frames per emitted chunk.
+    :param overlap_frames: Latent frames of cropped context on each side.
+    """
+    z_name = dec_session.get_inputs()[0].name
+    num_frames = z.shape[2]
+    hop: Optional[int] = None
+    for start in range(0, num_frames, chunk_frames):
+        end = min(start + chunk_frames, num_frames)
+        ctx_start = max(0, start - overlap_frames)
+        ctx_end = min(num_frames, end + overlap_frames)
+        audio = dec_session.run(
+            ["output"], {z_name: z[:, :, ctx_start:ctx_end]}
+        )[0].reshape(-1)
+        if hop is None:
+            hop = audio.shape[0] // (ctx_end - ctx_start)
+
+        yield audio[
+            (start - ctx_start) * hop: audio.shape[0] - (ctx_end - end) * hop
+        ]
+
+
 @dataclass
 class PiperVoice:
     """A voice for Piper."""
@@ -119,6 +156,10 @@ class PiperVoice:
     tashkeel_diacritizier: Optional[TashkeelDiacritizer] = None
     taskeen_threshold: Optional[float] = 0.8
 
+    # Encoder/decoder halves for synthesize_stream (see piper.split)
+    enc_session: Optional[onnxruntime.InferenceSession] = None
+    dec_session: Optional[onnxruntime.InferenceSession] = None
+
     @staticmethod
     def load(
         model_path: Union[str, Path],
@@ -127,6 +168,7 @@ class PiperVoice:
         espeak_data_dir: Union[str, Path] = ESPEAK_DATA_DIR,
         download_dir: Optional[Union[str, Path]] = None,
         include_alignments: bool = False,
+        streaming: bool = False,
     ) -> "PiperVoice":
         """
         Load an ONNX model and config.
@@ -139,6 +181,9 @@ class PiperVoice:
         :param include_alignments: If True, patch the model in memory (requires the
             onnx package) so phoneme/audio alignments are available even if the model
             file has not been patched with piper.patch_voice_with_alignment.
+        :param streaming: If True, also load the <voice>.enc.onnx/<voice>.dec.onnx
+            halves written by `python3 -m piper.split` so synthesize_stream() can
+            emit audio in decoder chunks.
         :return: Voice object.
         """
         if config_path is None:
@@ -188,6 +233,28 @@ class PiperVoice:
                 # Tensor not found or model already patched: use it as-is.
                 _LOGGER.debug("Not patching model for alignments: %s", error)
 
+        enc_session: Optional[onnxruntime.InferenceSession] = None
+        dec_session: Optional[onnxruntime.InferenceSession] = None
+        if streaming:
+            enc_path = Path(model_path).with_suffix(".enc.onnx")
+            dec_path = Path(model_path).with_suffix(".dec.onnx")
+            if not (enc_path.exists() and dec_path.exists()):
+                raise FileNotFoundError(
+                    f"Streaming needs {enc_path.name} and {dec_path.name}: "
+                    f"run `python3 -m piper.split {model_path}` once"
+                )
+
+            enc_session = onnxruntime.InferenceSession(
+                str(enc_path),
+                sess_options=onnxruntime.SessionOptions(),
+                providers=providers,
+            )
+            dec_session = onnxruntime.InferenceSession(
+                str(dec_path),
+                sess_options=onnxruntime.SessionOptions(),
+                providers=providers,
+            )
+
         return PiperVoice(
             config=PiperConfig.from_dict(config_dict),
             session=onnxruntime.InferenceSession(
@@ -197,6 +264,8 @@ class PiperVoice:
             ),
             espeak_data_dir=Path(espeak_data_dir),
             download_dir=Path(download_dir),
+            enc_session=enc_session,
+            dec_session=dec_session,
         )
 
     def phonemize(self, text: str) -> list[list[str]]:
@@ -440,6 +509,104 @@ class PiperVoice:
                 phoneme_id_samples=phoneme_id_samples,
                 phoneme_alignments=phoneme_alignments,
             )
+
+    def synthesize_stream(
+        self,
+        text: str,
+        syn_config: Optional[SynthesisConfig] = None,
+        chunk_frames: int = 10,
+        overlap_frames: int = 16,
+    ) -> Iterable[AudioChunk]:
+        """
+        Synthesize audio in decoder chunks instead of whole sentences.
+
+        The first chunk is available after the encoder pass plus one small
+        decoder call, so playback can begin while the rest of the sentence is
+        still being synthesized. Requires the voice halves written by
+        `python3 -m piper.split` and loaded with load(..., streaming=True).
+
+        Chunk interiors are exact: the decoder's receptive field is covered
+        by overlap_frames of context on each side, which are cropped from the
+        output (the default of 16 saturates for released Piper voices).
+
+        Audio is NOT peak-normalized (normalization needs the whole
+        sentence); syn_config.volume still applies.
+
+        :param text: Text to synthesize.
+        :param syn_config: Synthesis configuration.
+        :param chunk_frames: Latent frames per emitted chunk
+            (chunk_frames * hop_length samples of audio).
+        :param overlap_frames: Latent frames of context decoded on each side
+            of a chunk and cropped from the output.
+        """
+        if (self.enc_session is None) or (self.dec_session is None):
+            raise RuntimeError(
+                "Streaming synthesis needs PiperVoice.load(..., streaming=True)"
+            )
+
+        if syn_config is None:
+            syn_config = _DEFAULT_SYNTHESIS_CONFIG
+
+        if syn_config.normalize_audio:
+            _LOGGER.debug("Streaming synthesis does not normalize audio")
+
+        speaker_id = syn_config.speaker_id
+        length_scale = syn_config.length_scale
+        noise_scale = syn_config.noise_scale
+        noise_w_scale = syn_config.noise_w_scale
+
+        if length_scale is None:
+            length_scale = self.config.length_scale
+
+        if noise_scale is None:
+            noise_scale = self.config.noise_scale
+
+        if noise_w_scale is None:
+            noise_w_scale = self.config.noise_w_scale
+
+        z_name = self.enc_session.get_outputs()[0].name
+        for phonemes in self.phonemize(text):
+            if not phonemes:
+                continue
+
+            phoneme_ids = self.phonemes_to_ids(phonemes)
+            phoneme_ids_array = np.expand_dims(
+                np.array(phoneme_ids, dtype=np.int64), 0
+            )
+            args = {
+                "input": phoneme_ids_array,
+                "input_lengths": np.array(
+                    [phoneme_ids_array.shape[1]], dtype=np.int64
+                ),
+                "scales": np.array(
+                    [noise_scale, length_scale, noise_w_scale], dtype=np.float32
+                ),
+            }
+
+            if (self.config.num_speakers > 1) and (speaker_id is None):
+                # Default speaker
+                speaker_id = 0
+
+            if (self.config.num_speakers > 1) and (speaker_id is not None):
+                args["sid"] = np.array([speaker_id], dtype=np.int64)
+
+            z = self.enc_session.run([z_name], args)[0]
+            for audio in _iter_decoded_chunks(
+                self.dec_session, z, chunk_frames, overlap_frames
+            ):
+                if syn_config.volume != 1.0:
+                    audio = audio * syn_config.volume
+
+                yield AudioChunk(
+                    sample_rate=self.config.sample_rate,
+                    sample_width=2,
+                    sample_channels=1,
+                    audio_float_array=np.clip(audio, -1.0, 1.0).astype(
+                        np.float32
+                    ),
+                    phonemes=phonemes,
+                    phoneme_ids=phoneme_ids,
+                )
 
     def synthesize_wav(
         self,

--- a/src/piper/voice.py
+++ b/src/piper/voice.py
@@ -103,6 +103,7 @@ def _iter_decoded_chunks(
     z: np.ndarray,
     chunk_frames: int,
     overlap_frames: int,
+    conditioning: Optional[dict] = None,
 ) -> Iterable[np.ndarray]:
     """
     Run the decoder half over latent chunks, yielding audio as it decodes.
@@ -116,6 +117,9 @@ def _iter_decoded_chunks(
     :param z: Masked latent from the encoder half, shape (1, channels, frames).
     :param chunk_frames: Latent frames per emitted chunk.
     :param overlap_frames: Latent frames of cropped context on each side.
+    :param conditioning: Time-independent decoder inputs passed whole to every
+        chunk (a multi-speaker voice conditions its decoder on the speaker
+        embedding).
     """
     z_name = dec_session.get_inputs()[0].name
     num_frames = z.shape[2]
@@ -124,9 +128,10 @@ def _iter_decoded_chunks(
         end = min(start + chunk_frames, num_frames)
         ctx_start = max(0, start - overlap_frames)
         ctx_end = min(num_frames, end + overlap_frames)
-        audio = dec_session.run(
-            ["output"], {z_name: z[:, :, ctx_start:ctx_end]}
-        )[0].reshape(-1)
+        feed = {z_name: z[:, :, ctx_start:ctx_end]}
+        if conditioning:
+            feed.update(conditioning)
+        audio = dec_session.run(["output"], feed)[0].reshape(-1)
         if hop is None:
             hop = audio.shape[0] // (ctx_end - ctx_start)
 
@@ -564,7 +569,8 @@ class PiperVoice:
         if noise_w_scale is None:
             noise_w_scale = self.config.noise_w_scale
 
-        z_name = self.enc_session.get_outputs()[0].name
+        enc_outputs = [o.name for o in self.enc_session.get_outputs()]
+        dec_inputs = [i.name for i in self.dec_session.get_inputs()]
         for phonemes in self.phonemize(text):
             if not phonemes:
                 continue
@@ -590,9 +596,15 @@ class PiperVoice:
             if (self.config.num_speakers > 1) and (speaker_id is not None):
                 args["sid"] = np.array([speaker_id], dtype=np.int64)
 
-            z = self.enc_session.run([z_name], args)[0]
+            # The decoder half's inputs come from the encoder by name: the
+            # latent first (chunked along time), then any conditioning a
+            # multi-speaker decoder wants whole (the speaker embedding).
+            result = self.enc_session.run(enc_outputs, args)
+            by_name = dict(zip(enc_outputs, result))
+            z = by_name[dec_inputs[0]]
+            conditioning = {n: by_name[n] for n in dec_inputs[1:] if n in by_name}
             for audio in _iter_decoded_chunks(
-                self.dec_session, z, chunk_frames, overlap_frames
+                self.dec_session, z, chunk_frames, overlap_frames, conditioning
             ):
                 if syn_config.volume != 1.0:
                     audio = audio * syn_config.volume

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -4,9 +4,10 @@ Piper voices are not bundled with the repo, so these tests build a miniature
 VITS-shaped ONNX model by hand: a trivial "encoder" producing a latent, and a
 convolutional "decoder" under the /dec/ namespace with a real receptive field
 (Conv -> ConvTranspose upsampler -> Conv), mirroring how a torch export names
-a `self.dec` submodule. That is enough to exercise the boundary finder, the
-split, and the exactness of overlapped-chunk decoding against the monolithic
-output.
+a `self.dec` submodule. The conditioned variant adds what a multi-speaker
+voice has: a speaker embedding crossing into the decoder as a second boundary
+tensor. That is enough to exercise the boundary finder, the split, and the
+exactness of overlapped-chunk decoding against the monolithic output.
 """
 
 from pathlib import Path
@@ -17,7 +18,7 @@ import onnxruntime
 import pytest
 from onnx import TensorProto, helper, numpy_helper
 
-from piper.split import find_decoder_input, split_voice
+from piper.split import find_decoder_inputs, split_voice
 from piper.voice import _iter_decoded_chunks
 
 _CHANNELS = 8
@@ -25,8 +26,10 @@ _HIDDEN = 16
 _UPSAMPLE = 4  # hop: samples per latent frame
 
 
-def _make_vits_like_model(path: Path) -> None:
-    """Build input -> /flow/Mul -> /dec/ conv stack -> output."""
+def _make_vits_like_model(path: Path, conditioned: bool = False) -> None:
+    """Build input -> /flow/Mul -> /dec/ conv stack -> output; with
+    conditioned=True a speaker-embedding-like tensor also crosses into the
+    decoder (broadcast-added after conv_pre), as in multi-speaker voices."""
     rng = np.random.default_rng(0)
 
     def weight(name, *shape):
@@ -34,6 +37,7 @@ def _make_vits_like_model(path: Path) -> None:
             rng.standard_normal(shape).astype(np.float32) * 0.3, name
         )
 
+    up_input = "/dec/conv_pre/Conv_output_0"
     nodes = [
         helper.make_node(
             "Mul", ["input", "one"], ["/flow/Mul_output_0"], name="/flow/Mul"
@@ -45,9 +49,37 @@ def _make_vits_like_model(path: Path) -> None:
             name="/dec/conv_pre/Conv",
             pads=[3, 3],
         ),
+    ]
+    inputs = [
+        helper.make_tensor_value_info(
+            "input", TensorProto.FLOAT, ["batch_size", _CHANNELS, "frames"]
+        )
+    ]
+    if conditioned:
+        inputs.append(
+            helper.make_tensor_value_info(
+                "g", TensorProto.FLOAT, ["batch_size", _HIDDEN, 1]
+            )
+        )
+        nodes.append(
+            helper.make_node(
+                "Mul", ["g", "one"], ["/spk/Mul_output_0"], name="/spk/Mul"
+            )
+        )
+        nodes.append(
+            helper.make_node(
+                "Add",
+                ["/dec/conv_pre/Conv_output_0", "/spk/Mul_output_0"],
+                ["/dec/cond/Add_output_0"],
+                name="/dec/cond/Add",
+            )
+        )
+        up_input = "/dec/cond/Add_output_0"
+
+    nodes += [
         helper.make_node(
             "ConvTranspose",
-            ["/dec/conv_pre/Conv_output_0", "dec.ups.0.weight", "dec.ups.0.bias"],
+            [up_input, "dec.ups.0.weight", "dec.ups.0.bias"],
             ["/dec/ups.0/ConvTranspose_output_0"],
             name="/dec/ups.0/ConvTranspose",
             kernel_shape=[8],
@@ -75,11 +107,7 @@ def _make_vits_like_model(path: Path) -> None:
     graph = helper.make_graph(
         nodes,
         "vits_like",
-        inputs=[
-            helper.make_tensor_value_info(
-                "input", TensorProto.FLOAT, ["batch_size", _CHANNELS, "frames"]
-            )
-        ],
+        inputs=inputs,
         outputs=[
             helper.make_tensor_value_info(
                 "output", TensorProto.FLOAT, ["batch_size", 1, "samples"]
@@ -102,14 +130,20 @@ def _make_vits_like_model(path: Path) -> None:
     onnx.save(model, str(path))
 
 
-def test_find_decoder_input(tmp_path: Path) -> None:
-    """The single tensor crossing into /dec/ is found."""
+def test_find_decoder_inputs(tmp_path: Path) -> None:
+    """The tensors crossing into /dec/ are found, the latent first."""
     model_path = tmp_path / "voice.onnx"
     _make_vits_like_model(model_path)
-    assert find_decoder_input(onnx.load(str(model_path))) == "/flow/Mul_output_0"
+    assert find_decoder_inputs(onnx.load(str(model_path))) == ["/flow/Mul_output_0"]
+
+    _make_vits_like_model(model_path, conditioned=True)
+    assert find_decoder_inputs(onnx.load(str(model_path))) == [
+        "/flow/Mul_output_0",
+        "/spk/Mul_output_0",
+    ]
 
 
-def test_find_decoder_input_requires_dec(tmp_path: Path) -> None:
+def test_find_decoder_inputs_requires_dec(tmp_path: Path) -> None:
     """A graph without a /dec/ namespace is rejected."""
     graph = helper.make_graph(
         [helper.make_node("Identity", ["input"], ["output"], name="/enc/Identity")],
@@ -119,7 +153,7 @@ def test_find_decoder_input_requires_dec(tmp_path: Path) -> None:
     )
     model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 15)])
     with pytest.raises(ValueError):
-        find_decoder_input(model)
+        find_decoder_inputs(model)
 
 
 def test_split_and_chunked_decode_exact(tmp_path: Path) -> None:
@@ -157,3 +191,50 @@ def test_split_and_chunked_decode_exact(tmp_path: Path) -> None:
     # too little overlap must NOT match: proves the test can fail
     audio_bad = np.concatenate(list(_iter_decoded_chunks(dec_session, latent, 7, 0)))
     assert not np.allclose(audio_bad, reference, atol=1e-6)
+
+
+def test_conditioned_split_and_chunked_decode(tmp_path: Path) -> None:
+    """A multi-speaker-shaped voice: the speaker embedding crosses into the
+    decoder as a second boundary, is carried by the encoder half, and is fed
+    whole to every chunk — chunked still equals monolithic."""
+    model_path = tmp_path / "voice.onnx"
+    _make_vits_like_model(model_path, conditioned=True)
+    enc_path, dec_path = split_voice(model_path)
+
+    enc_session = onnxruntime.InferenceSession(
+        str(enc_path), providers=["CPUExecutionProvider"]
+    )
+    dec_session = onnxruntime.InferenceSession(
+        str(dec_path), providers=["CPUExecutionProvider"]
+    )
+
+    rng = np.random.default_rng(2)
+    z = rng.standard_normal((1, _CHANNELS, 64)).astype(np.float32)
+    g = rng.standard_normal((1, _HIDDEN, 1)).astype(np.float32)
+
+    enc_outputs = [o.name for o in enc_session.get_outputs()]
+    dec_inputs = [i.name for i in dec_session.get_inputs()]
+    assert dec_inputs == ["/flow/Mul_output_0", "/spk/Mul_output_0"]
+
+    by_name = dict(zip(enc_outputs, enc_session.run(enc_outputs, {"input": z, "g": g})))
+    latent = by_name[dec_inputs[0]]
+    conditioning = {n: by_name[n] for n in dec_inputs[1:]}
+
+    reference = dec_session.run(
+        ["output"], dict({dec_inputs[0]: latent}, **conditioning)
+    )[0].reshape(-1)
+    audio = np.concatenate(
+        list(_iter_decoded_chunks(dec_session, latent, 7, 8, conditioning))
+    )
+    assert audio.shape == reference.shape
+    assert np.allclose(audio, reference, atol=1e-6)
+
+    # the conditioning matters: a different speaker embedding changes the audio
+    other = dict(
+        zip(enc_outputs, enc_session.run(enc_outputs, {"input": z, "g": g + 1.0}))
+    )
+    changed = dec_session.run(
+        ["output"],
+        {dec_inputs[0]: other[dec_inputs[0]], dec_inputs[1]: other[dec_inputs[1]]},
+    )[0].reshape(-1)
+    assert not np.allclose(changed, reference, atol=1e-3)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,159 @@
+"""Tests for piper.split and streaming (chunked) decoding.
+
+Piper voices are not bundled with the repo, so these tests build a miniature
+VITS-shaped ONNX model by hand: a trivial "encoder" producing a latent, and a
+convolutional "decoder" under the /dec/ namespace with a real receptive field
+(Conv -> ConvTranspose upsampler -> Conv), mirroring how a torch export names
+a `self.dec` submodule. That is enough to exercise the boundary finder, the
+split, and the exactness of overlapped-chunk decoding against the monolithic
+output.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnxruntime
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+
+from piper.split import find_decoder_input, split_voice
+from piper.voice import _iter_decoded_chunks
+
+_CHANNELS = 8
+_HIDDEN = 16
+_UPSAMPLE = 4  # hop: samples per latent frame
+
+
+def _make_vits_like_model(path: Path) -> None:
+    """Build input -> /flow/Mul -> /dec/ conv stack -> output."""
+    rng = np.random.default_rng(0)
+
+    def weight(name, *shape):
+        return numpy_helper.from_array(
+            rng.standard_normal(shape).astype(np.float32) * 0.3, name
+        )
+
+    nodes = [
+        helper.make_node(
+            "Mul", ["input", "one"], ["/flow/Mul_output_0"], name="/flow/Mul"
+        ),
+        helper.make_node(
+            "Conv",
+            ["/flow/Mul_output_0", "dec.conv_pre.weight", "dec.conv_pre.bias"],
+            ["/dec/conv_pre/Conv_output_0"],
+            name="/dec/conv_pre/Conv",
+            pads=[3, 3],
+        ),
+        helper.make_node(
+            "ConvTranspose",
+            ["/dec/conv_pre/Conv_output_0", "dec.ups.0.weight", "dec.ups.0.bias"],
+            ["/dec/ups.0/ConvTranspose_output_0"],
+            name="/dec/ups.0/ConvTranspose",
+            kernel_shape=[8],
+            strides=[_UPSAMPLE],
+            pads=[2, 2],
+        ),
+        helper.make_node(
+            "LeakyRelu",
+            ["/dec/ups.0/ConvTranspose_output_0"],
+            ["/dec/LeakyRelu_output_0"],
+            name="/dec/LeakyRelu",
+            alpha=0.1,
+        ),
+        helper.make_node(
+            "Conv",
+            ["/dec/LeakyRelu_output_0", "dec.conv_post.weight", "dec.conv_post.bias"],
+            ["/dec/conv_post/Conv_output_0"],
+            name="/dec/conv_post/Conv",
+            pads=[3, 3],
+        ),
+        helper.make_node(
+            "Tanh", ["/dec/conv_post/Conv_output_0"], ["output"], name="/dec/Tanh"
+        ),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "vits_like",
+        inputs=[
+            helper.make_tensor_value_info(
+                "input", TensorProto.FLOAT, ["batch_size", _CHANNELS, "frames"]
+            )
+        ],
+        outputs=[
+            helper.make_tensor_value_info(
+                "output", TensorProto.FLOAT, ["batch_size", 1, "samples"]
+            )
+        ],
+        initializer=[
+            numpy_helper.from_array(np.float32(1.0), "one"),
+            weight("dec.conv_pre.weight", _HIDDEN, _CHANNELS, 7),
+            weight("dec.conv_pre.bias", _HIDDEN),
+            weight("dec.ups.0.weight", _HIDDEN, _HIDDEN, 8),
+            weight("dec.ups.0.bias", _HIDDEN),
+            weight("dec.conv_post.weight", 1, _HIDDEN, 7),
+            weight("dec.conv_post.bias", 1),
+        ],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 15)]
+    )
+    model.ir_version = 8
+    onnx.save(model, str(path))
+
+
+def test_find_decoder_input(tmp_path: Path) -> None:
+    """The single tensor crossing into /dec/ is found."""
+    model_path = tmp_path / "voice.onnx"
+    _make_vits_like_model(model_path)
+    assert find_decoder_input(onnx.load(str(model_path))) == "/flow/Mul_output_0"
+
+
+def test_find_decoder_input_requires_dec(tmp_path: Path) -> None:
+    """A graph without a /dec/ namespace is rejected."""
+    graph = helper.make_graph(
+        [helper.make_node("Identity", ["input"], ["output"], name="/enc/Identity")],
+        "no_dec",
+        inputs=[helper.make_tensor_value_info("input", TensorProto.FLOAT, [1])],
+        outputs=[helper.make_tensor_value_info("output", TensorProto.FLOAT, [1])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 15)])
+    with pytest.raises(ValueError):
+        find_decoder_input(model)
+
+
+def test_split_and_chunked_decode_exact(tmp_path: Path) -> None:
+    """Chunked decoding with enough overlap equals the monolithic decode."""
+    model_path = tmp_path / "voice.onnx"
+    _make_vits_like_model(model_path)
+    enc_path, dec_path = split_voice(model_path)
+    assert enc_path == tmp_path / "voice.enc.onnx"
+    assert dec_path == tmp_path / "voice.dec.onnx"
+
+    rng = np.random.default_rng(1)
+    z = rng.standard_normal((1, _CHANNELS, 64)).astype(np.float32)
+
+    enc_session = onnxruntime.InferenceSession(
+        str(enc_path), providers=["CPUExecutionProvider"]
+    )
+    dec_session = onnxruntime.InferenceSession(
+        str(dec_path), providers=["CPUExecutionProvider"]
+    )
+
+    # enc half reproduces the boundary tensor
+    z_name = enc_session.get_outputs()[0].name
+    latent = enc_session.run([z_name], {"input": z})[0]
+    assert np.array_equal(latent, z)  # the mini "flow" is Mul by 1.0
+
+    reference = dec_session.run(["output"], {z_name: latent})[0].reshape(-1)
+    assert reference.shape[0] == 64 * _UPSAMPLE
+
+    # uneven chunk size on purpose: exercises the final short chunk
+    chunks = list(_iter_decoded_chunks(dec_session, latent, 7, 8))
+    audio = np.concatenate(chunks)
+    assert audio.shape == reference.shape
+    assert np.allclose(audio, reference, atol=1e-6)
+
+    # too little overlap must NOT match: proves the test can fail
+    audio_bad = np.concatenate(list(_iter_decoded_chunks(dec_session, latent, 7, 0)))
+    assert not np.allclose(audio_bad, reference, atol=1e-6)


### PR DESCRIPTION
Piper currently generates the complete waveform for each sentence before returning audio. For 
interactive applications, this makes playback wait even when only the beginning of the response 
is needed.

This PR adds an opt-in execution path that separates an existing VITS ONNX model into two graphs:

  - Encoder: text encoding, duration prediction, and flow run over the complete sentence, retaining its
    global context and prosody.

  - Decoder: the waveform generator runs over small, overlapping chunks of the resulting latent
    sequence. Overlap supplies the decoder’s surrounding context and is cropped before emitting audio.

  Playback can therefore begin after the encoder pass and the first decoder chunk, while subsequent
  chunks are synthesized. This changes how the existing model executes; it requires neither retraining
  nor new voice weights. Multi-speaker conditioning is preserved and supplied to every decoder chunk.

  Run python -m piper.split voice.onnx once to generate the encoder and decoder files. Applications can
  then use PiperVoice.load(..., streaming=True) with synthesize_stream(), or the CLI’s --output-raw
  --stream options. Existing synthesis remains the default.

  In an illustrative local CPU test with Lessac and a roughly 12-second sentence, time to first audio
  decreased from 296 ms to 137 ms. The streaming path returned approximately 116 ms of audio initially
  instead of waiting for the full sentence. This targets playback latency, not necessarily total
  synthesis speed: overlapping chunks introduce additional decoding work.

  The encoder still requires the complete sentence, so this is waveform streaming rather than
  incremental text input. Streaming also omits whole-sentence peak normalization, while retaining volume
  control.

  Tests cover graph splitting, speaker conditioning, and agreement between concatenated chunks and full
  decoding within floating-point tolerance. An insufficient-overlap case verifies that the comparison
  detects boundary errors.

  ## Video demonstration: 
  https://www.reddit.com/r/LocalLLaMA/s/glCB6GlsXy
  https://youtube.com/shorts/M9To7wqjkF4?si=30cTGM_o0TJzevTY

  ## Usage:

  ```
from time import perf_counter
  from piper import PiperVoice, SynthesisConfig

  voice = PiperVoice.load("voice.onnx", streaming=True)
  text = "The teacher explains how rivers carry water from the mountains across the plains and through
  the cities before reaching the ocean while the students follow the route on a map and discuss why so
  many people choose to live along the river banks."
  cfg = SynthesisConfig(normalize_audio=False)

  for synth in (voice.synthesize, voice.synthesize_stream):
      list(synth(text, cfg))  # Warm up; model loading is excluded.
      start = perf_counter()
      next(synth(text, cfg))
      print(f"{synth.__name__}: {1000 * (perf_counter() - start):.0f} ms to first audio")
```

  Measured locally with Lessac: 296 ms → 137 ms. The default returns the whole ~12-second sentence; the
  split decoder returns its first ~116 ms of audio. This demonstrates startup latency, not total
  synthesis speed.
