### PR TITLE
Preserve voice files when downloads are interrupted

### DIFF
--- a/src/piper/download_voices.py
+++ b/src/piper/download_voices.py
@@ -4,9 +4,9 @@ import argparse
 import json
 import logging
 import re
-import shutil
 from pathlib import Path
-from urllib.request import urlopen
+from tempfile import TemporaryDirectory
+from urllib.request import urlopen, urlretrieve
 
 URL_FORMAT = "https://huggingface.co/rhasspy/piper-voices/resolve/main/{lang_family}/{lang_code}/{voice_name}/{voice_quality}/{lang_code}-{voice_name}-{voice_quality}{extension}?download=true"
 VOICES_JSON = (
@@ -97,25 +97,28 @@ def download_voice(
         "voice_quality": voice_quality,
     }
 
-    model_path = download_dir / f"{voice_code}.onnx"
-    if force_redownload or _needs_download(model_path):
-        model_url = URL_FORMAT.format(extension=".onnx", **format_args)
-        _LOGGER.debug("Downloading model from '%s' to '%s'", model_url, model_path)
-        with urlopen(model_url) as response:
-            with open(model_path, "wb") as model_file:
-                shutil.copyfileobj(response, model_file)
+    files_to_download = []
+    for extension in (".onnx", ".onnx.json"):
+        path = download_dir / f"{voice_code}{extension}"
+        if force_redownload or _needs_download(path):
+            files_to_download.append((extension, path))
 
-        _LOGGER.debug("Downloaded: '%s'", model_path)
+    if files_to_download:
+        with TemporaryDirectory(dir=download_dir) as temp_dir:
+            temp_path = Path(temp_dir)
+            for extension, path in files_to_download:
+                file_url = URL_FORMAT.format(extension=extension, **format_args)
+                file_type = "model" if extension == ".onnx" else "config"
+                _LOGGER.debug(
+                    "Downloading %s from '%s' to '%s'", file_type, file_url, path
+                )
+                # urlretrieve checks Content-Length when the server supplies it.
+                urlretrieve(file_url, temp_path / path.name)
 
-    config_path = download_dir / f"{voice_code}.onnx.json"
-    if force_redownload or _needs_download(config_path):
-        config_url = URL_FORMAT.format(extension=".onnx.json", **format_args)
-        _LOGGER.debug("Downloading config from '%s' to '%s'", config_url, config_path)
-        with urlopen(config_url) as response:
-            with open(config_path, "wb") as config_file:
-                shutil.copyfileobj(response, config_file)
-
-        _LOGGER.debug("Downloaded: '%s'", config_path)
+            # Keep existing files intact until every download has succeeded.
+            for _, path in files_to_download:
+                (temp_path / path.name).replace(path)
+                _LOGGER.debug("Downloaded: '%s'", path)
 
     _LOGGER.info("Downloaded: %s", voice)
 

--- a/tests/test_download_voices.py
+++ b/tests/test_download_voices.py
@@ -1,0 +1,123 @@
+"""Tests for downloading voice files."""
+
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import ContentTooShortError
+
+import pytest
+
+from piper import download_voices
+
+_VOICE = "en_US-lessac-medium"
+_PAYLOADS = {".onnx": b"complete model data", ".onnx.json": b'{"audio": {}}'}
+
+
+@pytest.fixture(name="voice_server")
+def fixture_voice_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[set[str], list[str]]]:
+    """Serve voice files, optionally closing before Content-Length is reached."""
+    short_responses: set[str] = set()
+    requests: list[str] = []
+
+    class VoiceRequestHandler(BaseHTTPRequestHandler):
+        """Serve complete or truncated responses over a real HTTP connection."""
+
+        def do_GET(self) -> None:
+            """Send the requested file."""
+            extension = self.path.removeprefix("/")
+            requests.append(extension)
+            payload = _PAYLOADS[extension]
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            if extension in short_responses:
+                payload = payload[: len(payload) // 2]
+            self.wfile.write(payload)
+
+    with ThreadingHTTPServer(("127.0.0.1", 0), VoiceRequestHandler) as server:
+        monkeypatch.setattr(
+            download_voices,
+            "URL_FORMAT",
+            f"http://127.0.0.1:{server.server_port}/{{extension}}",
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield short_responses, requests
+        finally:
+            server.shutdown()
+            thread.join()
+
+
+@pytest.mark.parametrize("extension", _PAYLOADS)
+@pytest.mark.parametrize("force_redownload", [False, True])
+def test_short_download_preserves_voice_and_allows_retry(
+    tmp_path: Path,
+    voice_server: tuple[set[str], list[str]],
+    extension: str,
+    force_redownload: bool,
+) -> None:
+    """A short model or config download must not publish either partial file."""
+    short_responses, _ = voice_server
+    original_files = {}
+    if force_redownload:
+        for suffix in _PAYLOADS:
+            filename = f"{_VOICE}{suffix}"
+            original_files[filename] = b"original " + suffix.encode()
+            (tmp_path / filename).write_bytes(original_files[filename])
+
+    short_responses.add(extension)
+    with pytest.raises(ContentTooShortError):
+        download_voices.download_voice(_VOICE, tmp_path, force_redownload)
+
+    assert {
+        path.name: path.read_bytes() for path in tmp_path.iterdir()
+    } == original_files
+
+    short_responses.clear()
+    download_voices.download_voice(_VOICE, tmp_path, force_redownload)
+    assert {path.name: path.read_bytes() for path in tmp_path.iterdir()} == {
+        f"{_VOICE}{suffix}": payload for suffix, payload in _PAYLOADS.items()
+    }
+
+
+@pytest.mark.parametrize("extension", _PAYLOADS)
+@pytest.mark.parametrize("existing_data", [b"", b"cached file"])
+def test_download_only_missing_or_empty_files(
+    tmp_path: Path,
+    voice_server: tuple[set[str], list[str]],
+    extension: str,
+    existing_data: bytes,
+) -> None:
+    """Preserve nonempty cached files and download missing or empty files."""
+    _, requests = voice_server
+    (tmp_path / f"{_VOICE}{extension}").write_bytes(existing_data)
+
+    download_voices.download_voice(_VOICE, tmp_path)
+
+    assert requests == [
+        suffix for suffix in _PAYLOADS if suffix != extension or not existing_data
+    ]
+    for suffix, payload in _PAYLOADS.items():
+        expected = existing_data if suffix == extension and existing_data else payload
+        assert (tmp_path / f"{_VOICE}{suffix}").read_bytes() == expected
+    assert len(list(tmp_path.iterdir())) == 2
+
+
+def test_download_skips_cached_voice(
+    tmp_path: Path, voice_server: tuple[set[str], list[str]]
+) -> None:
+    """An already downloaded voice does not require another HTTP request."""
+    _, requests = voice_server
+    for extension, payload in _PAYLOADS.items():
+        (tmp_path / f"{_VOICE}{extension}").write_bytes(payload)
+
+    download_voices.download_voice(_VOICE, tmp_path)
+
+    assert not requests
+    assert {path.name: path.read_bytes() for path in tmp_path.iterdir()} == {
+        f"{_VOICE}{suffix}": payload for suffix, payload in _PAYLOADS.items()
+    }


### PR DESCRIPTION
An interrupted voice download can leave a nonempty `.onnx` or `.onnx.json` at its final path. The next attempt treats that partial file as cached, and `--force-redownload` can overwrite a working voice before the replacement download succeeds.

Download the files that need updating into a temporary directory inside the destination, then replace the final files only after all downloads for that voice succeed. `urlretrieve` also rejects responses shorter than their advertised `Content-Length`. Existing nonempty files retain their normal skip behavior, and download failures clean up temporary files while preserving the previous model/config pair.

Validation on Windows with Python 3.12:

- A real local HTTP server truncates model/config responses during first-time and forced downloads: the unmodified implementation fails all four regression cases; the fix passes all nine download tests, including retries, cleanup, missing/empty files, and cache reuse.
- The existing `test_load_voice` also passes: **10 tests passed** in total.
- Black, isort, Flake8, Pylint (10/10), Mypy, and `git diff --check` pass for the changed files. The full synthesis/training suite was not run; it needs native phonemizer and optional dependencies.

Size validation depends on the server providing `Content-Length`; this does not add checksum validation. Replacement is atomic per file, so this protects against download failures rather than providing a transaction across both final files if a local replacement itself fails.

AI assistance was used to investigate, implement, and test this change.
